### PR TITLE
署名URLのリフレッシュエンドポイント追加

### DIFF
--- a/apps/kaede/src/routes/recordings/init-recording.test.ts
+++ b/apps/kaede/src/routes/recordings/init-recording.test.ts
@@ -8,6 +8,10 @@ vi.mock('../../usecases/init-recording.js', () => ({
   initRecording: initRecordingMock,
 }))
 
+vi.mock('../../usecases/refresh-upload-urls.js', () => ({
+  refreshUploadUrls: vi.fn(),
+}))
+
 import { createApp } from '../../server.js'
 
 describe('POST /api/recordings/init', () => {

--- a/apps/kaede/src/routes/recordings/init-recording.test.ts
+++ b/apps/kaede/src/routes/recordings/init-recording.test.ts
@@ -137,4 +137,25 @@ describe('POST /api/recordings/init', () => {
       },
     })
   })
+
+  it('不正な upload_targets はバリデーションエラーを返し usecase を呼ばない', async () => {
+    const pedestrianId = '11111111-1111-4111-8111-111111111111'
+    const floorId = '22222222-2222-4222-8222-222222222222'
+
+    const app = createApp()
+    const response = await app.request('/api/recordings/init', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        pedestrian_id: pedestrianId,
+        floor_id: floorId,
+        upload_targets: ['acce'],
+      }),
+    })
+
+    expect(response.status).toBe(400)
+    expect(initRecordingMock).not.toHaveBeenCalled()
+  })
 })

--- a/apps/kaede/src/routes/recordings/refresh-upload-urls.test.ts
+++ b/apps/kaede/src/routes/recordings/refresh-upload-urls.test.ts
@@ -166,4 +166,20 @@ describe('POST /api/recordings/:recordingId/refresh-upload-urls', () => {
       },
     })
   })
+
+  it('不正な path/body はバリデーションエラーを返し usecase を呼ばない', async () => {
+    const app = createApp()
+    const response = await app.request('/api/recordings/not-a-uuid/refresh-upload-urls', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        targets: [],
+      }),
+    })
+
+    expect(response.status).toBe(400)
+    expect(refreshUploadUrlsMock).not.toHaveBeenCalled()
+  })
 })

