### PR TITLE
floor,buildingにorganization_idを追加する

### DIFF
--- a/apps/kaede/src/routes/buildings/create-building.test.ts
+++ b/apps/kaede/src/routes/buildings/create-building.test.ts
@@ -17,12 +17,16 @@ describe('POST /api/buildings', () => {
 
   it('building を作成して返す', async () => {
     createBuildingMock.mockResolvedValue({
-      building_id: '11111111-1111-4111-8111-111111111111',
-      name: 'Test Building',
-      latitude: 35.681236,
-      longitude: 139.767125,
-      created_at: '2026-05-13T00:00:00.000Z',
-      updated_at: '2026-05-13T00:00:00.000Z',
+      ok: true,
+      value: {
+        building_id: '11111111-1111-4111-8111-111111111111',
+        organization_id: '99999999-9999-4999-8999-999999999999',
+        name: 'Test Building',
+        latitude: 35.681236,
+        longitude: 139.767125,
+        created_at: '2026-05-13T00:00:00.000Z',
+        updated_at: '2026-05-13T00:00:00.000Z',
+      },
     })
 
     const app = createRouteTestApp('/buildings', registerCreateBuildingRoute)
@@ -32,6 +36,7 @@ describe('POST /api/buildings', () => {
         'content-type': 'application/json',
       },
       body: JSON.stringify({
+        organization_id: '99999999-9999-4999-8999-999999999999',
         name: 'Test Building',
         latitude: 35.681236,
         longitude: 139.767125,
@@ -41,6 +46,7 @@ describe('POST /api/buildings', () => {
     expect(response.status).toBe(201)
     await expect(response.json()).resolves.toEqual({
       building_id: '11111111-1111-4111-8111-111111111111',
+      organization_id: '99999999-9999-4999-8999-999999999999',
       name: 'Test Building',
       latitude: 35.681236,
       longitude: 139.767125,
@@ -49,6 +55,7 @@ describe('POST /api/buildings', () => {
     })
 
     expect(createBuildingMock).toHaveBeenCalledWith({
+      organization_id: '99999999-9999-4999-8999-999999999999',
       name: 'Test Building',
       latitude: 35.681236,
       longitude: 139.767125,
@@ -57,12 +64,16 @@ describe('POST /api/buildings', () => {
 
   it('name だけで building を作成できる', async () => {
     createBuildingMock.mockResolvedValue({
-      building_id: '11111111-1111-4111-8111-111111111111',
-      name: 'Test Building',
-      latitude: null,
-      longitude: null,
-      created_at: '2026-05-13T00:00:00.000Z',
-      updated_at: '2026-05-13T00:00:00.000Z',
+      ok: true,
+      value: {
+        building_id: '11111111-1111-4111-8111-111111111111',
+        organization_id: '99999999-9999-4999-8999-999999999999',
+        name: 'Test Building',
+        latitude: null,
+        longitude: null,
+        created_at: '2026-05-13T00:00:00.000Z',
+        updated_at: '2026-05-13T00:00:00.000Z',
+      },
     })
 
     const app = createRouteTestApp('/buildings', registerCreateBuildingRoute)
@@ -72,6 +83,7 @@ describe('POST /api/buildings', () => {
         'content-type': 'application/json',
       },
       body: JSON.stringify({
+        organization_id: '99999999-9999-4999-8999-999999999999',
         name: 'Test Building',
       }),
     })
@@ -84,7 +96,39 @@ describe('POST /api/buildings', () => {
     })
 
     expect(createBuildingMock).toHaveBeenCalledWith({
+      organization_id: '99999999-9999-4999-8999-999999999999',
       name: 'Test Building',
+    })
+  })
+
+  it('存在しない organization_id は 404 を返す', async () => {
+    createBuildingMock.mockResolvedValue({
+      ok: false,
+      error: {
+        type: 'ORGANIZATION_NOT_FOUND',
+        organizationId: '99999999-9999-4999-8999-999999999999',
+      },
+    })
+
+    const app = createRouteTestApp('/buildings', registerCreateBuildingRoute)
+    const response = await app.request('/api/buildings', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        organization_id: '99999999-9999-4999-8999-999999999999',
+        name: 'Test Building',
+      }),
+    })
+
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toEqual({
+      error_code: 'ORGANIZATION_NOT_FOUND',
+      error_message: 'organization not found',
+      details: {
+        organization_id: '99999999-9999-4999-8999-999999999999',
+      },
     })
   })
 
@@ -96,6 +140,39 @@ describe('POST /api/buildings', () => {
         'content-type': 'application/json',
       },
       body: JSON.stringify({}),
+    })
+
+    expect(response.status).toBe(400)
+    expect(createBuildingMock).not.toHaveBeenCalled()
+  })
+
+  it('organization_id がない場合はバリデーションエラーを返し usecase を呼ばない', async () => {
+    const app = createRouteTestApp('/buildings', registerCreateBuildingRoute)
+    const response = await app.request('/api/buildings', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: 'Test Building',
+      }),
+    })
+
+    expect(response.status).toBe(400)
+    expect(createBuildingMock).not.toHaveBeenCalled()
+  })
+
+  it('organization_id が UUID 形式でない場合はバリデーションエラーを返し usecase を呼ばない', async () => {
+    const app = createRouteTestApp('/buildings', registerCreateBuildingRoute)
+    const response = await app.request('/api/buildings', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        organization_id: 'invalid-organization-id',
+        name: 'Test Building',
+      }),
     })
 
     expect(response.status).toBe(400)

--- a/apps/kaede/src/routes/buildings/create-building.ts
+++ b/apps/kaede/src/routes/buildings/create-building.ts
@@ -1,7 +1,24 @@
 import { createRoute } from '@hono/zod-openapi'
 import type { OpenAPIHono } from '@hono/zod-openapi'
 import { buildingSchema, createBuildingRequestSchema } from '../../schemas/buildings.js'
+import { errorResponseSchema } from '../../schemas/common.js'
 import { createBuilding } from '../../usecases/create-building.js'
+import type { CreateBuildingResult } from '../../usecases/create-building.js'
+
+type CreateBuildingError = Extract<CreateBuildingResult, { ok: false }>['error']
+
+const toCreateBuildingErrorResponse = (error: CreateBuildingError) => {
+  return {
+    body: {
+      error_code: error.type,
+      error_message: 'organization not found',
+      details: {
+        organization_id: error.organizationId,
+      },
+    },
+    status: 404 as const,
+  }
+}
 
 export const registerCreateBuildingRoute = (app: OpenAPIHono) => {
   const route = createRoute({
@@ -27,6 +44,14 @@ export const registerCreateBuildingRoute = (app: OpenAPIHono) => {
           },
         },
       },
+      404: {
+        description: 'organization not found',
+        content: {
+          'application/json': {
+            schema: errorResponseSchema,
+          },
+        },
+      },
     },
   })
 
@@ -34,6 +59,11 @@ export const registerCreateBuildingRoute = (app: OpenAPIHono) => {
     const payload = c.req.valid('json')
     const result = await createBuilding(payload)
 
-    return c.json(result, 201)
+    if (!result.ok) {
+      const error = toCreateBuildingErrorResponse(result.error)
+      return c.json(error.body, error.status)
+    }
+
+    return c.json(result.value, 201)
   })
 }

