### PR TITLE
recordingの各routesにauth middleware追加

### DIFF
--- a/apps/kaede/src/routes/recordings/complete-ground-truth-upload.ts
+++ b/apps/kaede/src/routes/recordings/complete-ground-truth-upload.ts
@@ -1,5 +1,6 @@
 import type { OpenAPIHono } from '@hono/zod-openapi'
 import { createRoute } from '@hono/zod-openapi'
+import type { RequestActorHonoEnv } from '../../middleware/request-actor-context.js'
 import { notImplementedResponseSchema } from '../../schemas/common.js'
 import {
   recordingGroundTruthCompleteResponseSchema,
@@ -8,7 +9,7 @@ import {
 } from '../../schemas/recordings.js'
 import { notImplemented } from '../../utils/not-implemented.js'
 
-export const registerCompleteGroundTruthUploadRoute = (app: OpenAPIHono) => {
+export const registerCompleteGroundTruthUploadRoute = (app: OpenAPIHono<RequestActorHonoEnv>) => {
   const route = createRoute({
     method: 'post',
     path: '/{recordingId}/ground-truth/complete',

--- a/apps/kaede/src/routes/recordings/complete-upload.test.ts
+++ b/apps/kaede/src/routes/recordings/complete-upload.test.ts
@@ -2,6 +2,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createRouteTestApp } from '../create-route-test-app.js'
 import { registerCompleteUploadRoute } from './complete-upload.js'
 
+const serviceClientActor = {
+  type: 'service_client',
+  name: 'shared_token',
+} as const
+
 const { completeUploadMock } = vi.hoisted(() => ({
   completeUploadMock: vi.fn(),
 }))
@@ -26,7 +31,9 @@ describe('POST /api/recordings/:recordingId/complete-upload', () => {
       },
     })
 
-    const app = createRouteTestApp('/recordings', registerCompleteUploadRoute)
+    const app = createRouteTestApp('/recordings', registerCompleteUploadRoute, {
+      actor: serviceClientActor,
+    })
     const response = await app.request(`/api/recordings/${recordingId}/complete-upload`, {
       method: 'POST',
     })
@@ -36,7 +43,7 @@ describe('POST /api/recordings/:recordingId/complete-upload', () => {
       recording_id: recordingId,
       upload_status: 'ready',
     })
-    expect(completeUploadMock).toHaveBeenCalledWith({
+    expect(completeUploadMock).toHaveBeenCalledWith(serviceClientActor, {
       recordingId,
     })
   })
@@ -53,7 +60,9 @@ describe('POST /api/recordings/:recordingId/complete-upload', () => {
       },
     })
 
-    const app = createRouteTestApp('/recordings', registerCompleteUploadRoute)
+    const app = createRouteTestApp('/recordings', registerCompleteUploadRoute, {
+      actor: serviceClientActor,
+    })
     const response = await app.request(`/api/recordings/${recordingId}/complete-upload`, {
       method: 'POST',
     })
@@ -81,7 +90,9 @@ describe('POST /api/recordings/:recordingId/complete-upload', () => {
       },
     })
 
-    const app = createRouteTestApp('/recordings', registerCompleteUploadRoute)
+    const app = createRouteTestApp('/recordings', registerCompleteUploadRoute, {
+      actor: serviceClientActor,
+    })
     const response = await app.request(`/api/recordings/${recordingId}/complete-upload`, {
       method: 'POST',
     })
@@ -108,7 +119,9 @@ describe('POST /api/recordings/:recordingId/complete-upload', () => {
       },
     })
 
-    const app = createRouteTestApp('/recordings', registerCompleteUploadRoute)
+    const app = createRouteTestApp('/recordings', registerCompleteUploadRoute, {
+      actor: serviceClientActor,
+    })
     const response = await app.request(`/api/recordings/${recordingId}/complete-upload`, {
       method: 'POST',
     })
@@ -135,7 +148,9 @@ describe('POST /api/recordings/:recordingId/complete-upload', () => {
       },
     })
 
-    const app = createRouteTestApp('/recordings', registerCompleteUploadRoute)
+    const app = createRouteTestApp('/recordings', registerCompleteUploadRoute, {
+      actor: serviceClientActor,
+    })
     const response = await app.request(`/api/recordings/${recordingId}/complete-upload`, {
       method: 'POST',
     })
@@ -159,5 +174,29 @@ describe('POST /api/recordings/:recordingId/complete-upload', () => {
 
     expect(response.status).toBe(400)
     expect(completeUploadMock).not.toHaveBeenCalled()
+  })
+
+  it('organization 権限がない場合は 403 を返す', async () => {
+    const recordingId = '11111111-1111-4111-8111-111111111111'
+
+    completeUploadMock.mockResolvedValue({
+      ok: false,
+      error: {
+        type: 'AUTH_ORGANIZATION_FORBIDDEN',
+      },
+    })
+
+    const app = createRouteTestApp('/recordings', registerCompleteUploadRoute, {
+      actor: serviceClientActor,
+    })
+    const response = await app.request(`/api/recordings/${recordingId}/complete-upload`, {
+      method: 'POST',
+    })
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({
+      error_code: 'AUTH_ORGANIZATION_FORBIDDEN',
+      error_message: 'organization access forbidden',
+    })
   })
 })

--- a/apps/kaede/src/routes/recordings/complete-upload.ts
+++ b/apps/kaede/src/routes/recordings/complete-upload.ts
@@ -1,10 +1,13 @@
 import type { OpenAPIHono } from '@hono/zod-openapi'
 import { createRoute } from '@hono/zod-openapi'
+import { requireRequestActor } from '../../middleware/request-actor-context.js'
+import type { RequestActorHonoEnv } from '../../middleware/request-actor-context.js'
 import { errorResponseSchema } from '../../schemas/common.js'
 import { completeUploadResponseSchema, recordingIdParamsSchema } from '../../schemas/recordings.js'
 import { completeUpload } from '../../usecases/complete-upload.js'
+import { toAuthorizationErrorResponse } from '../authorization-error.js'
 