--- a/apps/kaede/src/routes/recordings/refresh-upload-urls.test.ts
+++ b/apps/kaede/src/routes/recordings/refresh-upload-urls.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { refreshUploadUrlsMock } = vi.hoisted(() => ({
+  refreshUploadUrlsMock: vi.fn(),
+}))
+
+vi.mock('../../usecases/init-recording.js', () => ({
+  initRecording: vi.fn(),
+}))
+
+vi.mock('../../usecases/refresh-upload-urls.js', () => ({
+  refreshUploadUrls: refreshUploadUrlsMock,
+}))
+
+import { createApp } from '../../server.js'
+
+describe('POST /api/recordings/:recordingId/refresh-upload-urls', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('署名付き URL を再発行して返す', async () => {
+    const recordingId = '11111111-1111-4111-8111-111111111111'
+
+    refreshUploadUrlsMock.mockResolvedValue({
+      ok: true,
+      value: {
+        recording_id: recordingId,
+        upload_status: 'accepted',
+        upload_urls: {
+          acce: 'https://example.test/acce',
+          gyro: 'https://example.test/gyro',
+        },
+        expires_at: '2026-05-15T00:15:00.000Z',
+      },
+    })
+
+    const app = createApp()
+    const response = await app.request(`/api/recordings/${recordingId}/refresh-upload-urls`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        targets: ['acce', 'gyro'],
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      recording_id: recordingId,
+      upload_status: 'accepted',
+      upload_urls: {
+        acce: 'https://example.test/acce',
+        gyro: 'https://example.test/gyro',
+      },
+      expires_at: '2026-05-15T00:15:00.000Z',
+    })
+
+    expect(refreshUploadUrlsMock).toHaveBeenCalledWith(
+      {
+        recordingId,
+      },
+      {
+        targets: ['acce', 'gyro'],
+      }
+    )
+  })
+
+  it('存在しない recording は 404 を返す', async () => {
+    const recordingId = '11111111-1111-4111-8111-111111111111'
+
+    refreshUploadUrlsMock.mockResolvedValue({
+      ok: false,
+      error: {
+        type: 'RECORDING_NOT_FOUND',
+        recordingId,
+      },
+    })
+
+    const app = createApp()
+    const response = await app.request(`/api/recordings/${recordingId}/refresh-upload-urls`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        targets: ['acce', 'gyro'],
+      }),
+    })
+
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toEqual({
+      error_code: 'RECORDING_NOT_FOUND',
+      error_message: 'recording not found',
+      details: {
+        recording_id: recordingId,
+      },
+    })
+  })
+
+  it('accepted 以外の recording は 409 を返す', async () => {
+    const recordingId = '11111111-1111-4111-8111-111111111111'
+
+    refreshUploadUrlsMock.mockResolvedValue({
+      ok: false,
+      error: {
+        type: 'RECORDING_UPLOAD_URL_REFRESH_FORBIDDEN',
+        recordingId,
+        uploadStatus: 'ready',
+      },
+    })
+
+    const app = createApp()
+    const response = await app.request(`/api/recordings/${recordingId}/refresh-upload-urls`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        targets: ['acce', 'gyro'],
+      }),
+    })
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({
+      error_code: 'RECORDING_UPLOAD_URL_REFRESH_FORBIDDEN',
+      error_message: 'upload url refresh is not allowed in the current upload state',
+      details: {
+        recording_id: recordingId,
+        upload_status: 'ready',
+      },
+    })
+  })
+
+  it('recording に含まれない target は 409 を返す', async () => {
+    const recordingId = '11111111-1111-4111-8111-111111111111'
+
+    refreshUploadUrlsMock.mockResolvedValue({
+      ok: false,
+      error: {
+        type: 'RECORDING_UPLOAD_TARGETS_INVALID',
+        recordingId,
+        invalidTargets: ['pressure'],
+      },
+    })
+
+    const app = createApp()
+    const response = await app.request(`/api/recordings/${recordingId}/refresh-upload-urls`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        targets: ['pressure'],
+      }),
+    })
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({
+      error_code: 'RECORDING_UPLOAD_TARGETS_INVALID',
+      error_message: 'requested targets are not allowed for this recording',
+      details: {
+        recording_id: recordingId,
+        invalid_targets: ['pressure'],
+      },
+    })
+  })
+})