--- a/apps/kaede/src/routes/floors/create-floor.test.ts
+++ b/apps/kaede/src/routes/floors/create-floor.test.ts
@@ -23,6 +23,7 @@ describe('POST /api/floors', () => {
       value: {
         floor_id: '22222222-2222-4222-8222-222222222222',
         building_id: buildingId,
+        organization_id: '99999999-9999-4999-8999-999999999999',
         building_name: 'Test Building',
         level: 1,
         name: '1F',
@@ -51,6 +52,7 @@ describe('POST /api/floors', () => {
     await expect(response.json()).resolves.toEqual({
       floor_id: '22222222-2222-4222-8222-222222222222',
       building_id: buildingId,
+      organization_id: '99999999-9999-4999-8999-999999999999',
       building_name: 'Test Building',
       level: 1,
       name: '1F',

--- a/apps/kaede/src/routes/floors/list-floors.test.ts
+++ b/apps/kaede/src/routes/floors/list-floors.test.ts
@@ -21,6 +21,7 @@ describe('GET /api/floors', () => {
         {
           floor_id: '22222222-2222-4222-8222-222222222222',
           building_id: '11111111-1111-4111-8111-111111111111',
+          organization_id: '99999999-9999-4999-8999-999999999999',
           building_name: 'Test Building',
           level: 1,
           name: '1F',
@@ -40,6 +41,7 @@ describe('GET /api/floors', () => {
         {
           floor_id: '22222222-2222-4222-8222-222222222222',
           building_id: '11111111-1111-4111-8111-111111111111',
+          organization_id: '99999999-9999-4999-8999-999999999999',
           building_name: 'Test Building',
           level: 1,
           name: '1F',

--- a/apps/kaede/src/schemas/buildings.ts
+++ b/apps/kaede/src/schemas/buildings.ts
@@ -6,6 +6,9 @@ export const buildingSchema = z.object({
   building_id: uuidSchema.openapi({
     description: 'building の ID',
   }),
+  organization_id: uuidSchema.openapi({
+    description: 'building が属する organization の ID',
+  }),
   name: z.string().min(1).openapi({
     description: 'building の名称',
   }),
@@ -24,6 +27,9 @@ export const buildingSchema = z.object({
 })
 
 export const createBuildingRequestSchema = z.object({
+  organization_id: uuidSchema.openapi({
+    description: 'building を所属させる organization の ID',
+  }),
   name: z.string().min(1).openapi({
     description: 'building の名称',
   }),

--- a/apps/kaede/src/schemas/floors.ts
+++ b/apps/kaede/src/schemas/floors.ts
@@ -9,6 +9,9 @@ export const floorSchema = z.object({
   building_id: uuidSchema.openapi({
     description: 'floor が属する building の ID',
   }),
+  organization_id: uuidSchema.openapi({
+    description: 'floor が属する organization の ID',
+  }),
   building_name: z.string().min(1).openapi({
     description: 'floor が属する building の名称',
   }),

--- a/apps/kaede/src/services/floors/floor-repository.ts
+++ b/apps/kaede/src/services/floors/floor-repository.ts
@@ -13,6 +13,7 @@ export const listFloors = async () => {
     .select([
       'floors.id as floor_id',
       'floors.building_id',
+      'floors.organization_id',
       'buildings.name as building_name',
       'floors.level',
       'floors.name',

--- a/apps/kaede/src/usecases/create-building.ts
+++ b/apps/kaede/src/usecases/create-building.ts
@@ -1,19 +1,52 @@
 import type { BuildingResponse, CreateBuildingRequest } from '../schemas/buildings.js'
 import { insertBuilding } from '../services/buildings/index.js'
+import { findOrganizationById } from '../services/organizations/index.js'
 
-export const createBuilding = async (payload: CreateBuildingRequest): Promise<BuildingResponse> => {
+export type CreateBuildingResult =
+  | {
+      ok: true
+      value: BuildingResponse
+    }
+  | {
+      ok: false
+      error: {
+        type: 'ORGANIZATION_NOT_FOUND'
+        organizationId: string
+      }
+    }
+
+export const createBuilding = async (
+  payload: CreateBuildingRequest
+): Promise<CreateBuildingResult> => {
+  const organization = await findOrganizationById(payload.organization_id)
+
+  if (!organization) {
+    return {
+      ok: false,
+      error: {
+        type: 'ORGANIZATION_NOT_FOUND',
+        organizationId: payload.organization_id,
+      },
+    }
+  }
+
   const building = await insertBuilding({
+    organization_id: organization.id,
     name: payload.name,
     latitude: payload.latitude ?? null,
     longitude: payload.longitude ?? null,
   })
 
   return {
-    building_id: building.id,
-    name: building.name,
-    latitude: building.latitude,
-    longitude: building.longitude,
-    created_at: building.created_at.toISOString(),
-    updated_at: building.updated_at.toISOString(),
+    ok: true,
+    value: {
+      building_id: building.id,
+      organization_id: organization.id,
+      name: building.name,
+      latitude: building.latitude,
+      longitude: building.longitude,
+      created_at: building.created_at.toISOString(),
+      updated_at: building.updated_at.toISOString(),
+    },
   }
 }

--- a/apps/kaede/src/usecases/create-floor.ts
+++ b/apps/kaede/src/usecases/create-floor.ts
@@ -30,11 +30,16 @@ export const createFloor = async (payload: CreateFloorRequest): Promise<CreateFl
     }
   }
 
+  if (!building.organization_id) {
+    throw new Error(`building ${building.id} does not have organization_id`)
+  }
+
   const mapImageExtension = payload.map_image_extension ?? 'png'
   const floorId = randomUUID()
   const floor = await insertFloor({
     id: floorId,
     building_id: building.id,
+    organization_id: building.organization_id,
     level: payload.level,
     name: payload.name,
     image_object_path: `maps/${building.id}/${floorId}.${mapImageExtension}`,
@@ -46,6 +51,7 @@ export const createFloor = async (payload: CreateFloorRequest): Promise<CreateFl
     value: {
       floor_id: floor.id,
       building_id: building.id,
+      organization_id: building.organization_id,
       building_name: building.name,
       level: floor.level,
       name: floor.name,

--- a/apps/kaede/src/usecases/list-floors.ts
+++ b/apps/kaede/src/usecases/list-floors.ts
@@ -1,5 +1,13 @@
 import { listFloors as listFloorRows } from '../services/floors/index.js'
 
+const requireOrganizationId = (floorId: string, organizationId: string | null): string => {
+  if (!organizationId) {
+    throw new Error(`floor ${floorId} does not have organization_id`)
+  }
+
+  return organizationId
+}
+
 export const listFloors = async () => {
   const floors = await listFloorRows()
 
@@ -7,6 +15,7 @@ export const listFloors = async () => {
     floors: floors.map((floor) => ({
       floor_id: floor.floor_id,
       building_id: floor.building_id,
+      organization_id: requireOrganizationId(floor.floor_id, floor.organization_id),
       building_name: floor.building_name,
       level: floor.level,
       name: floor.name,

--- a/apps/kaede/tests/services/buildings/create-building.test.ts
+++ b/apps/kaede/tests/services/buildings/create-building.test.ts
@@ -15,13 +15,26 @@ describe('createBuilding', () => {
   })
 
   it('building を作成できる', async () => {
+    const organization = await db
+      .insertInto('organizations')
+      .values({ name: 'Building Test Organization' })
+      .returning(['id'])
+      .executeTakeFirstOrThrow()
+
     const result = await createBuilding({
+      organization_id: organization.id,
       name: 'Building Test Site',
       latitude: 35.681236,
       longitude: 139.767125,
     })
 
-    expect(result).toMatchObject({
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      throw new Error('expected createBuilding to succeed')
+    }
+
+    expect(result.value).toMatchObject({
+      organization_id: organization.id,
       name: 'Building Test Site',
       latitude: 35.681236,
       longitude: 139.767125,
@@ -30,11 +43,12 @@ describe('createBuilding', () => {
     const building = await db
       .selectFrom('buildings')
       .selectAll()
-      .where('id', '=', result.building_id)
+      .where('id', '=', result.value.building_id)
       .executeTakeFirstOrThrow()
 
     expect(building).toMatchObject({
-      id: result.building_id,
+      id: result.value.building_id,
+      organization_id: organization.id,
       name: 'Building Test Site',
       latitude: 35.681236,
       longitude: 139.767125,
@@ -42,11 +56,24 @@ describe('createBuilding', () => {
   })
 
   it('任意項目を省略すると null で作成できる', async () => {
+    const organization = await db
+      .insertInto('organizations')
+      .values({ name: 'Minimal Building Organization' })
+      .returning(['id'])
+      .executeTakeFirstOrThrow()
+
     const result = await createBuilding({
+      organization_id: organization.id,
       name: 'Minimal Building',
     })
 
-    expect(result).toMatchObject({
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      throw new Error('expected createBuilding to succeed')
+    }
+
+    expect(result.value).toMatchObject({
+      organization_id: organization.id,
       name: 'Minimal Building',
       latitude: null,
       longitude: null,
@@ -55,20 +82,49 @@ describe('createBuilding', () => {
     const building = await db
       .selectFrom('buildings')
       .selectAll()
-      .where('id', '=', result.building_id)
+      .where('id', '=', result.value.building_id)
       .executeTakeFirstOrThrow()
 
     expect(building).toMatchObject({
-      id: result.building_id,
+      id: result.value.building_id,
+      organization_id: organization.id,
       name: 'Minimal Building',
       latitude: null,
       longitude: null,
     })
   })
 
+  it('存在しない organization_id では building を作成しない', async () => {
+    const organizationId = '99999999-9999-4999-8999-999999999999'
+
+    const result = await createBuilding({
+      organization_id: organizationId,
+      name: 'Missing Organization Building',
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        type: 'ORGANIZATION_NOT_FOUND',
+        organizationId,
+      },
+    })
+
+    const buildings = await db.selectFrom('buildings').select('id').execute()
+
+    expect(buildings).toEqual([])
+  })
+
   it('name がない場合は DB constraint で作成できない', async () => {
+    const organization = await db
+      .insertInto('organizations')
+      .values({ name: 'Constraint Test Organization' })
+      .returning(['id'])
+      .executeTakeFirstOrThrow()
+
     await expect(
       createBuilding({
+        organization_id: organization.id,
         // route validation normally rejects this before usecase execution.
         name: undefined as unknown as string,
       })

--- a/apps/kaede/tests/services/floors/create-floor.test.ts
+++ b/apps/kaede/tests/services/floors/create-floor.test.ts
@@ -15,9 +15,15 @@ describe('createFloor', () => {
   })
 
   it('building に紐づく floor を作成できる', async () => {
+    const organization = await db
+      .insertInto('organizations')
+      .values({ name: 'Floor Test Organization' })
+      .returning(['id'])
+      .executeTakeFirstOrThrow()
+
     const building = await db
       .insertInto('buildings')
-      .values({ name: 'Floor Test Building' })
+      .values({ organization_id: organization.id, name: 'Floor Test Building' })
       .returning(['id'])
       .executeTakeFirstOrThrow()
 
@@ -36,6 +42,7 @@ describe('createFloor', () => {
 
     expect(result.value).toMatchObject({
       building_id: building.id,
+      organization_id: organization.id,
       building_name: 'Floor Test Building',
       level: 2,
       name: '2F',
@@ -51,6 +58,7 @@ describe('createFloor', () => {
     expect(floor).toMatchObject({
       id: result.value.floor_id,
       building_id: building.id,
+      organization_id: organization.id,
       level: 2,
       name: '2F',
       scale: 25,

--- a/apps/kaede/tests/services/floors/list-floors.test.ts
+++ b/apps/kaede/tests/services/floors/list-floors.test.ts
@@ -15,9 +15,15 @@ describe('listFloors', () => {
   })
 
   it('building 情報を含む floor 一覧を返す', async () => {
+    const organization = await db
+      .insertInto('organizations')
+      .values({ name: 'List Floor Organization' })
+      .returning(['id'])
+      .executeTakeFirstOrThrow()
+
     const building = await db
       .insertInto('buildings')
-      .values({ name: 'List Floor Building' })
+      .values({ organization_id: organization.id, name: 'List Floor Building' })
       .returning(['id'])
       .executeTakeFirstOrThrow()
 
@@ -25,6 +31,7 @@ describe('listFloors', () => {
       .insertInto('floors')
       .values({
         building_id: building.id,
+        organization_id: organization.id,
         level: 1,
         name: '1F',
         image_object_path: `maps/${building.id}/11111111-1111-4111-8111-111111111111.png`,
@@ -39,6 +46,7 @@ describe('listFloors', () => {
     expect(result.floors[0]).toMatchObject({
       floor_id: floor.id,
       building_id: building.id,
+      organization_id: organization.id,
       building_name: 'List Floor Building',
       level: 1,
       name: '1F',
@@ -47,14 +55,20 @@ describe('listFloors', () => {
   })
 
   it('building 名、level、floor 名の順で並ぶ', async () => {
+    const organization = await db
+      .insertInto('organizations')
+      .values({ name: 'Sorted Floor Organization' })
+      .returning(['id'])
+      .executeTakeFirstOrThrow()
+
     const buildingB = await db
       .insertInto('buildings')
-      .values({ name: 'B Building' })
+      .values({ organization_id: organization.id, name: 'B Building' })
       .returning(['id'])
       .executeTakeFirstOrThrow()
     const buildingA = await db
       .insertInto('buildings')
-      .values({ name: 'A Building' })
+      .values({ organization_id: organization.id, name: 'A Building' })
       .returning(['id'])
       .executeTakeFirstOrThrow()
 
@@ -63,18 +77,21 @@ describe('listFloors', () => {
       .values([
         {
           building_id: buildingB.id,
+          organization_id: organization.id,
           level: 2,
           name: '2F',
           image_object_path: `maps/${buildingB.id}/22222222-2222-4222-8222-222222222222.png`,
         },
         {
           building_id: buildingA.id,
+          organization_id: organization.id,
           level: 3,
           name: '3F',
           image_object_path: `maps/${buildingA.id}/33333333-3333-4333-8333-333333333333.png`,
         },
         {
           building_id: buildingA.id,
+          organization_id: organization.id,
           level: 1,
           name: '1F',
           image_object_path: `maps/${buildingA.id}/44444444-4444-4444-8444-444444444444.png`,


### PR DESCRIPTION
# issue番号

- https://github.com/kajiLabTeam/okarin/issues/136

# 変更内容(写真か動画も一緒に)

- `buildings` schema / usecase / repository を `organization_id` 対応にする。
  - `CreateBuildingRequest` に `organization_id` を追加する。
  - `BuildingResponse` に `organization_id` を追加する。
  - `insertBuilding` 時に `organization_id` を保存する。
- `floors` schema / usecase / repository を `organization_id` 対応にする。
  - `FloorResponse` に `organization_id` を追加する。
  - `createFloor` では `building_id` から building を取得し、`building.organization_id` を `floors.organization_id` に保存する。
  - `listFloors` は floor と building の organization が一致している前提で `organization_id` を返す。

# 影響範囲(あれば)