-export const registerCompleteUploadRoute = (app: OpenAPIHono) => {
+export const registerCompleteUploadRoute = (app: OpenAPIHono<RequestActorHonoEnv>) => {
   const route = createRoute({
     method: 'post',
     path: '/{recordingId}/complete-upload',
@@ -38,6 +41,14 @@ export const registerCompleteUploadRoute = (app: OpenAPIHono) => {
           },
         },
       },
+      403: {
+        description: 'permission denied',
+        content: {
+          'application/json': {
+            schema: errorResponseSchema,
+          },
+        },
+      },
       500: {
         description: 'recording の内部データ不整合により upload 完了を確定できない',
         content: {
@@ -51,10 +62,17 @@ export const registerCompleteUploadRoute = (app: OpenAPIHono) => {
 
   app.openapi(route, async (c) => {
     const params = c.req.valid('param')
-    const result = await completeUpload(params)
+    const actor = requireRequestActor(c)
+    const result = await completeUpload(actor, params)
 
     if (!result.ok) {
       switch (result.error.type) {
+        case 'AUTH_DASHBOARD_FORBIDDEN':
+        case 'AUTH_ORGANIZATION_FORBIDDEN': {
+          const error = toAuthorizationErrorResponse(result.error)
+          return c.json(error.body, error.status)
+        }
+
         case 'RECORDING_NOT_FOUND':
           return c.json(
             {

--- a/apps/kaede/src/routes/recordings/create-trajectory.test.ts
+++ b/apps/kaede/src/routes/recordings/create-trajectory.test.ts
@@ -2,6 +2,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createRouteTestApp } from '../create-route-test-app.js'
 import { registerCreateTrajectoryRoute } from './create-trajectory.js'
 
+const serviceClientActor = {
+  type: 'service_client',
+  name: 'shared_token',
+} as const
+
 const { createTrajectoryMock } = vi.hoisted(() => ({
   createTrajectoryMock: vi.fn(),
 }))
@@ -30,7 +35,9 @@ describe('POST /api/recordings/:recordingId/trajectories', () => {
       },
     })
 
-    const app = createRouteTestApp('/recordings', registerCreateTrajectoryRoute)
+    const app = createRouteTestApp('/recordings', registerCreateTrajectoryRoute, {
+      actor: serviceClientActor,
+    })
     const response = await app.request(`/api/recordings/${recordingId}/trajectories`, {
       method: 'POST',
       headers: {
@@ -49,6 +56,7 @@ describe('POST /api/recordings/:recordingId/trajectories', () => {
       status: 'processing',
     })
     expect(createTrajectoryMock).toHaveBeenCalledWith(
+      serviceClientActor,
       {
         recordingId,
       },
@@ -69,7 +77,9 @@ describe('POST /api/recordings/:recordingId/trajectories', () => {
       },
     })
 
-    const app = createRouteTestApp('/recordings', registerCreateTrajectoryRoute)
+    const app = createRouteTestApp('/recordings', registerCreateTrajectoryRoute, {
+      actor: serviceClientActor,
+    })
     const response = await app.request(`/api/recordings/${recordingId}/trajectories`, {
       method: 'POST',
       headers: {
@@ -102,7 +112,9 @@ describe('POST /api/recordings/:recordingId/trajectories', () => {
       },
     })
 
-    const app = createRouteTestApp('/recordings', registerCreateTrajectoryRoute)
+    const app = createRouteTestApp('/recordings', registerCreateTrajectoryRoute, {
+      actor: serviceClientActor,
+    })
     const response = await app.request(`/api/recordings/${recordingId}/trajectories`, {
       method: 'POST',
       headers: {
@@ -137,7 +149,9 @@ describe('POST /api/recordings/:recordingId/trajectories', () => {
       },
     })
 
-    const app = createRouteTestApp('/recordings', registerCreateTrajectoryRoute)
+    const app = createRouteTestApp('/recordings', registerCreateTrajectoryRoute, {
+      actor: serviceClientActor,
+    })
     const response = await app.request(`/api/recordings/${recordingId}/trajectories`, {
       method: 'POST',
       headers: {
@@ -174,7 +188,9 @@ describe('POST /api/recordings/:recordingId/trajectories', () => {
       },
     })
 
-    const app = createRouteTestApp('/recordings', registerCreateTrajectoryRoute)
+    const app = createRouteTestApp('/recordings', registerCreateTrajectoryRoute, {
+      actor: serviceClientActor,
+    })
     const response = await app.request(`/api/recordings/${recordingId}/trajectories`, {
       method: 'POST',
       headers: {
@@ -211,7 +227,9 @@ describe('POST /api/recordings/:recordingId/trajectories', () => {
       },
     })
 
-    const app = createRouteTestApp('/recordings', registerCreateTrajectoryRoute)
+    const app = createRouteTestApp('/recordings', registerCreateTrajectoryRoute, {
+      actor: serviceClientActor,
+    })
     const response = await app.request(`/api/recordings/${recordingId}/trajectories`, {
       method: 'POST',
       headers: {
@@ -246,7 +264,9 @@ describe('POST /api/recordings/:recordingId/trajectories', () => {
       },
     })
 
-    const app = createRouteTestApp('/recordings', registerCreateTrajectoryRoute)
+    const app = createRouteTestApp('/recordings', registerCreateTrajectoryRoute, {
+      actor: serviceClientActor,
+    })
     const response = await app.request(`/api/recordings/${recordingId}/trajectories`, {
       method: 'POST',
       headers: {
@@ -271,7 +291,9 @@ describe('POST /api/recordings/:recordingId/trajectories', () => {
   it('不正な constraints は 400 を返し usecase を呼ばない', async () => {
     const recordingId = '11111111-1111-4111-8111-111111111111'
 
-    const app = createRouteTestApp('/recordings', registerCreateTrajectoryRoute)
+    const app = createRouteTestApp('/recordings', registerCreateTrajectoryRoute, {
+      actor: serviceClientActor,
+    })
     const response = await app.request(`/api/recordings/${recordingId}/trajectories`, {
       method: 'POST',
       headers: {
@@ -291,5 +313,35 @@ describe('POST /api/recordings/:recordingId/trajectories', () => {
 
     expect(response.status).toBe(400)
     expect(createTrajectoryMock).not.toHaveBeenCalled()
+  })
+
+  it('organization 権限がない場合は 403 を返す', async () => {
+    const recordingId = '11111111-1111-4111-8111-111111111111'
+
+    createTrajectoryMock.mockResolvedValue({
+      ok: false,
+      error: {
+        type: 'AUTH_ORGANIZATION_FORBIDDEN',
+      },
+    })
+
+    const app = createRouteTestApp('/recordings', registerCreateTrajectoryRoute, {
+      actor: serviceClientActor,
+    })
+    const response = await app.request(`/api/recordings/${recordingId}/trajectories`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        constraints: [],
+      }),
+    })
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({
+      error_code: 'AUTH_ORGANIZATION_FORBIDDEN',
+      error_message: 'organization access forbidden',
+    })
   })
 })

--- a/apps/kaede/src/routes/recordings/create-trajectory.ts
+++ b/apps/kaede/src/routes/recordings/create-trajectory.ts
@@ -1,5 +1,6 @@
 import type { OpenAPIHono } from '@hono/zod-openapi'
 import { createRoute } from '@hono/zod-openapi'
+import type { RequestActorHonoEnv } from '../../middleware/request-actor-context.js'
 import { errorResponseSchema } from '../../schemas/common.js'
 import { recordingIdParamsSchema } from '../../schemas/recordings.js'
 import {
@@ -8,7 +9,7 @@ import {
 } from '../../schemas/trajectories.js'
 import { createTrajectory } from '../../usecases/create-trajectory.js'
 
-export const registerCreateTrajectoryRoute = (app: OpenAPIHono) => {
+export const registerCreateTrajectoryRoute = (app: OpenAPIHono<RequestActorHonoEnv>) => {
   const route = createRoute({
     method: 'post',
     path: '/{recordingId}/trajectories',

--- a/apps/kaede/src/routes/recordings/create-trajectory.ts
+++ b/apps/kaede/src/routes/recordings/create-trajectory.ts
@@ -1,5 +1,6 @@
 import type { OpenAPIHono } from '@hono/zod-openapi'
 import { createRoute } from '@hono/zod-openapi'
+import { requireRequestActor } from '../../middleware/request-actor-context.js'
 import type { RequestActorHonoEnv } from '../../middleware/request-actor-context.js'
 import { errorResponseSchema } from '../../schemas/common.js'
 import { recordingIdParamsSchema } from '../../schemas/recordings.js'
@@ -8,6 +9,7 @@ import {
   createTrajectoryResponseSchema,
 } from '../../schemas/trajectories.js'
 import { createTrajectory } from '../../usecases/create-trajectory.js'
+import { toAuthorizationErrorResponse } from '../authorization-error.js'
 
 export const registerCreateTrajectoryRoute = (app: OpenAPIHono<RequestActorHonoEnv>) => {
   const route = createRoute({
@@ -58,6 +60,14 @@ export const registerCreateTrajectoryRoute = (app: OpenAPIHono<RequestActorHonoE
           },
         },
       },
+      403: {
+        description: 'permission denied',
+        content: {
+          'application/json': {
+            schema: errorResponseSchema,
+          },
+        },
+      },
       500: {
         description:
           'recording の内部データ不整合または解析依頼準備失敗により trajectory を作成できない',
@@ -81,10 +91,17 @@ export const registerCreateTrajectoryRoute = (app: OpenAPIHono<RequestActorHonoE
   app.openapi(route, async (c) => {
     const params = c.req.valid('param')
     const body = c.req.valid('json')
-    const result = await createTrajectory(params, body)
+    const actor = requireRequestActor(c)
+    const result = await createTrajectory(actor, params, body)
 
     if (!result.ok) {
       switch (result.error.type) {
+        case 'AUTH_DASHBOARD_FORBIDDEN':
+        case 'AUTH_ORGANIZATION_FORBIDDEN': {
+          const error = toAuthorizationErrorResponse(result.error)
+          return c.json(error.body, error.status)
+        }
+
         case 'RECORDING_NOT_FOUND':
           return c.json(
             {

--- a/apps/kaede/src/routes/recordings/get-recording.ts
+++ b/apps/kaede/src/routes/recordings/get-recording.ts
@@ -1,10 +1,11 @@
 import type { OpenAPIHono } from '@hono/zod-openapi'
 import { createRoute } from '@hono/zod-openapi'
+import type { RequestActorHonoEnv } from '../../middleware/request-actor-context.js'
 import { notImplementedResponseSchema } from '../../schemas/common.js'
 import { recordingDetailResponseSchema, recordingIdParamsSchema } from '../../schemas/recordings.js'
 import { notImplemented } from '../../utils/not-implemented.js'
 
-export const registerGetRecordingRoute = (app: OpenAPIHono) => {
+export const registerGetRecordingRoute = (app: OpenAPIHono<RequestActorHonoEnv>) => {
   const route = createRoute({
     method: 'get',
     path: '/{recordingId}',

--- a/apps/kaede/src/routes/recordings/index.ts
+++ b/apps/kaede/src/routes/recordings/index.ts
@@ -1,4 +1,5 @@
 import { OpenAPIHono } from '@hono/zod-openapi'
+import type { RequestActorHonoEnv } from '../../middleware/request-actor-context.js'
 import { registerCompleteGroundTruthUploadRoute } from './complete-ground-truth-upload.js'
 import { registerCompleteUploadRoute } from './complete-upload.js'
 import { registerCreateTrajectoryRoute } from './create-trajectory.js'
@@ -8,7 +9,7 @@ import { registerIssueGroundTruthUploadUrlRoute } from './issue-ground-truth-upl
 import { registerListRecordingTrajectoriesRoute } from './list-recording-trajectories.js'
 import { registerRefreshUploadUrlsRoute } from './refresh-upload-urls.js'
 
-export const recordingsRoutes = new OpenAPIHono()
+export const recordingsRoutes = new OpenAPIHono<RequestActorHonoEnv>()
 
 registerInitRecordingRoute(recordingsRoutes)
 registerCompleteUploadRoute(recordingsRoutes)

--- a/apps/kaede/src/routes/recordings/init-recording.test.ts
+++ b/apps/kaede/src/routes/recordings/init-recording.test.ts
@@ -2,6 +2,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createRouteTestApp } from '../create-route-test-app.js'
 import { registerInitRecordingRoute } from './init-recording.js'
 
+const serviceClientActor = {
+  type: 'service_client',
+  name: 'shared_token',
+} as const
+
 const { initRecordingMock } = vi.hoisted(() => ({
   initRecordingMock: vi.fn(),
 }))
@@ -36,7 +41,9 @@ describe('POST /api/recordings/init', () => {
       },
     })
 
-    const app = createRouteTestApp('/recordings', registerInitRecordingRoute)
+    const app = createRouteTestApp('/recordings', registerInitRecordingRoute, {
+      actor: serviceClientActor,
+    })
     const response = await app.request('/api/recordings/init', {
       method: 'POST',
       headers: {
@@ -62,7 +69,7 @@ describe('POST /api/recordings/init', () => {
       expires_at: '2026-05-13T00:15:00.000Z',
     })
 
-    expect(initRecordingMock).toHaveBeenCalledWith({
+    expect(initRecordingMock).toHaveBeenCalledWith(serviceClientActor, {
       pedestrian_id: pedestrianId,
       floor_id: floorId,
       upload_targets: ['acce', 'gyro'],
@@ -81,7 +88,9 @@ describe('POST /api/recordings/init', () => {
       },
     })
 
-    const app = createRouteTestApp('/recordings', registerInitRecordingRoute)
+    const app = createRouteTestApp('/recordings', registerInitRecordingRoute, {
+      actor: serviceClientActor,
+    })
     const response = await app.request('/api/recordings/init', {
       method: 'POST',
       headers: {
@@ -116,7 +125,9 @@ describe('POST /api/recordings/init', () => {
       },
     })
 
-    const app = createRouteTestApp('/recordings', registerInitRecordingRoute)
+    const app = createRouteTestApp('/recordings', registerInitRecordingRoute, {
+      actor: serviceClientActor,
+    })
     const response = await app.request('/api/recordings/init', {
       method: 'POST',
       headers: {
@@ -154,7 +165,9 @@ describe('POST /api/recordings/init', () => {
       },
     })
 
-    const app = createRouteTestApp('/recordings', registerInitRecordingRoute)
+    const app = createRouteTestApp('/recordings', registerInitRecordingRoute, {
+      actor: serviceClientActor,
+    })
     const response = await app.request('/api/recordings/init', {
       method: 'POST',
       headers: {
@@ -199,5 +212,38 @@ describe('POST /api/recordings/init', () => {
 
     expect(response.status).toBe(400)
     expect(initRecordingMock).not.toHaveBeenCalled()
+  })
+
+  it('organization 権限がない場合は 403 を返す', async () => {
+    const pedestrianId = '11111111-1111-4111-8111-111111111111'
+    const floorId = '22222222-2222-4222-8222-222222222222'
+
+    initRecordingMock.mockResolvedValue({
+      ok: false,
+      error: {
+        type: 'AUTH_ORGANIZATION_FORBIDDEN',
+      },
+    })
+
+    const app = createRouteTestApp('/recordings', registerInitRecordingRoute, {
+      actor: serviceClientActor,
+    })
+    const response = await app.request('/api/recordings/init', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        pedestrian_id: pedestrianId,
+        floor_id: floorId,
+        upload_targets: ['acce', 'gyro'],
+      }),
+    })
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({
+      error_code: 'AUTH_ORGANIZATION_FORBIDDEN',
+      error_message: 'organization access forbidden',
+    })
   })
 })

--- a/apps/kaede/src/routes/recordings/init-recording.ts
+++ b/apps/kaede/src/routes/recordings/init-recording.ts
@@ -1,13 +1,16 @@
 import type { OpenAPIHono } from '@hono/zod-openapi'
 import { createRoute } from '@hono/zod-openapi'
+import { requireRequestActor } from '../../middleware/request-actor-context.js'
+import type { RequestActorHonoEnv } from '../../middleware/request-actor-context.js'
 import { errorResponseSchema } from '../../schemas/common.js'
 import {
   initRecordingRequestSchema,
   initRecordingResponseSchema,
 } from '../../schemas/recordings.js'
 import { initRecording } from '../../usecases/init-recording.js'
+import { toAuthorizationErrorResponse } from '../authorization-error.js'
 
-export const registerInitRecordingRoute = (app: OpenAPIHono) => {
+export const registerInitRecordingRoute = (app: OpenAPIHono<RequestActorHonoEnv>) => {
   const route = createRoute({
     method: 'post',
     path: '/init',
@@ -47,55 +50,72 @@ export const registerInitRecordingRoute = (app: OpenAPIHono) => {
           },
         },
       },
+      403: {
+        description: 'permission denied',
+        content: {
+          'application/json': {
+            schema: errorResponseSchema,
+          },
+        },
+      },
     },
   })
 
   app.openapi(route, async (c) => {
     const payload = c.req.valid('json')
-    const result = await initRecording(payload)
+    const actor = requireRequestActor(c)
+    const result = await initRecording(actor, payload)
 
-    if (!result.ok && result.error.type === 'PEDESTRIAN_NOT_FOUND') {
-      return c.json(
-        {
-          error_code: result.error.type,
-          error_message: 'pedestrian_id does not exist',
-          details: {
-            pedestrian_id: result.error.pedestrianId,
-          },
-        },
-        404
-      )
+    if (result.ok) {
+      return c.json(result.value, 201)
     }
 
-    if (!result.ok && result.error.type === 'FLOOR_NOT_FOUND') {
-      return c.json(
-        {
-          error_code: result.error.type,
-          error_message: 'floor_id does not exist',
-          details: {
-            floor_id: result.error.floorId,
+    switch (result.error.type) {
+      case 'AUTH_DASHBOARD_FORBIDDEN':
+      case 'AUTH_ORGANIZATION_FORBIDDEN': {
+        const error = toAuthorizationErrorResponse(result.error)
+        return c.json(error.body, error.status)
+      }
+      case 'PEDESTRIAN_NOT_FOUND':
+        return c.json(
+          {
+            error_code: result.error.type,
+            error_message: 'pedestrian_id does not exist',
+            details: {
+              pedestrian_id: result.error.pedestrianId,
+            },
           },
-        },
-        404
-      )
-    }
-
-    if (!result.ok && result.error.type === 'RESOURCE_ORGANIZATION_MISMATCH') {
-      return c.json(
-        {
-          error_code: result.error.type,
-          error_message: 'pedestrian and floor belong to different organizations',
-          details: {
-            pedestrian_id: result.error.pedestrianId,
-            pedestrian_organization_id: result.error.pedestrianOrganizationId,
-            floor_id: result.error.floorId,
-            floor_organization_id: result.error.floorOrganizationId,
+          404
+        )
+      case 'FLOOR_NOT_FOUND':
+        return c.json(
+          {
+            error_code: result.error.type,
+            error_message: 'floor_id does not exist',
+            details: {
+              floor_id: result.error.floorId,
+            },
           },
-        },
-        409
-      )
+          404
+        )
+      case 'RESOURCE_ORGANIZATION_MISMATCH':
+        return c.json(
+          {
+            error_code: result.error.type,
+            error_message: 'pedestrian and floor belong to different organizations',
+            details: {
+              pedestrian_id: result.error.pedestrianId,
+              pedestrian_organization_id: result.error.pedestrianOrganizationId,
+              floor_id: result.error.floorId,
+              floor_organization_id: result.error.floorOrganizationId,
+            },
+          },
+          409
+        )
+      default: {
+        const exhaustiveCheck: never = result.error
+        throw new Error(`unhandled init-recording error: ${JSON.stringify(exhaustiveCheck)}`)
+      }
     }
-
-    return c.json(result.value, 201)
   })
 }

--- a/apps/kaede/src/routes/recordings/issue-ground-truth-upload-url.ts
+++ b/apps/kaede/src/routes/recordings/issue-ground-truth-upload-url.ts
@@ -1,5 +1,6 @@
 import type { OpenAPIHono } from '@hono/zod-openapi'
 import { createRoute } from '@hono/zod-openapi'
+import type { RequestActorHonoEnv } from '../../middleware/request-actor-context.js'
 import { notImplementedResponseSchema } from '../../schemas/common.js'
 import {
   recordingGroundTruthRequestSchema,
@@ -8,7 +9,7 @@ import {
 } from '../../schemas/recordings.js'
 import { notImplemented } from '../../utils/not-implemented.js'
 
-export const registerIssueGroundTruthUploadUrlRoute = (app: OpenAPIHono) => {
+export const registerIssueGroundTruthUploadUrlRoute = (app: OpenAPIHono<RequestActorHonoEnv>) => {
   const route = createRoute({
     method: 'post',
     path: '/{recordingId}/ground-truth/upload-url',

--- a/apps/kaede/src/routes/recordings/list-recording-trajectories.ts
+++ b/apps/kaede/src/routes/recordings/list-recording-trajectories.ts
@@ -1,5 +1,6 @@
 import type { OpenAPIHono } from '@hono/zod-openapi'
 import { createRoute } from '@hono/zod-openapi'
+import type { RequestActorHonoEnv } from '../../middleware/request-actor-context.js'
 import { notImplementedResponseSchema } from '../../schemas/common.js'
 import {
   recordingIdParamsSchema,
@@ -7,7 +8,7 @@ import {
 } from '../../schemas/recordings.js'
 import { notImplemented } from '../../utils/not-implemented.js'
 
-export const registerListRecordingTrajectoriesRoute = (app: OpenAPIHono) => {
+export const registerListRecordingTrajectoriesRoute = (app: OpenAPIHono<RequestActorHonoEnv>) => {
   const route = createRoute({
     method: 'get',
     path: '/{recordingId}/trajectories',

--- a/apps/kaede/src/routes/recordings/refresh-upload-urls.test.ts
+++ b/apps/kaede/src/routes/recordings/refresh-upload-urls.test.ts
@@ -2,6 +2,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createRouteTestApp } from '../create-route-test-app.js'
 import { registerRefreshUploadUrlsRoute } from './refresh-upload-urls.js'
 
+const serviceClientActor = {
+  type: 'service_client',
+  name: 'shared_token',
+} as const
+
 const { refreshUploadUrlsMock } = vi.hoisted(() => ({
   refreshUploadUrlsMock: vi.fn(),
 }))
@@ -31,7 +36,9 @@ describe('POST /api/recordings/:recordingId/refresh-upload-urls', () => {
       },
     })
 
-    const app = createRouteTestApp('/recordings', registerRefreshUploadUrlsRoute)
+    const app = createRouteTestApp('/recordings', registerRefreshUploadUrlsRoute, {
+      actor: serviceClientActor,
+    })
     const response = await app.request(`/api/recordings/${recordingId}/refresh-upload-urls`, {
       method: 'POST',
       headers: {
@@ -54,6 +61,7 @@ describe('POST /api/recordings/:recordingId/refresh-upload-urls', () => {
     })
 
     expect(refreshUploadUrlsMock).toHaveBeenCalledWith(
+      serviceClientActor,
       {
         recordingId,
       },
@@ -74,7 +82,9 @@ describe('POST /api/recordings/:recordingId/refresh-upload-urls', () => {
       },
     })
 
-    const app = createRouteTestApp('/recordings', registerRefreshUploadUrlsRoute)
+    const app = createRouteTestApp('/recordings', registerRefreshUploadUrlsRoute, {
+      actor: serviceClientActor,
+    })
     const response = await app.request(`/api/recordings/${recordingId}/refresh-upload-urls`, {
       method: 'POST',
       headers: {
@@ -107,7 +117,9 @@ describe('POST /api/recordings/:recordingId/refresh-upload-urls', () => {
       },
     })
 
-    const app = createRouteTestApp('/recordings', registerRefreshUploadUrlsRoute)
+    const app = createRouteTestApp('/recordings', registerRefreshUploadUrlsRoute, {
+      actor: serviceClientActor,
+    })
     const response = await app.request(`/api/recordings/${recordingId}/refresh-upload-urls`, {
       method: 'POST',
       headers: {
@@ -141,7 +153,9 @@ describe('POST /api/recordings/:recordingId/refresh-upload-urls', () => {
       },
     })
 
-    const app = createRouteTestApp('/recordings', registerRefreshUploadUrlsRoute)
+    const app = createRouteTestApp('/recordings', registerRefreshUploadUrlsRoute, {
+      actor: serviceClientActor,
+    })
     const response = await app.request(`/api/recordings/${recordingId}/refresh-upload-urls`, {
       method: 'POST',
       headers: {
@@ -177,5 +191,35 @@ describe('POST /api/recordings/:recordingId/refresh-upload-urls', () => {
 
     expect(response.status).toBe(400)
     expect(refreshUploadUrlsMock).not.toHaveBeenCalled()
+  })
+
+  it('organization 権限がない場合は 403 を返す', async () => {
+    const recordingId = '11111111-1111-4111-8111-111111111111'
+
+    refreshUploadUrlsMock.mockResolvedValue({
+      ok: false,
+      error: {
+        type: 'AUTH_ORGANIZATION_FORBIDDEN',
+      },
+    })
+
+    const app = createRouteTestApp('/recordings', registerRefreshUploadUrlsRoute, {
+      actor: serviceClientActor,
+    })
+    const response = await app.request(`/api/recordings/${recordingId}/refresh-upload-urls`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        targets: ['acce', 'gyro'],
+      }),
+    })
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({
+      error_code: 'AUTH_ORGANIZATION_FORBIDDEN',
+      error_message: 'organization access forbidden',
+    })
   })
 })

--- a/apps/kaede/src/routes/recordings/refresh-upload-urls.ts
+++ b/apps/kaede/src/routes/recordings/refresh-upload-urls.ts
@@ -1,5 +1,7 @@
 import type { OpenAPIHono } from '@hono/zod-openapi'
 import { createRoute } from '@hono/zod-openapi'
+import { requireRequestActor } from '../../middleware/request-actor-context.js'
+import type { RequestActorHonoEnv } from '../../middleware/request-actor-context.js'
 import { errorResponseSchema } from '../../schemas/common.js'
 import {
   recordingIdParamsSchema,
@@ -7,8 +9,9 @@ import {
   refreshUploadUrlsResponseSchema,
 } from '../../schemas/recordings.js'
 import { refreshUploadUrls } from '../../usecases/refresh-upload-urls.js'
+import { toAuthorizationErrorResponse } from '../authorization-error.js'
 
-export const registerRefreshUploadUrlsRoute = (app: OpenAPIHono) => {
+export const registerRefreshUploadUrlsRoute = (app: OpenAPIHono<RequestActorHonoEnv>) => {
   const route = createRoute({
     method: 'post',
     path: '/{recordingId}/refresh-upload-urls',
@@ -50,16 +53,31 @@ export const registerRefreshUploadUrlsRoute = (app: OpenAPIHono) => {
           },
         },
       },
+      403: {
+        description: 'permission denied',
+        content: {
+          'application/json': {
+            schema: errorResponseSchema,
+          },
+        },
+      },
     },
   })
 
   app.openapi(route, async (c) => {
     const params = c.req.valid('param')
     const payload = c.req.valid('json')
-    const result = await refreshUploadUrls(params, payload)
+    const actor = requireRequestActor(c)
+    const result = await refreshUploadUrls(actor, params, payload)
 
     if (!result.ok) {
       switch (result.error.type) {
+        case 'AUTH_DASHBOARD_FORBIDDEN':
+        case 'AUTH_ORGANIZATION_FORBIDDEN': {
+          const error = toAuthorizationErrorResponse(result.error)
+          return c.json(error.body, error.status)
+        }
+
         case 'RECORDING_NOT_FOUND':
           return c.json(
             {

--- a/apps/kaede/src/services/pedestrians/pedestrian-repository.ts
+++ b/apps/kaede/src/services/pedestrians/pedestrian-repository.ts
@@ -42,10 +42,10 @@ export const insertPedestrian = async (
 export const findPedestrianById = async (
   pedestrianId: string,
   executor: DbExecutor = db
-): Promise<Pick<Pedestrian, 'id' | 'organization_id'> | undefined> => {
+): Promise<Pick<Pedestrian, 'id' | 'organization_id' | 'user_id'> | undefined> => {
   return executor
     .selectFrom('pedestrians')
-    .select(['id', 'organization_id'])
+    .select(['id', 'organization_id', 'user_id'])
     .where('id', '=', pedestrianId)
     .executeTakeFirst()
 }

--- a/apps/kaede/src/services/recordings/index.ts
+++ b/apps/kaede/src/services/recordings/index.ts
@@ -1,7 +1,9 @@
 export {
+  findRecordingAuthorizationById,
   findRecordingById,
   insertRecording,
   markRecordingUploadFailed,
   markRecordingUploadReady,
   updateRecording,
 } from './recording-repository.js'
+export type { Recording, RecordingAuthorizationRow } from './recording-repository.js'

--- a/apps/kaede/src/services/recordings/recording-repository.ts
+++ b/apps/kaede/src/services/recordings/recording-repository.ts
@@ -7,6 +7,14 @@ type DbExecutor = Kysely<DB> | Transaction<DB>
 type Recording = Selectable<Recordings>
 type NewRecording = Insertable<Recordings>
 type RecordingUpdate = Updateable<Recordings>
+export type { Recording }
+
+export interface RecordingAuthorizationRow {
+  id: string
+  organization_id: string
+  pedestrian_id: string
+  pedestrian_user_id: string | null
+}
 
 const activeRecordingsQuery = (executor: DbExecutor) =>
   executor.selectFrom('recordings').where('deleted_at', 'is', null)
@@ -18,6 +26,22 @@ export const findRecordingById = async (
   return activeRecordingsQuery(executor)
     .selectAll()
     .where('id', '=', recordingId)
+    .executeTakeFirst()
+}
+
+export const findRecordingAuthorizationById = async (
+  recordingId: string,
+  executor: DbExecutor = db
+): Promise<RecordingAuthorizationRow | undefined> => {
+  return activeRecordingsQuery(executor)
+    .innerJoin('pedestrians', 'pedestrians.id', 'recordings.pedestrian_id')
+    .select([
+      'recordings.id as id',
+      'recordings.organization_id as organization_id',
+      'recordings.pedestrian_id as pedestrian_id',
+      'pedestrians.user_id as pedestrian_user_id',
+    ])
+    .where('recordings.id', '=', recordingId)
     .executeTakeFirst()
 }
 

--- a/apps/kaede/src/usecases/authorization.test.ts
+++ b/apps/kaede/src/usecases/authorization.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+import type { UserRequestActor } from '../middleware/request-actor-context.js'
+import { requireRecordingAccess } from './authorization.js'
+
+const organizationId = '99999999-9999-4999-8999-999999999999'
+const otherOrganizationId = '88888888-8888-4888-8888-888888888888'
+const userId = '11111111-1111-4111-8111-111111111111'
+const otherUserId = '22222222-2222-4222-8222-222222222222'
+
+const userActor = (overrides: Partial<UserRequestActor> = {}): UserRequestActor => ({
+  type: 'user',
+  user_id: userId,
+  email: 'user@example.test',
+  global_role: 'none',
+  password_must_change: false,
+  memberships: [
+    {
+      organization_id: organizationId,
+      organization_name: 'Test Organization',
+      role: 'member',
+    },
+  ],
+  ...overrides,
+})
+
+describe('requireRecordingAccess', () => {
+  it('service client は organization / owner 制限を受けない', () => {
+    expect(
+      requireRecordingAccess(
+        { type: 'service_client', name: 'shared_token' },
+        {
+          organization_id: otherOrganizationId,
+          pedestrian_user_id: otherUserId,
+        }
+      )
+    ).toEqual({ ok: true })
+  })
+
+  it('admin は任意 organization の recording を操作できる', () => {
+    expect(
+      requireRecordingAccess(
+        userActor({
+          global_role: 'admin',
+          memberships: [],
+        }),
+        {
+          organization_id: otherOrganizationId,
+          pedestrian_user_id: otherUserId,
+        }
+      )
+    ).toEqual({ ok: true })
+  })
+
+  it('manager は所属 organization の recording を操作できる', () => {
+    expect(
+      requireRecordingAccess(
+        userActor({
+          memberships: [
+            {
+              organization_id: organizationId,
+              organization_name: 'Test Organization',
+              role: 'manager',
+            },
+          ],
+        }),
+        {
+          organization_id: organizationId,
+          pedestrian_user_id: otherUserId,
+        }
+      )
+    ).toEqual({ ok: true })
+  })
+
+  it('manager は別 organization の recording を操作できない', () => {
+    expect(
+      requireRecordingAccess(
+        userActor({
+          memberships: [
+            {
+              organization_id: organizationId,
+              organization_name: 'Test Organization',
+              role: 'manager',
+            },
+          ],
+        }),
+        {
+          organization_id: otherOrganizationId,
+          pedestrian_user_id: otherUserId,
+        }
+      )
+    ).toEqual({
+      ok: false,
+      error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' },
+    })
+  })
+
+  it('member は自分に紐づく pedestrian の recording を操作できる', () => {
+    expect(
+      requireRecordingAccess(userActor(), {
+        organization_id: organizationId,
+        pedestrian_user_id: userId,
+      })
+    ).toEqual({ ok: true })
+  })
+
+  it('member は他 user に紐づく pedestrian の recording を操作できない', () => {
+    expect(
+      requireRecordingAccess(userActor(), {
+        organization_id: organizationId,
+        pedestrian_user_id: otherUserId,
+      })
+    ).toEqual({
+      ok: false,
+      error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' },
+    })
+  })
+})

--- a/apps/kaede/src/usecases/authorization.ts
+++ b/apps/kaede/src/usecases/authorization.ts
@@ -64,3 +64,37 @@ export const requireDashboardReadAccess = (
     organizationIds: managerOrganizationIds,
   }
 }
+
+export interface RecordingAccessResource {
+  organization_id: string
+  pedestrian_user_id: string | null
+}
+
+export const requireRecordingAccess = (
+  actor: RequestActor,
+  resource: RecordingAccessResource
+): { ok: true } | { ok: false; error: AuthorizationError } => {
+  if (actor.type === 'service_client' || actor.global_role === 'admin') {
+    return { ok: true }
+  }
+
+  const membership = actor.memberships.find(
+    (candidate) => candidate.organization_id === resource.organization_id
+  )
+
+  if (!membership) {
+    return {
+      ok: false,
+      error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' },
+    }
+  }
+
+  if (membership.role === 'manager' || resource.pedestrian_user_id === actor.user_id) {
+    return { ok: true }
+  }
+
+  return {
+    ok: false,
+    error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' },
+  }
+}

--- a/apps/kaede/src/usecases/complete-upload.test.ts
+++ b/apps/kaede/src/usecases/complete-upload.test.ts
@@ -1,13 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RequestActor } from '../middleware/request-actor-context.js'
 
-const { findRecordingByIdMock, listRecordingRawObjectKeysMock, markRecordingUploadReadyMock } =
-  vi.hoisted(() => ({
-    findRecordingByIdMock: vi.fn(),
-    listRecordingRawObjectKeysMock: vi.fn(),
-    markRecordingUploadReadyMock: vi.fn(),
-  }))
+const {
+  findRecordingAuthorizationByIdMock,
+  findRecordingByIdMock,
+  listRecordingRawObjectKeysMock,
+  markRecordingUploadReadyMock,
+} = vi.hoisted(() => ({
+  findRecordingAuthorizationByIdMock: vi.fn(),
+  findRecordingByIdMock: vi.fn(),
+  listRecordingRawObjectKeysMock: vi.fn(),
+  markRecordingUploadReadyMock: vi.fn(),
+}))
 
 vi.mock('../services/recordings/index.js', () => ({
+  findRecordingAuthorizationById: findRecordingAuthorizationByIdMock,
   findRecordingById: findRecordingByIdMock,
   markRecordingUploadReady: markRecordingUploadReadyMock,
 }))
@@ -25,6 +32,17 @@ vi.mock('../services/storage/index.js', () => ({
 
 import { completeUpload } from './complete-upload.js'
 
+const serviceClientActor: RequestActor = { type: 'service_client', name: 'shared_token' }
+
+const mockRecordingAuthorization = (recordingId: string) => {
+  findRecordingAuthorizationByIdMock.mockResolvedValue({
+    id: recordingId,
+    organization_id: '99999999-9999-4999-8999-999999999999',
+    pedestrian_id: '22222222-2222-4222-8222-222222222222',
+    pedestrian_user_id: null,
+  })
+}
+
 describe('completeUpload', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -34,7 +52,7 @@ describe('completeUpload', () => {
     findRecordingByIdMock.mockResolvedValue(undefined)
 
     await expect(
-      completeUpload({
+      completeUpload(serviceClientActor, {
         recordingId: '11111111-1111-4111-8111-111111111111',
       })
     ).resolves.toEqual({
@@ -50,11 +68,14 @@ describe('completeUpload', () => {
   })
 
   it('全 target が存在する場合 ready に更新する', async () => {
+    const recordingId = '11111111-1111-4111-8111-111111111111'
+
     findRecordingByIdMock.mockResolvedValue({
-      id: '11111111-1111-4111-8111-111111111111',
+      id: recordingId,
       upload_status: 'accepted',
       upload_targets: ['acce', 'gyro', 'metadata'],
     })
+    mockRecordingAuthorization(recordingId)
     listRecordingRawObjectKeysMock.mockResolvedValue([
       'recordings/11111111-1111-4111-8111-111111111111/raw/acce.csv',
       'recordings/11111111-1111-4111-8111-111111111111/raw/gyro.csv',
@@ -66,8 +87,8 @@ describe('completeUpload', () => {
     })
 
     await expect(
-      completeUpload({
-        recordingId: '11111111-1111-4111-8111-111111111111',
+      completeUpload(serviceClientActor, {
+        recordingId,
       })
     ).resolves.toEqual({
       ok: true,
@@ -86,18 +107,21 @@ describe('completeUpload', () => {
   })
 
   it('不足 target がある場合 missing_targets を返す', async () => {
+    const recordingId = '11111111-1111-4111-8111-111111111111'
+
     findRecordingByIdMock.mockResolvedValue({
-      id: '11111111-1111-4111-8111-111111111111',
+      id: recordingId,
       upload_status: 'accepted',
       upload_targets: ['acce', 'gyro', 'wifi'],
     })
+    mockRecordingAuthorization(recordingId)
     listRecordingRawObjectKeysMock.mockResolvedValue([
       'recordings/11111111-1111-4111-8111-111111111111/raw/acce.csv',
     ])
 
     await expect(
-      completeUpload({
-        recordingId: '11111111-1111-4111-8111-111111111111',
+      completeUpload(serviceClientActor, {
+        recordingId,
       })
     ).resolves.toEqual({
       ok: false,
@@ -112,15 +136,18 @@ describe('completeUpload', () => {
   })
 
   it('ready または failed は finalized として拒否する', async () => {
+    const recordingId = '11111111-1111-4111-8111-111111111111'
+
     findRecordingByIdMock.mockResolvedValue({
-      id: '11111111-1111-4111-8111-111111111111',
+      id: recordingId,
       upload_status: 'failed',
       upload_targets: ['acce', 'gyro'],
     })
+    mockRecordingAuthorization(recordingId)
 
     await expect(
-      completeUpload({
-        recordingId: '11111111-1111-4111-8111-111111111111',
+      completeUpload(serviceClientActor, {
+        recordingId,
       })
     ).resolves.toEqual({
       ok: false,
@@ -136,15 +163,18 @@ describe('completeUpload', () => {
   })
 
   it('recording.upload_targets に不正値がある場合は制御されたエラーを返す', async () => {
+    const recordingId = '11111111-1111-4111-8111-111111111111'
+
     findRecordingByIdMock.mockResolvedValue({
-      id: '11111111-1111-4111-8111-111111111111',
+      id: recordingId,
       upload_status: 'accepted',
       upload_targets: ['acce', 'broken-target'],
     })
+    mockRecordingAuthorization(recordingId)
 
     await expect(
-      completeUpload({
-        recordingId: '11111111-1111-4111-8111-111111111111',
+      completeUpload(serviceClientActor, {
+        recordingId,
       })
     ).resolves.toEqual({
       ok: false,
@@ -152,6 +182,51 @@ describe('completeUpload', () => {
         type: 'RECORDING_UPLOAD_TARGETS_INVALID',
         recordingId: '11111111-1111-4111-8111-111111111111',
         invalidTargets: ['broken-target'],
+      },
+    })
+
+    expect(listRecordingRawObjectKeysMock).not.toHaveBeenCalled()
+    expect(markRecordingUploadReadyMock).not.toHaveBeenCalled()
+  })
+
+  it('member が別 user の pedestrian recording を完了しようとすると AUTH_ORGANIZATION_FORBIDDEN を返す', async () => {
+    const recordingId = '11111111-1111-4111-8111-111111111111'
+    const organizationId = '99999999-9999-4999-8999-999999999999'
+
+    findRecordingByIdMock.mockResolvedValue({
+      id: recordingId,
+      upload_status: 'accepted',
+      upload_targets: ['acce', 'gyro'],
+    })
+    findRecordingAuthorizationByIdMock.mockResolvedValue({
+      id: recordingId,
+      organization_id: organizationId,
+      pedestrian_id: '22222222-2222-4222-8222-222222222222',
+      pedestrian_user_id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    })
+
+    await expect(
+      completeUpload(
+        {
+          type: 'user',
+          user_id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+          email: 'member@example.test',
+          global_role: 'none',
+          password_must_change: false,
+          memberships: [
+            {
+              organization_id: organizationId,
+              organization_name: 'Test Organization',
+              role: 'member',
+            },
+          ],
+        },
+        { recordingId }
+      )
+    ).resolves.toEqual({
+      ok: false,
+      error: {
+        type: 'AUTH_ORGANIZATION_FORBIDDEN',
       },
     })
 

--- a/apps/kaede/src/usecases/complete-upload.ts
+++ b/apps/kaede/src/usecases/complete-upload.ts
@@ -1,13 +1,21 @@
+import type { RequestActor } from '../middleware/request-actor-context.js'
 import { uploadTargetSchema, recordingUploadStatusSchema } from '../schemas/common.js'
 import type { UploadTarget } from '../schemas/common.js'
 import type { RecordingIdParams } from '../schemas/recordings.js'
-import { findRecordingById, markRecordingUploadReady } from '../services/recordings/index.js'
+import {
+  findRecordingAuthorizationById,
+  findRecordingById,
+  markRecordingUploadReady,
+} from '../services/recordings/index.js'
 import {
   buildRecordingRawObjectKey,
   listRecordingRawObjectKeys,
 } from '../services/storage/index.js'
+import type { AuthorizationError } from './authorization.js'
+import { requireRecordingAccess } from './authorization.js'
 
 export type CompleteUploadError =
+  | AuthorizationError
   | {
       type: 'RECORDING_NOT_FOUND'
       recordingId: string
@@ -41,7 +49,10 @@ export type CompleteUploadResult =
       error: CompleteUploadError
     }
 
-export const completeUpload = async (params: RecordingIdParams): Promise<CompleteUploadResult> => {
+export const completeUpload = async (
+  actor: RequestActor,
+  params: RecordingIdParams
+): Promise<CompleteUploadResult> => {
   const recording = await findRecordingById(params.recordingId)
 
   if (!recording) {
@@ -52,6 +63,24 @@ export const completeUpload = async (params: RecordingIdParams): Promise<Complet
         recordingId: params.recordingId,
       },
     }
+  }
+
+  const recordingAuthorization = await findRecordingAuthorizationById(recording.id)
+
+  if (!recordingAuthorization) {
+    return {
+      ok: false,
+      error: {
+        type: 'RECORDING_NOT_FOUND',
+        recordingId: recording.id,
+      },
+    }
+  }
+
+  const authorization = requireRecordingAccess(actor, recordingAuthorization)
+
+  if (!authorization.ok) {
+    return authorization
   }
 
   if (recording.upload_status === 'ready' || recording.upload_status === 'failed') {

--- a/apps/kaede/src/usecases/create-trajectory.test.ts
+++ b/apps/kaede/src/usecases/create-trajectory.test.ts
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { CallbackRuntimeConfig } from '../config/runtime.js'
+import type { RequestActor } from '../middleware/request-actor-context.js'
 
 const {
   findFloorByIdMock,
+  findRecordingAuthorizationByIdMock,
   findRecordingByIdMock,
   insertTrajectoryWithConstraintsMock,
   markTrajectoryFailedMock,
@@ -14,6 +16,7 @@ const {
   getCallbackRuntimeConfigMock,
 } = vi.hoisted(() => ({
   findFloorByIdMock: vi.fn(),
+  findRecordingAuthorizationByIdMock: vi.fn(),
   findRecordingByIdMock: vi.fn(),
   insertTrajectoryWithConstraintsMock: vi.fn(),
   markTrajectoryFailedMock: vi.fn(),
@@ -30,6 +33,7 @@ vi.mock('@sentry/node', () => ({
 }))
 
 vi.mock('../services/recordings/index.js', () => ({
+  findRecordingAuthorizationById: findRecordingAuthorizationByIdMock,
   findRecordingById: findRecordingByIdMock,
 }))
 
@@ -62,6 +66,8 @@ vi.mock('../config/runtime.js', () => ({
 
 import { createTrajectory } from './create-trajectory.js'
 
+const serviceClientActor: RequestActor = { type: 'service_client', name: 'shared_token' }
+
 describe('createTrajectory', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -88,6 +94,12 @@ describe('createTrajectory', () => {
     findFloorByIdMock.mockResolvedValue({
       id: floorId,
       organization_id: organizationId,
+    })
+    findRecordingAuthorizationByIdMock.mockResolvedValue({
+      id: recordingId,
+      organization_id: organizationId,
+      pedestrian_id: '44444444-4444-4444-8444-444444444444',
+      pedestrian_user_id: null,
     })
     insertTrajectoryWithConstraintsMock.mockResolvedValue({
       id: trajectoryId,
@@ -121,6 +133,7 @@ describe('createTrajectory', () => {
     })
 
     const result = await createTrajectory(
+      serviceClientActor,
       { recordingId },
       {
         constraints: [],
@@ -161,10 +174,63 @@ describe('createTrajectory', () => {
     })
   })
 
+  it('member が他 user の recording から trajectory を作成しようとすると AUTH_ORGANIZATION_FORBIDDEN を返す', async () => {
+    const recordingId = '11111111-1111-4111-8111-111111111111'
+    const floorId = '33333333-3333-4333-8333-333333333333'
+    const organizationId = '99999999-9999-4999-8999-999999999999'
+
+    findRecordingByIdMock.mockResolvedValue({
+      id: recordingId,
+      floor_id: floorId,
+      organization_id: organizationId,
+      upload_status: 'ready',
+      upload_targets: ['acce', 'gyro'],
+    })
+    findRecordingAuthorizationByIdMock.mockResolvedValue({
+      id: recordingId,
+      organization_id: organizationId,
+      pedestrian_id: '44444444-4444-4444-8444-444444444444',
+      pedestrian_user_id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    })
+    findFloorByIdMock.mockResolvedValue({
+      id: floorId,
+      organization_id: organizationId,
+    })
+
+    const result = await createTrajectory(
+      {
+        type: 'user',
+        user_id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+        email: 'member@example.test',
+        global_role: 'none',
+        password_must_change: false,
+        memberships: [
+          {
+            organization_id: organizationId,
+            organization_name: 'Test Organization',
+            role: 'member',
+          },
+        ],
+      },
+      { recordingId },
+      { constraints: [] }
+    )
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        type: 'AUTH_ORGANIZATION_FORBIDDEN',
+      },
+    })
+    expect(insertTrajectoryWithConstraintsMock).not.toHaveBeenCalled()
+    expect(submitAnalyzeRequestMock).not.toHaveBeenCalled()
+  })
+
   it('存在しない recording は 404 相当エラーを返す', async () => {
     findRecordingByIdMock.mockResolvedValue(undefined)
 
     const result = await createTrajectory(
+      serviceClientActor,
       { recordingId: '11111111-1111-4111-8111-111111111111' },
       { constraints: [] }
     )
@@ -188,6 +254,7 @@ describe('createTrajectory', () => {
     })
 
     const result = await createTrajectory(
+      serviceClientActor,
       { recordingId: '11111111-1111-4111-8111-111111111111' },
       { constraints: [] }
     )
@@ -212,6 +279,7 @@ describe('createTrajectory', () => {
     })
 
     const result = await createTrajectory(
+      serviceClientActor,
       { recordingId: '11111111-1111-4111-8111-111111111111' },
       { constraints: [] }
     )
@@ -239,7 +307,14 @@ describe('createTrajectory', () => {
     })
     findFloorByIdMock.mockResolvedValue(undefined)
 
-    const result = await createTrajectory({ recordingId }, { constraints: [] })
+    findRecordingAuthorizationByIdMock.mockResolvedValue({
+      id: recordingId,
+      organization_id: '99999999-9999-4999-8999-999999999999',
+      pedestrian_id: '44444444-4444-4444-8444-444444444444',
+      pedestrian_user_id: null,
+    })
+
+    const result = await createTrajectory(serviceClientActor, { recordingId }, { constraints: [] })
 
     expect(result).toEqual({
       ok: false,
@@ -270,7 +345,14 @@ describe('createTrajectory', () => {
       organization_id: floorOrganizationId,
     })
 
-    const result = await createTrajectory({ recordingId }, { constraints: [] })
+    findRecordingAuthorizationByIdMock.mockResolvedValue({
+      id: recordingId,
+      organization_id: recordingOrganizationId,
+      pedestrian_id: '44444444-4444-4444-8444-444444444444',
+      pedestrian_user_id: null,
+    })
+
+    const result = await createTrajectory(serviceClientActor, { recordingId }, { constraints: [] })
 
     expect(result).toEqual({
       ok: false,
@@ -334,7 +416,14 @@ describe('createTrajectory', () => {
       status: 'failed',
     })
 
-    const result = await createTrajectory({ recordingId }, { constraints: [] })
+    findRecordingAuthorizationByIdMock.mockResolvedValue({
+      id: recordingId,
+      organization_id: organizationId,
+      pedestrian_id: '44444444-4444-4444-8444-444444444444',
+      pedestrian_user_id: null,
+    })
+
+    const result = await createTrajectory(serviceClientActor, { recordingId }, { constraints: [] })
 
     expect(markTrajectoryFailedMock).toHaveBeenCalledWith(
       trajectoryId,
@@ -387,7 +476,7 @@ describe('createTrajectory', () => {
       status: 'failed',
     })
 
-    const result = await createTrajectory({ recordingId }, { constraints: [] })
+    const result = await createTrajectory(serviceClientActor, { recordingId }, { constraints: [] })
 
     expect(markTrajectoryFailedMock).toHaveBeenCalledWith(
       trajectoryId,

--- a/apps/kaede/src/usecases/create-trajectory.ts
+++ b/apps/kaede/src/usecases/create-trajectory.ts
@@ -1,11 +1,12 @@
 import * as Sentry from '@sentry/node'
 import { getCallbackRuntimeConfig } from '../config/runtime.js'
+import type { RequestActor } from '../middleware/request-actor-context.js'
 import { uploadTargetsSchema } from '../schemas/common.js'
 import type { RecordingIdParams } from '../schemas/recordings.js'
 import type { CreateTrajectoryRequest } from '../schemas/trajectories.js'
 import { findFloorById } from '../services/floors/index.js'
 import { submitAnalyzeRequest } from '../services/nozomi/index.js'
-import { findRecordingById } from '../services/recordings/index.js'
+import { findRecordingAuthorizationById, findRecordingById } from '../services/recordings/index.js'
 import {
   issueInternalRecordingRawDownloadUrls,
   issueInternalTrajectoryResultUploadUrl,
@@ -16,8 +17,11 @@ import {
   markTrajectoryFailed,
   markTrajectoryProcessing,
 } from '../services/trajectories/index.js'
+import type { AuthorizationError } from './authorization.js'
+import { requireRecordingAccess } from './authorization.js'
 
 export type CreateTrajectoryError =
+  | AuthorizationError
   | {
       type: 'RECORDING_NOT_FOUND'
       recordingId: string
@@ -79,6 +83,7 @@ const throwOrganizationInvariantError = (message: string): never => {
 }
 
 export const createTrajectory = async (
+  actor: RequestActor,
   params: RecordingIdParams,
   payload: CreateTrajectoryRequest
 ): Promise<CreateTrajectoryResult> => {
@@ -119,6 +124,24 @@ export const createTrajectory = async (
 
   if (!recording.organization_id) {
     throwOrganizationInvariantError(`recording ${recording.id} does not have organization_id`)
+  }
+
+  const recordingAuthorization = await findRecordingAuthorizationById(recording.id)
+
+  if (!recordingAuthorization) {
+    return {
+      ok: false,
+      error: {
+        type: 'RECORDING_NOT_FOUND',
+        recordingId: recording.id,
+      },
+    }
+  }
+
+  const authorization = requireRecordingAccess(actor, recordingAuthorization)
+
+  if (!authorization.ok) {
+    return authorization
   }
 
   const floor = await findFloorById(recording.floor_id)

--- a/apps/kaede/src/usecases/init-recording.test.ts
+++ b/apps/kaede/src/usecases/init-recording.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RequestActor } from '../middleware/request-actor-context.js'
 
 const {
   findFloorByIdMock,
@@ -30,11 +31,13 @@ vi.mock('../services/storage/index.js', () => ({
 
 import { initRecording } from './init-recording.js'
 
+const serviceClientActor: RequestActor = { type: 'service_client', name: 'shared_token' }
+
 const mockEntityLookups = ({
   pedestrian,
   floor,
 }: {
-  pedestrian?: { id: string; organization_id: string }
+  pedestrian?: { id: string; organization_id: string; user_id?: string | null }
   floor?: { id: string; organization_id: string }
 }) => {
   findPedestrianByIdMock.mockResolvedValue(pedestrian)
@@ -70,7 +73,7 @@ describe('initRecording', () => {
       },
     })
 
-    const result = await initRecording({
+    const result = await initRecording(serviceClientActor, {
       pedestrian_id: pedestrianId,
       floor_id: floorId,
       upload_targets: ['acce', 'gyro'],
@@ -112,7 +115,7 @@ describe('initRecording', () => {
       floor: { id: floorId, organization_id: '99999999-9999-4999-8999-999999999999' },
     })
 
-    const result = await initRecording({
+    const result = await initRecording(serviceClientActor, {
       pedestrian_id: pedestrianId,
       floor_id: floorId,
       upload_targets: ['acce', 'gyro'],
@@ -138,7 +141,7 @@ describe('initRecording', () => {
       floor: undefined,
     })
 
-    const result = await initRecording({
+    const result = await initRecording(serviceClientActor, {
       pedestrian_id: pedestrianId,
       floor_id: floorId,
       upload_targets: ['acce', 'gyro'],
@@ -166,7 +169,7 @@ describe('initRecording', () => {
       floor: { id: floorId, organization_id: floorOrganizationId },
     })
 
-    const result = await initRecording({
+    const result = await initRecording(serviceClientActor, {
       pedestrian_id: pedestrianId,
       floor_id: floorId,
       upload_targets: ['acce', 'gyro'],
@@ -196,7 +199,7 @@ describe('initRecording', () => {
       organization_id: '99999999-9999-4999-8999-999999999999',
     })
 
-    await initRecording({
+    await initRecording(serviceClientActor, {
       pedestrian_id: '11111111-1111-4111-8111-111111111111',
       floor_id: '22222222-2222-4222-8222-222222222222',
       upload_targets: ['acce', 'gyro'],
@@ -204,5 +207,51 @@ describe('initRecording', () => {
 
     expect(findPedestrianByIdMock).toHaveBeenCalledWith('11111111-1111-4111-8111-111111111111')
     expect(findFloorByIdMock).toHaveBeenCalledWith('22222222-2222-4222-8222-222222222222')
+  })
+
+  it('member が別 user の pedestrian で作成しようとすると AUTH_ORGANIZATION_FORBIDDEN を返す', async () => {
+    const pedestrianId = '11111111-1111-4111-8111-111111111111'
+    const floorId = '22222222-2222-4222-8222-222222222222'
+    const organizationId = '99999999-9999-4999-8999-999999999999'
+
+    mockEntityLookups({
+      pedestrian: {
+        id: pedestrianId,
+        organization_id: organizationId,
+        user_id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      },
+      floor: { id: floorId, organization_id: organizationId },
+    })
+
+    const result = await initRecording(
+      {
+        type: 'user',
+        user_id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+        email: 'member@example.test',
+        global_role: 'none',
+        password_must_change: false,
+        memberships: [
+          {
+            organization_id: organizationId,
+            organization_name: 'Test Organization',
+            role: 'member',
+          },
+        ],
+      },
+      {
+        pedestrian_id: pedestrianId,
+        floor_id: floorId,
+        upload_targets: ['acce', 'gyro'],
+      }
+    )
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        type: 'AUTH_ORGANIZATION_FORBIDDEN',
+      },
+    })
+    expect(insertRecordingMock).not.toHaveBeenCalled()
+    expect(issueRecordingUploadUrlsMock).not.toHaveBeenCalled()
   })
 })

--- a/apps/kaede/src/usecases/init-recording.ts
+++ b/apps/kaede/src/usecases/init-recording.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/node'
+import type { RequestActor } from '../middleware/request-actor-context.js'
 import { recordingUploadStatusSchema } from '../schemas/common.js'
 import type { UploadTarget } from '../schemas/common.js'
 import type { InitRecordingRequest } from '../schemas/recordings.js'
@@ -6,8 +7,11 @@ import { findFloorById } from '../services/floors/index.js'
 import { findPedestrianById } from '../services/pedestrians/index.js'
 import { insertRecording } from '../services/recordings/index.js'
 import { issueRecordingUploadUrls } from '../services/storage/index.js'
+import type { AuthorizationError } from './authorization.js'
+import { requireRecordingAccess } from './authorization.js'
 
 export type InitRecordingError =
+  | AuthorizationError
   | {
       type: 'PEDESTRIAN_NOT_FOUND'
       pedestrianId: string
@@ -59,7 +63,7 @@ const throwOrganizationInvariantError = (message: string): never => {
   throw error
 }
 
-export const initRecording = async (payload: InitRecordingRequest) => {
+export const initRecording = async (actor: RequestActor, payload: InitRecordingRequest) => {
   const [pedestrian, floor] = await Promise.all([
     findPedestrianById(payload.pedestrian_id),
     findFloorById(payload.floor_id),
@@ -104,6 +108,15 @@ export const initRecording = async (payload: InitRecordingRequest) => {
         floorOrganizationId: floor.organization_id,
       },
     } satisfies InitRecordingResult
+  }
+
+  const authorization = requireRecordingAccess(actor, {
+    organization_id: pedestrian.organization_id,
+    pedestrian_user_id: pedestrian.user_id,
+  })
+
+  if (!authorization.ok) {
+    return authorization satisfies InitRecordingResult
   }
 
   const uploadTargets = withRequiredMetadataTarget(payload.upload_targets)

--- a/apps/kaede/src/usecases/refresh-upload-urls.test.ts
+++ b/apps/kaede/src/usecases/refresh-upload-urls.test.ts
@@ -1,11 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RequestActor } from '../middleware/request-actor-context.js'
 
-const { findRecordingByIdMock, issueRecordingUploadUrlsMock } = vi.hoisted(() => ({
-  findRecordingByIdMock: vi.fn(),
-  issueRecordingUploadUrlsMock: vi.fn(),
-}))
+const { findRecordingAuthorizationByIdMock, findRecordingByIdMock, issueRecordingUploadUrlsMock } =
+  vi.hoisted(() => ({
+    findRecordingAuthorizationByIdMock: vi.fn(),
+    findRecordingByIdMock: vi.fn(),
+    issueRecordingUploadUrlsMock: vi.fn(),
+  }))
 
 vi.mock('../services/recordings/index.js', () => ({
+  findRecordingAuthorizationById: findRecordingAuthorizationByIdMock,
   findRecordingById: findRecordingByIdMock,
 }))
 
@@ -14,6 +18,17 @@ vi.mock('../services/storage/index.js', () => ({
 }))
 
 import { refreshUploadUrls } from './refresh-upload-urls.js'
+
+const serviceClientActor: RequestActor = { type: 'service_client', name: 'shared_token' }
+
+const mockRecordingAuthorization = (recordingId: string) => {
+  findRecordingAuthorizationByIdMock.mockResolvedValue({
+    id: recordingId,
+    organization_id: '99999999-9999-4999-8999-999999999999',
+    pedestrian_id: '22222222-2222-4222-8222-222222222222',
+    pedestrian_user_id: null,
+  })
+}
 
 describe('refreshUploadUrls', () => {
   beforeEach(() => {
@@ -28,6 +43,7 @@ describe('refreshUploadUrls', () => {
       upload_status: 'accepted',
       upload_targets: ['acce', 'gyro', 'wifi'],
     })
+    mockRecordingAuthorization(recordingId)
     issueRecordingUploadUrlsMock.mockResolvedValue({
       expiresAt: '2026-05-13T00:15:00.000Z',
       uploadUrls: {
@@ -36,6 +52,7 @@ describe('refreshUploadUrls', () => {
     })
 
     const result = await refreshUploadUrls(
+      serviceClientActor,
       { recordingId },
       {
         targets: ['gyro'],
@@ -62,6 +79,7 @@ describe('refreshUploadUrls', () => {
     findRecordingByIdMock.mockResolvedValue(undefined)
 
     const result = await refreshUploadUrls(
+      serviceClientActor,
       { recordingId },
       {
         targets: ['acce'],
@@ -86,8 +104,10 @@ describe('refreshUploadUrls', () => {
       upload_status: 'ready',
       upload_targets: ['acce', 'gyro'],
     })
+    mockRecordingAuthorization(recordingId)
 
     const result = await refreshUploadUrls(
+      serviceClientActor,
       { recordingId },
       {
         targets: ['acce'],
@@ -113,8 +133,10 @@ describe('refreshUploadUrls', () => {
       upload_status: 'accepted',
       upload_targets: ['acce', 'gyro'],
     })
+    mockRecordingAuthorization(recordingId)
 
     const result = await refreshUploadUrls(
+      serviceClientActor,
       { recordingId },
       {
         targets: ['wifi'],
@@ -127,6 +149,52 @@ describe('refreshUploadUrls', () => {
         type: 'RECORDING_UPLOAD_TARGETS_INVALID',
         recordingId,
         invalidTargets: ['wifi'],
+      },
+    })
+    expect(issueRecordingUploadUrlsMock).not.toHaveBeenCalled()
+  })
+
+  it('member が別 user の pedestrian recording の URL を再発行しようとすると AUTH_ORGANIZATION_FORBIDDEN を返す', async () => {
+    const recordingId = '11111111-1111-4111-8111-111111111111'
+    const organizationId = '99999999-9999-4999-8999-999999999999'
+
+    findRecordingByIdMock.mockResolvedValue({
+      id: recordingId,
+      upload_status: 'accepted',
+      upload_targets: ['acce', 'gyro'],
+    })
+    findRecordingAuthorizationByIdMock.mockResolvedValue({
+      id: recordingId,
+      organization_id: organizationId,
+      pedestrian_id: '22222222-2222-4222-8222-222222222222',
+      pedestrian_user_id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    })
+
+    const result = await refreshUploadUrls(
+      {
+        type: 'user',
+        user_id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+        email: 'member@example.test',
+        global_role: 'none',
+        password_must_change: false,
+        memberships: [
+          {
+            organization_id: organizationId,
+            organization_name: 'Test Organization',
+            role: 'member',
+          },
+        ],
+      },
+      { recordingId },
+      {
+        targets: ['acce'],
+      }
+    )
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        type: 'AUTH_ORGANIZATION_FORBIDDEN',
       },
     })
     expect(issueRecordingUploadUrlsMock).not.toHaveBeenCalled()

--- a/apps/kaede/src/usecases/refresh-upload-urls.ts
+++ b/apps/kaede/src/usecases/refresh-upload-urls.ts
@@ -1,10 +1,14 @@
+import type { RequestActor } from '../middleware/request-actor-context.js'
 import type { UploadTarget } from '../schemas/common.js'
 import { recordingUploadStatusSchema } from '../schemas/common.js'
 import type { RefreshUploadUrlsRequest, RecordingIdParams } from '../schemas/recordings.js'
-import { findRecordingById } from '../services/recordings/index.js'
+import { findRecordingAuthorizationById, findRecordingById } from '../services/recordings/index.js'
 import { issueRecordingUploadUrls } from '../services/storage/index.js'
+import type { AuthorizationError } from './authorization.js'
+import { requireRecordingAccess } from './authorization.js'
 
 export type RefreshUploadUrlsError =
+  | AuthorizationError
   | {
       type: 'RECORDING_NOT_FOUND'
       recordingId: string
@@ -41,6 +45,7 @@ export type RefreshUploadUrlsResult =
     }
 
 export const refreshUploadUrls = async (
+  actor: RequestActor,
   params: RecordingIdParams,
   payload: RefreshUploadUrlsRequest
 ) => {
@@ -54,6 +59,24 @@ export const refreshUploadUrls = async (
         recordingId: params.recordingId,
       },
     } satisfies RefreshUploadUrlsResult
+  }
+
+  const recordingAuthorization = await findRecordingAuthorizationById(recording.id)
+
+  if (!recordingAuthorization) {
+    return {
+      ok: false,
+      error: {
+        type: 'RECORDING_NOT_FOUND',
+        recordingId: recording.id,
+      },
+    } satisfies RefreshUploadUrlsResult
+  }
+
+  const authorization = requireRecordingAccess(actor, recordingAuthorization)
+
+  if (!authorization.ok) {
+    return authorization satisfies RefreshUploadUrlsResult
   }
 
   const uploadStatus = recordingUploadStatusSchema.parse(recording.upload_status)

--- a/apps/kaede/tests/routes/recordings/create-trajectory.test.ts
+++ b/apps/kaede/tests/routes/recordings/create-trajectory.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { resetRuntimeConfigForTests } from '../../../src/config/runtime.js'
 import { createTrajectoryResponseSchema } from '../../../src/schemas/trajectories.js'
 import { createApp } from '../../../src/server.js'
 import { createDb } from '../../../src/services/db/client.js'
@@ -33,10 +34,17 @@ vi.mock('../../../src/services/nozomi/index.js', () => ({
 }))
 
 const db = createDb()
-const app = createApp()
+let app: ReturnType<typeof createApp>
+
+const authHeaders = {
+  authorization: 'Bearer shared-token',
+}
 
 describe('POST /api/recordings/:recordingId/trajectories', () => {
   beforeEach(async () => {
+    process.env.KAEDE_API_SHARED_TOKEN = 'shared-token'
+    resetRuntimeConfigForTests()
+    app = createApp()
     await resetDatabase(db)
     vi.clearAllMocks()
     issueInternalRecordingRawDownloadUrlsMock.mockResolvedValue({
@@ -55,6 +63,8 @@ describe('POST /api/recordings/:recordingId/trajectories', () => {
 
   afterAll(async () => {
     await db.destroy()
+    Reflect.deleteProperty(process.env, 'KAEDE_API_SHARED_TOKEN')
+    resetRuntimeConfigForTests()
   })
 
   it('trajectory と constraints を作成し processing を返す', async () => {
@@ -71,6 +81,7 @@ describe('POST /api/recordings/:recordingId/trajectories', () => {
     const response = await app.request(`/api/recordings/${recordingId}/trajectories`, {
       method: 'POST',
       headers: {
+        ...authHeaders,
         'content-type': 'application/json',
       },
       body: JSON.stringify({
@@ -148,6 +159,7 @@ describe('POST /api/recordings/:recordingId/trajectories', () => {
     const response = await app.request(`/api/recordings/${recordingId}/trajectories`, {
       method: 'POST',
       headers: {
+        ...authHeaders,
         'content-type': 'application/json',
       },
       body: JSON.stringify({
@@ -178,6 +190,7 @@ describe('POST /api/recordings/:recordingId/trajectories', () => {
     const response = await app.request(`/api/recordings/${recordingId}/trajectories`, {
       method: 'POST',
       headers: {
+        ...authHeaders,
         'content-type': 'application/json',
       },
       body: JSON.stringify({

--- a/apps/kaede/tests/routes/recordings/init-recording.test.ts
+++ b/apps/kaede/tests/routes/recordings/init-recording.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { resetRuntimeConfigForTests } from '../../../src/config/runtime.js'
 import { initRecordingResponseSchema } from '../../../src/schemas/recordings.js'
 import { createApp } from '../../../src/server.js'
 import { createDb } from '../../../src/services/db/client.js'
@@ -6,15 +7,24 @@ import { resetDatabase } from '../../db/helpers.js'
 import { createRecordingFixture } from '../../fixtures/recordings.js'
 
 const db = createDb()
-const app = createApp()
+let app: ReturnType<typeof createApp>
+
+const authHeaders = {
+  authorization: 'Bearer shared-token',
+}
 
 describe('POST /api/recordings/init', () => {
   beforeEach(async () => {
+    process.env.KAEDE_API_SHARED_TOKEN = 'shared-token'
+    resetRuntimeConfigForTests()
+    app = createApp()
     await resetDatabase(db)
   })
 
   afterAll(async () => {
     await db.destroy()
+    Reflect.deleteProperty(process.env, 'KAEDE_API_SHARED_TOKEN')
+    resetRuntimeConfigForTests()
   })
 
   it('recording を作成しアップロード URL を返す', async () => {
@@ -23,6 +33,7 @@ describe('POST /api/recordings/init', () => {
     const response = await app.request('/api/recordings/init', {
       method: 'POST',
       headers: {
+        ...authHeaders,
         'content-type': 'application/json',
       },
       body: JSON.stringify({
@@ -71,6 +82,7 @@ describe('POST /api/recordings/init', () => {
     const response = await app.request('/api/recordings/init', {
       method: 'POST',
       headers: {
+        ...authHeaders,
         'content-type': 'application/json',
       },
       body: JSON.stringify({
@@ -96,6 +108,7 @@ describe('POST /api/recordings/init', () => {
     const response = await app.request('/api/recordings/init', {
       method: 'POST',
       headers: {
+        ...authHeaders,
         'content-type': 'application/json',
       },
       body: JSON.stringify({

--- a/apps/kaede/tests/routes/recordings/refresh-upload-urls.test.ts
+++ b/apps/kaede/tests/routes/recordings/refresh-upload-urls.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { resetRuntimeConfigForTests } from '../../../src/config/runtime.js'
 import { refreshUploadUrlsResponseSchema } from '../../../src/schemas/recordings.js'
 import { createApp } from '../../../src/server.js'
 import { createDb } from '../../../src/services/db/client.js'
@@ -6,15 +7,24 @@ import { resetDatabase } from '../../db/helpers.js'
 import { createRecordingFixture } from '../../fixtures/recordings.js'
 
 const db = createDb()
-const app = createApp()
+let app: ReturnType<typeof createApp>
+
+const authHeaders = {
+  authorization: 'Bearer shared-token',
+}
 
 describe('POST /api/recordings/:recordingId/refresh-upload-urls', () => {
   beforeEach(async () => {
+    process.env.KAEDE_API_SHARED_TOKEN = 'shared-token'
+    resetRuntimeConfigForTests()
+    app = createApp()
     await resetDatabase(db)
   })
 
   afterAll(async () => {
     await db.destroy()
+    Reflect.deleteProperty(process.env, 'KAEDE_API_SHARED_TOKEN')
+    resetRuntimeConfigForTests()
   })
 
   it('accepted な recording に対して upload URL を再発行する', async () => {
@@ -26,6 +36,7 @@ describe('POST /api/recordings/:recordingId/refresh-upload-urls', () => {
     const response = await app.request(`/api/recordings/${recordingId}/refresh-upload-urls`, {
       method: 'POST',
       headers: {
+        ...authHeaders,
         'content-type': 'application/json',
       },
       body: JSON.stringify({
@@ -54,6 +65,7 @@ describe('POST /api/recordings/:recordingId/refresh-upload-urls', () => {
       {
         method: 'POST',
         headers: {
+          ...authHeaders,
           'content-type': 'application/json',
         },
         body: JSON.stringify({
@@ -81,6 +93,7 @@ describe('POST /api/recordings/:recordingId/refresh-upload-urls', () => {
     const response = await app.request(`/api/recordings/${recordingId}/refresh-upload-urls`, {
       method: 'POST',
       headers: {
+        ...authHeaders,
         'content-type': 'application/json',
       },
       body: JSON.stringify({
@@ -108,6 +121,7 @@ describe('POST /api/recordings/:recordingId/refresh-upload-urls', () => {
     const response = await app.request(`/api/recordings/${recordingId}/refresh-upload-urls`, {
       method: 'POST',
       headers: {
+        ...authHeaders,
         'content-type': 'application/json',
       },
       body: JSON.stringify({
@@ -135,6 +149,7 @@ describe('POST /api/recordings/:recordingId/refresh-upload-urls', () => {
     const response = await app.request(`/api/recordings/${recordingId}/refresh-upload-urls`, {
       method: 'POST',
       headers: {
+        ...authHeaders,
         'content-type': 'application/json',
       },
       body: JSON.stringify({
@@ -162,6 +177,7 @@ describe('POST /api/recordings/:recordingId/refresh-upload-urls', () => {
     const response = await app.request(`/api/recordings/${recordingId}/refresh-upload-urls`, {
       method: 'POST',
       headers: {
+        ...authHeaders,
         'content-type': 'application/json',
       },
       body: JSON.stringify({

--- a/apps/kaede/tests/storage/complete-upload.test.ts
+++ b/apps/kaede/tests/storage/complete-upload.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { resetRuntimeConfigForTests } from '../../src/config/runtime.js'
 import { createApp } from '../../src/server.js'
 import { createDb } from '../../src/services/db/client.js'
 import {
@@ -10,11 +11,18 @@ import { createRecordingFixture } from '../fixtures/recordings.js'
 import { createStorageClient, putObjectText } from './support/helpers.js'
 
 const db = createDb()
-const app = createApp()
+let app: ReturnType<typeof createApp>
 const s3 = createStorageClient()
+
+const authHeaders = {
+  authorization: 'Bearer shared-token',
+}
 
 describe('POST /api/recordings/:recordingId/complete-upload', () => {
   beforeEach(async () => {
+    process.env.KAEDE_API_SHARED_TOKEN = 'shared-token'
+    resetRuntimeConfigForTests()
+    app = createApp()
     await resetDatabase(db)
     resetS3ClientForTests()
   })
@@ -22,6 +30,8 @@ describe('POST /api/recordings/:recordingId/complete-upload', () => {
   afterAll(async () => {
     s3.destroy()
     await db.destroy()
+    Reflect.deleteProperty(process.env, 'KAEDE_API_SHARED_TOKEN')
+    resetRuntimeConfigForTests()
   })
 
   it('必要な raw が揃っていれば ready に更新する', async () => {
@@ -36,6 +46,7 @@ describe('POST /api/recordings/:recordingId/complete-upload', () => {
 
     const response = await app.request(`/api/recordings/${recordingId}/complete-upload`, {
       method: 'POST',
+      headers: authHeaders,
     })
 
     expect(response.status).toBe(200)
@@ -64,6 +75,7 @@ describe('POST /api/recordings/:recordingId/complete-upload', () => {
 
     const response = await app.request(`/api/recordings/${recordingId}/complete-upload`, {
       method: 'POST',
+      headers: authHeaders,
     })
 
     expect(response.status).toBe(409)


### PR DESCRIPTION
# issue番号

- https://github.com/kajiLabTeam/okarin/issues/137

# 変更内容(写真か動画も一緒に)

recording関係のAPIにauth middlewareを追加
  - service client/admin は許可
  - manager は所属 organization の recording を許可
  - member は自分の pedestrian.user_id に紐づく recording のみ許可

# 影響範囲(あれば)