--- a/apps/kaede/src/routes/recordings/refresh-upload-urls.ts
+++ b/apps/kaede/src/routes/recordings/refresh-upload-urls.ts
@@ -42,7 +42,8 @@ export const registerRefreshUploadUrlsRoute = (app: OpenAPIHono) => {
         },
       },
       409: {
-        description: '現在状態では upload URL を再発行できない',
+        description:
+          '現在状態では upload URL を再発行できない、または対象 target が recording に対して不正',
         content: {
           'application/json': {
             schema: errorResponseSchema,

--- a/apps/kaede/src/routes/recordings/refresh-upload-urls.ts
+++ b/apps/kaede/src/routes/recordings/refresh-upload-urls.ts
@@ -1,12 +1,12 @@
 import type { OpenAPIHono } from '@hono/zod-openapi'
 import { createRoute } from '@hono/zod-openapi'
-import { errorResponseSchema, notImplementedResponseSchema } from '../../schemas/common.js'
+import { errorResponseSchema } from '../../schemas/common.js'
 import {
   recordingIdParamsSchema,
   refreshUploadUrlsRequestSchema,
   refreshUploadUrlsResponseSchema,
 } from '../../schemas/recordings.js'
-import { notImplemented } from '../../utils/not-implemented.js'
+import { refreshUploadUrls } from '../../usecases/refresh-upload-urls.js'
 
 export const registerRefreshUploadUrlsRoute = (app: OpenAPIHono) => {
   const route = createRoute({
@@ -49,25 +49,55 @@ export const registerRefreshUploadUrlsRoute = (app: OpenAPIHono) => {
           },
         },
       },
-      501: {
-        description: 'not implemented',
-        content: {
-          'application/json': {
-            schema: notImplementedResponseSchema,
-          },
-        },
-      },
     },
   })
 
-  app.openapi(route, (c) => {
-    c.req.valid('param')
-    c.req.valid('json')
+  app.openapi(route, async (c) => {
+    const params = c.req.valid('param')
+    const payload = c.req.valid('json')
+    const result = await refreshUploadUrls(params, payload)
 
-    return notImplemented(
-      c,
-      'POST /api/recordings/:recordingId/refresh-upload-urls',
-      'recording の upload URL を再発行する'
-    )
+    if (!result.ok && result.error.type === 'RECORDING_NOT_FOUND') {
+      return c.json(
+        {
+          error_code: result.error.type,
+          error_message: 'recording not found',
+          details: {
+            recording_id: result.error.recordingId,
+          },
+        },
+        404
+      )
+    }
+
+    if (!result.ok && result.error.type === 'RECORDING_UPLOAD_URL_REFRESH_FORBIDDEN') {
+      return c.json(
+        {
+          error_code: result.error.type,
+          error_message: 'upload url refresh is not allowed in the current upload state',
+          details: {
+            recording_id: result.error.recordingId,
+            upload_status: result.error.uploadStatus,
+          },
+        },
+        409
+      )
+    }
+
+    if (!result.ok && result.error.type === 'RECORDING_UPLOAD_TARGETS_INVALID') {
+      return c.json(
+        {
+          error_code: result.error.type,
+          error_message: 'requested targets are not allowed for this recording',
+          details: {
+            recording_id: result.error.recordingId,
+            invalid_targets: result.error.invalidTargets,
+          },
+        },
+        409
+      )
+    }
+
+    return c.json(result.value, 200)
   })
 }

--- a/apps/kaede/src/schemas/recordings.test.ts
+++ b/apps/kaede/src/schemas/recordings.test.ts
@@ -53,6 +53,14 @@ describe('recording schemas', () => {
     expect(result.success).toBe(false)
   })
 
+  it('refreshUploadUrlsRequestSchema は重複した targets を拒否する', () => {
+    const result = refreshUploadUrlsRequestSchema.safeParse({
+      targets: ['acce', 'acce'],
+    })
+
+    expect(result.success).toBe(false)
+  })
+
   it('recordingGroundTruthRequestSchema は truth_type=uwb を受け入れる', () => {
     const result = recordingGroundTruthRequestSchema.safeParse({
       truth_type: 'uwb',

--- a/apps/kaede/src/schemas/recordings.ts
+++ b/apps/kaede/src/schemas/recordings.ts
@@ -159,3 +159,4 @@ export const recordingGroundTruthCompleteResponseSchema = z.object({
 
 export type InitRecordingRequest = z.infer<typeof initRecordingRequestSchema>
 export type RecordingIdParams = z.infer<typeof recordingIdParamsSchema>
+export type RefreshUploadUrlsRequest = z.infer<typeof refreshUploadUrlsRequestSchema>

--- a/apps/kaede/src/schemas/recordings.ts
+++ b/apps/kaede/src/schemas/recordings.ts
@@ -62,9 +62,20 @@ export const completeUploadResponseSchema = z.object({
 })
 
 export const refreshUploadUrlsRequestSchema = z.object({
-  targets: z.array(uploadTargetSchema).min(1).openapi({
-    description: '再発行したいアップロード URL の対象一覧',
-  }),
+  targets: z
+    .array(uploadTargetSchema)
+    .min(1)
+    .openapi({
+      description: '再発行したいアップロード URL の対象一覧',
+    })
+    .superRefine((targets, ctx) => {
+      if (new Set(targets).size !== targets.length) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'targets must not contain duplicates',
+        })
+      }
+    }),
 })
 
 export const refreshUploadUrlsResponseSchema = z.object({

--- a/apps/kaede/src/usecases/refresh-upload-urls.ts
+++ b/apps/kaede/src/usecases/refresh-upload-urls.ts
@@ -67,7 +67,8 @@ export const refreshUploadUrls = async (
     } satisfies RefreshUploadUrlsResult
   }
 
-  const invalidTargets = payload.targets.filter(
+  const uniqueTargets = Array.from(new Set(payload.targets))
+  const invalidTargets = uniqueTargets.filter(
     (target) => !recording.upload_targets.includes(target)
   )
   if (invalidTargets.length > 0) {
@@ -81,7 +82,7 @@ export const refreshUploadUrls = async (
     } satisfies RefreshUploadUrlsResult
   }
 
-  const { expiresAt, uploadUrls } = await issueRecordingUploadUrls(recording.id, payload.targets)
+  const { expiresAt, uploadUrls } = await issueRecordingUploadUrls(recording.id, uniqueTargets)
 
   return {
     ok: true,

--- a/apps/kaede/src/usecases/refresh-upload-urls.ts
+++ b/apps/kaede/src/usecases/refresh-upload-urls.ts
@@ -68,8 +68,7 @@ export const refreshUploadUrls = async (
     } satisfies RefreshUploadUrlsResult
   }
 
-  const uniqueTargets = Array.from(new Set(payload.targets))
-  const invalidTargets = uniqueTargets.filter(
+  const invalidTargets = payload.targets.filter(
     (target) => !recording.upload_targets.includes(target)
   )
   if (invalidTargets.length > 0) {
@@ -83,7 +82,7 @@ export const refreshUploadUrls = async (
     } satisfies RefreshUploadUrlsResult
   }
 
-  const { expiresAt, uploadUrls } = await issueRecordingUploadUrls(recording.id, uniqueTargets)
+  const { expiresAt, uploadUrls } = await issueRecordingUploadUrls(recording.id, payload.targets)
 
   return {
     ok: true,

--- a/apps/kaede/src/usecases/refresh-upload-urls.ts
+++ b/apps/kaede/src/usecases/refresh-upload-urls.ts
@@ -1,3 +1,4 @@
+import type { UploadTarget } from '../schemas/common.js'
 import { recordingUploadStatusSchema } from '../schemas/common.js'
 import type { RefreshUploadUrlsRequest, RecordingIdParams } from '../schemas/recordings.js'
 import { findRecordingById } from '../services/recordings/index.js'
@@ -16,7 +17,7 @@ export type RefreshUploadUrlsError =
   | {
       type: 'RECORDING_UPLOAD_TARGETS_INVALID'
       recordingId: string
-      invalidTargets: string[]
+      invalidTargets: UploadTarget[]
     }
 
 export type RefreshUploadUrlsResult =

--- a/apps/kaede/src/usecases/refresh-upload-urls.ts
+++ b/apps/kaede/src/usecases/refresh-upload-urls.ts
@@ -1,0 +1,95 @@
+import { recordingUploadStatusSchema } from '../schemas/common.js'
+import type { RefreshUploadUrlsRequest, RecordingIdParams } from '../schemas/recordings.js'
+import { findRecordingById } from '../services/recordings/index.js'
+import { issueRecordingUploadUrls } from '../services/storage/index.js'
+
+export type RefreshUploadUrlsError =
+  | {
+      type: 'RECORDING_NOT_FOUND'
+      recordingId: string
+    }
+  | {
+      type: 'RECORDING_UPLOAD_URL_REFRESH_FORBIDDEN'
+      recordingId: string
+      uploadStatus: 'accepted' | 'ready' | 'failed'
+    }
+  | {
+      type: 'RECORDING_UPLOAD_TARGETS_INVALID'
+      recordingId: string
+      invalidTargets: string[]
+    }
+
+export type RefreshUploadUrlsResult =
+  | {
+      ok: true
+      value: {
+        recording_id: string
+        upload_status: 'accepted' | 'ready' | 'failed'
+        upload_urls: {
+          acce?: string
+          gyro?: string
+          pressure?: string
+          wifi?: string
+        }
+        expires_at: string
+      }
+    }
+  | {
+      ok: false
+      error: RefreshUploadUrlsError
+    }
+
+export const refreshUploadUrls = async (
+  params: RecordingIdParams,
+  payload: RefreshUploadUrlsRequest
+) => {
+  const recording = await findRecordingById(params.recordingId)
+
+  if (!recording) {
+    return {
+      ok: false,
+      error: {
+        type: 'RECORDING_NOT_FOUND',
+        recordingId: params.recordingId,
+      },
+    } satisfies RefreshUploadUrlsResult
+  }
+
+  const uploadStatus = recordingUploadStatusSchema.parse(recording.upload_status)
+  if (uploadStatus !== 'accepted') {
+    return {
+      ok: false,
+      error: {
+        type: 'RECORDING_UPLOAD_URL_REFRESH_FORBIDDEN',
+        recordingId: recording.id,
+        uploadStatus,
+      },
+    } satisfies RefreshUploadUrlsResult
+  }
+
+  const invalidTargets = payload.targets.filter(
+    (target) => !recording.upload_targets.includes(target)
+  )
+  if (invalidTargets.length > 0) {
+    return {
+      ok: false,
+      error: {
+        type: 'RECORDING_UPLOAD_TARGETS_INVALID',
+        recordingId: recording.id,
+        invalidTargets,
+      },
+    } satisfies RefreshUploadUrlsResult
+  }
+
+  const { expiresAt, uploadUrls } = await issueRecordingUploadUrls(recording.id, payload.targets)
+
+  return {
+    ok: true,
+    value: {
+      recording_id: recording.id,
+      upload_status: uploadStatus,
+      upload_urls: uploadUrls,
+      expires_at: expiresAt,
+    },
+  } satisfies RefreshUploadUrlsResult
+}

--- a/apps/kaede/tests/routes/recordings/init-recording.test.ts
+++ b/apps/kaede/tests/routes/recordings/init-recording.test.ts
@@ -112,4 +112,29 @@ describe('POST /api/recordings/init', () => {
       },
     })
   })
+
+  it('存在しない floor_id は 404 を返す', async () => {
+    const { pedestrianId } = await createRecordingFixture()
+
+    const response = await app.request('/api/recordings/init', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        pedestrian_id: pedestrianId,
+        floor_id: '22222222-2222-4222-8222-222222222222',
+        upload_targets: ['acce', 'gyro'],
+      }),
+    })
+
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toEqual({
+      error_code: 'FLOOR_NOT_FOUND',
+      error_message: 'floor_id does not exist',
+      details: {
+        floor_id: '22222222-2222-4222-8222-222222222222',
+      },
+    })
+  })
 })

--- a/apps/kaede/tests/routes/recordings/refresh-upload-urls.test.ts
+++ b/apps/kaede/tests/routes/recordings/refresh-upload-urls.test.ts
@@ -132,6 +132,30 @@ describe('POST /api/recordings/:recordingId/refresh-upload-urls', () => {
     })
   })
 
+  it('failed 状態の recording は 409 を返す', async () => {
+    const { recordingId } = await createRecordingFixture('failed')
+
+    const response = await app.request(`/api/recordings/${recordingId}/refresh-upload-urls`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        targets: ['acce', 'gyro'],
+      }),
+    })
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({
+      error_code: 'RECORDING_UPLOAD_URL_REFRESH_FORBIDDEN',
+      error_message: 'upload url refresh is not allowed in the current upload state',
+      details: {
+        recording_id: recordingId,
+        upload_status: 'failed',
+      },
+    })
+  })
+
   it('recording に含まれない target の再発行は 409 を返す', async () => {
     const { recordingId } = await createRecordingFixture('accepted')
 
@@ -142,6 +166,30 @@ describe('POST /api/recordings/:recordingId/refresh-upload-urls', () => {
       },
       body: JSON.stringify({
         targets: ['pressure'],
+      }),
+    })
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({
+      error_code: 'RECORDING_UPLOAD_TARGETS_INVALID',
+      error_message: 'requested targets are not allowed for this recording',
+      details: {
+        recording_id: recordingId,
+        invalid_targets: ['pressure'],
+      },
+    })
+  })
+
+  it('一部に不正 target が含まれる場合は 409 を返す', async () => {
+    const { recordingId } = await createRecordingFixture('accepted')
+
+    const response = await app.request(`/api/recordings/${recordingId}/refresh-upload-urls`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        targets: ['acce', 'pressure'],
       }),
     })
 

--- a/apps/kaede/tests/routes/recordings/refresh-upload-urls.test.ts
+++ b/apps/kaede/tests/routes/recordings/refresh-upload-urls.test.ts
@@ -1,0 +1,158 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { refreshUploadUrlsResponseSchema } from '../../../src/schemas/recordings.js'
+import { createApp } from '../../../src/server.js'
+import { createDb } from '../../../src/services/db/client.js'
+import { resetDatabase } from '../../db/helpers.js'
+
+const db = createDb()
+const app = createApp()
+
+const createRecordingFixture = async (
+  uploadStatus: 'accepted' | 'ready' | 'failed' = 'accepted'
+) => {
+  const building = await db
+    .insertInto('buildings')
+    .values({ name: 'Fixture Building' })
+    .returning(['id'])
+    .executeTakeFirstOrThrow()
+
+  const floor = await db
+    .insertInto('floors')
+    .values({
+      building_id: building.id,
+      level: 3,
+      name: '3F',
+      image_object_path: `maps/${building.id}/33333333-3333-4333-8333-333333333333.png`,
+    })
+    .returning(['id'])
+    .executeTakeFirstOrThrow()
+
+  const pedestrian = await db
+    .insertInto('pedestrians')
+    .defaultValues()
+    .returning(['id'])
+    .executeTakeFirstOrThrow()
+
+  const recording = await db
+    .insertInto('recordings')
+    .values({
+      pedestrian_id: pedestrian.id,
+      floor_id: floor.id,
+      upload_status: uploadStatus,
+      upload_targets: ['acce', 'gyro', 'wifi'],
+    })
+    .returning(['id'])
+    .executeTakeFirstOrThrow()
+
+  return { recordingId: recording.id }
+}
+
+describe('POST /api/recordings/:recordingId/refresh-upload-urls', () => {
+  beforeEach(async () => {
+    await resetDatabase(db)
+  })
+
+  afterAll(async () => {
+    await db.destroy()
+  })
+
+  it('accepted な recording に対して upload URL を再発行する', async () => {
+    const { recordingId } = await createRecordingFixture('accepted')
+
+    const response = await app.request(`/api/recordings/${recordingId}/refresh-upload-urls`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        targets: ['acce', 'wifi'],
+      }),
+    })
+
+    expect(response.status).toBe(200)
+
+    const raw = await response.json()
+    const body = refreshUploadUrlsResponseSchema.parse(raw)
+
+    expect(body.recording_id).toBe(recordingId)
+    expect(body.upload_status).toBe('accepted')
+    expect(body.upload_urls).toEqual({
+      acce: expect.stringContaining(`/recordings/${recordingId}/raw/acce.csv`),
+      wifi: expect.stringContaining(`/recordings/${recordingId}/raw/wifi.csv`),
+    })
+    expect(body.upload_urls.gyro).toBeUndefined()
+    expect(Date.parse(body.expires_at)).not.toBeNaN()
+  })
+
+  it('存在しない recording は 404 を返す', async () => {
+    const response = await app.request(
+      '/api/recordings/11111111-1111-4111-8111-111111111111/refresh-upload-urls',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          targets: ['acce', 'gyro'],
+        }),
+      }
+    )
+
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toEqual({
+      error_code: 'RECORDING_NOT_FOUND',
+      error_message: 'recording not found',
+      details: {
+        recording_id: '11111111-1111-4111-8111-111111111111',
+      },
+    })
+  })
+
+  it('accepted 以外の recording は 409 を返す', async () => {
+    const { recordingId } = await createRecordingFixture('ready')
+
+    const response = await app.request(`/api/recordings/${recordingId}/refresh-upload-urls`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        targets: ['acce', 'gyro'],
+      }),
+    })
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({
+      error_code: 'RECORDING_UPLOAD_URL_REFRESH_FORBIDDEN',
+      error_message: 'upload url refresh is not allowed in the current upload state',
+      details: {
+        recording_id: recordingId,
+        upload_status: 'ready',
+      },
+    })
+  })
+
+  it('recording に含まれない target の再発行は 409 を返す', async () => {
+    const { recordingId } = await createRecordingFixture('accepted')
+
+    const response = await app.request(`/api/recordings/${recordingId}/refresh-upload-urls`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        targets: ['pressure'],
+      }),
+    })
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({
+      error_code: 'RECORDING_UPLOAD_TARGETS_INVALID',
+      error_message: 'requested targets are not allowed for this recording',
+      details: {
+        recording_id: recordingId,
+        invalid_targets: ['pressure'],
+      },
+    })
+  })
+})


### PR DESCRIPTION
# issue番号

- https://github.com/kajiLabTeam/okarin/issues/109

# 変更内容(写真か動画も一緒に)

署名URLの再発行ロジックを追加

# 影響範囲(あれば)
