### PR TITLE
user紐付け時にsubjectのみを見る

### DIFF
--- a/apps/kaede/src/routes/auth/auth.test.ts
+++ b/apps/kaede/src/routes/auth/auth.test.ts
@@ -1,26 +1,38 @@
 import { OpenAPIHono } from '@hono/zod-openapi'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { resetRuntimeConfigForTests } from '../../config/runtime.js'
+import { serializeGoogleOidcStateCookie } from './oidc-cookie.js'
 import { authRoutes } from './index.js'
 
 const originalAppEnv = process.env.APP_ENV
 
-const { changePasswordMock, completeGoogleOidcLoginMock, getMeMock, loginMock, logoutMock } =
-  vi.hoisted(() => ({
-    changePasswordMock: vi.fn(),
-    completeGoogleOidcLoginMock: vi.fn(),
-    getMeMock: vi.fn(),
-    loginMock: vi.fn(),
-    logoutMock: vi.fn(),
-  }))
+const {
+  changePasswordMock,
+  completeGoogleOidcLinkMock,
+  completeGoogleOidcLoginMock,
+  getMeMock,
+  loginMock,
+  logoutMock,
+  requireActiveSessionUserMock,
+} = vi.hoisted(() => ({
+  changePasswordMock: vi.fn(),
+  completeGoogleOidcLinkMock: vi.fn(),
+  completeGoogleOidcLoginMock: vi.fn(),
+  getMeMock: vi.fn(),
+  loginMock: vi.fn(),
+  logoutMock: vi.fn(),
+  requireActiveSessionUserMock: vi.fn(),
+}))
 
 vi.mock('../../services/auth/index.js', () => ({
   generateOidcNonce: vi.fn(() => 'nonce-value'),
   generateOidcState: vi.fn(() => 'state-value'),
   generatePkceCodeVerifier: vi.fn(() => 'code-verifier'),
-  GoogleOidcClient: vi.fn(() => ({
-    createAuthorizationUrl: vi.fn(() => 'https://accounts.example.test/auth'),
-  })),
+  GoogleOidcClient: vi.fn(function () {
+    return {
+      createAuthorizationUrl: vi.fn(() => 'https://accounts.example.test/auth'),
+    }
+  }),
 }))
 
 vi.mock('../../usecases/auth/index.js', () => ({
@@ -34,10 +46,12 @@ vi.mock('../../usecases/auth/index.js', () => ({
     }
   },
   changePassword: changePasswordMock,
+  completeGoogleOidcLink: completeGoogleOidcLinkMock,
   completeGoogleOidcLogin: completeGoogleOidcLoginMock,
   getMe: getMeMock,
   login: loginMock,
   logout: logoutMock,
+  requireActiveSessionUser: requireActiveSessionUserMock,
 }))
 
 const createAuthTestApp = () => {
@@ -75,6 +89,11 @@ describe('auth routes', () => {
       process.env.APP_ENV = originalAppEnv
     }
     process.env.OIDC_ENABLED = 'false'
+    Reflect.deleteProperty(process.env, 'FRONTEND_ORIGIN')
+    Reflect.deleteProperty(process.env, 'OIDC_GOOGLE_CLIENT_ID')
+    Reflect.deleteProperty(process.env, 'OIDC_GOOGLE_CLIENT_SECRET')
+    Reflect.deleteProperty(process.env, 'OIDC_GOOGLE_REDIRECT_URI')
+    Reflect.deleteProperty(process.env, 'OIDC_STATE_COOKIE_SECRET')
     Reflect.deleteProperty(process.env, 'PASSWORD_LOGIN_ENABLED')
     Reflect.deleteProperty(process.env, 'SESSION_COOKIE_SAME_SITE')
     resetRuntimeConfigForTests()
@@ -87,6 +106,11 @@ describe('auth routes', () => {
       process.env.APP_ENV = originalAppEnv
     }
     Reflect.deleteProperty(process.env, 'OIDC_ENABLED')
+    Reflect.deleteProperty(process.env, 'FRONTEND_ORIGIN')
+    Reflect.deleteProperty(process.env, 'OIDC_GOOGLE_CLIENT_ID')
+    Reflect.deleteProperty(process.env, 'OIDC_GOOGLE_CLIENT_SECRET')
+    Reflect.deleteProperty(process.env, 'OIDC_GOOGLE_REDIRECT_URI')
+    Reflect.deleteProperty(process.env, 'OIDC_STATE_COOKIE_SECRET')
     Reflect.deleteProperty(process.env, 'PASSWORD_LOGIN_ENABLED')
     Reflect.deleteProperty(process.env, 'SESSION_COOKIE_SAME_SITE')
     resetRuntimeConfigForTests()
@@ -207,6 +231,84 @@ describe('auth routes', () => {
 
     expect(response.status).toBe(302)
     expect(response.headers.get('location')).toBe('/?error=oidc_disabled')
+  })
+
+  it('GET /api/auth/oidc/google/link はログイン済み user の Google 連携を開始する', async () => {
+    process.env.OIDC_ENABLED = 'true'
+    process.env.OIDC_GOOGLE_CLIENT_ID = 'client-id'
+    process.env.OIDC_GOOGLE_CLIENT_SECRET = 'client-secret'
+    process.env.OIDC_GOOGLE_REDIRECT_URI = 'https://api.example.test/api/auth/oidc/google/callback'
+    process.env.OIDC_STATE_COOKIE_SECRET = 'state-cookie-secret'
+    process.env.FRONTEND_ORIGIN = 'https://app.example.test'
+    resetRuntimeConfigForTests()
+    requireActiveSessionUserMock.mockResolvedValue({
+      ok: true,
+      value: {
+        id: '11111111-1111-4111-8111-111111111111',
+      },
+    })
+
+    const app = createAuthTestApp()
+    const response = await app.request('/api/auth/oidc/google/link', {
+      headers: {
+        cookie: 'okarin_session=session-token',
+      },
+    })
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toBe('https://accounts.example.test/auth')
+    expect(response.headers.get('set-cookie')).toContain('okarin_oidc_google=')
+    expect(requireActiveSessionUserMock).toHaveBeenCalledWith('session-token')
+  })
+
+  it('GET /api/auth/oidc/google/callback は link intent なら Google 連携を完了する', async () => {
+    process.env.OIDC_ENABLED = 'true'
+    process.env.OIDC_GOOGLE_CLIENT_ID = 'client-id'
+    process.env.OIDC_GOOGLE_CLIENT_SECRET = 'client-secret'
+    process.env.OIDC_GOOGLE_REDIRECT_URI = 'https://api.example.test/api/auth/oidc/google/callback'
+    process.env.OIDC_STATE_COOKIE_SECRET = 'state-cookie-secret'
+    process.env.FRONTEND_ORIGIN = 'https://app.example.test'
+    resetRuntimeConfigForTests()
+    completeGoogleOidcLinkMock.mockResolvedValue({
+      ok: true,
+      value: { ok: true },
+    })
+    const stateCookie = serializeGoogleOidcStateCookie(
+      {
+        state: 'state-value',
+        nonce: 'nonce-value',
+        codeVerifier: 'code-verifier',
+        expiresAt: '2099-06-17T00:10:00.000Z',
+        intent: 'link',
+      },
+      'state-cookie-secret'
+    )
+
+    const app = createAuthTestApp()
+    const response = await app.request(
+      '/api/auth/oidc/google/callback?code=authorization-code&state=state-value',
+      {
+        headers: {
+          cookie: `okarin_oidc_google=${stateCookie}; okarin_session=session-token`,
+        },
+      }
+    )
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toBe('https://app.example.test/')
+    expect(response.headers.get('set-cookie')).not.toContain('okarin_session=')
+    expect(completeGoogleOidcLinkMock).toHaveBeenCalledWith(
+      'session-token',
+      {
+        code: 'authorization-code',
+        state: 'state-value',
+        expectedState: 'state-value',
+        nonce: 'nonce-value',
+        codeVerifier: 'code-verifier',
+      },
+      expect.any(Object)
+    )
+    expect(completeGoogleOidcLoginMock).not.toHaveBeenCalled()
   })
 
   it('GET /api/auth/me は cookie の session token で user を返す', async () => {

--- a/apps/kaede/src/routes/auth/index.ts
+++ b/apps/kaede/src/routes/auth/index.ts
@@ -4,12 +4,14 @@ import { registerLoginRoute } from './login.js'
 import { registerLogoutRoute } from './logout.js'
 import { registerMeRoute } from './me.js'
 import { registerGoogleOidcCallbackRoute } from './oidc-google-callback.js'
+import { registerGoogleOidcLinkRoute } from './oidc-google-link.js'
 import { registerGoogleOidcLoginRoute } from './oidc-google-login.js'
 
 export const authRoutes = new OpenAPIHono()
 
 registerLoginRoute(authRoutes)
 registerGoogleOidcLoginRoute(authRoutes)
+registerGoogleOidcLinkRoute(authRoutes)
 registerGoogleOidcCallbackRoute(authRoutes)
 registerLogoutRoute(authRoutes)
 registerMeRoute(authRoutes)

--- a/apps/kaede/src/routes/auth/oidc-cookie.test.ts
+++ b/apps/kaede/src/routes/auth/oidc-cookie.test.ts
@@ -6,6 +6,7 @@ const payload = {
   nonce: 'nonce-value',
   codeVerifier: 'code-verifier',
   expiresAt: '2026-06-17T00:10:00.000Z',
+  intent: 'login' as const,
 }
 
 describe('Google OIDC state cookie', () => {

--- a/apps/kaede/src/routes/auth/oidc-cookie.ts
+++ b/apps/kaede/src/routes/auth/oidc-cookie.ts
@@ -10,6 +10,7 @@ export interface GoogleOidcStateCookiePayload {
   nonce: string
   codeVerifier: string
   expiresAt: string
+  intent: 'login' | 'link'
   inviteToken?: string
 }
 

--- a/apps/kaede/src/routes/auth/oidc-google-callback.ts
+++ b/apps/kaede/src/routes/auth/oidc-google-callback.ts
@@ -2,8 +2,8 @@ import { createRoute, z } from '@hono/zod-openapi'
 import type { OpenAPIHono } from '@hono/zod-openapi'
 import { getOidcRuntimeConfig } from '../../config/runtime.js'
 import { GoogleOidcClient } from '../../services/auth/index.js'
-import { completeGoogleOidcLogin } from '../../usecases/auth/index.js'
-import { setSessionCookie } from './cookie.js'
+import { completeGoogleOidcLink, completeGoogleOidcLogin } from '../../usecases/auth/index.js'
+import { getSessionTokenFromCookie, setSessionCookie } from './cookie.js'
 import { clearGoogleOidcStateCookie, getGoogleOidcStateCookie } from './oidc-cookie.js'
 
 const callbackQuerySchema = z.object({
@@ -58,13 +58,31 @@ export const registerGoogleOidcCallbackRoute = (app: OpenAPIHono) => {
       clientSecret: config.googleClientSecret,
       redirectUri: config.googleRedirectUri,
     })
+    const params = {
+      code: query.code,
+      state: query.state,
+      expectedState: stateCookie.state,
+      nonce: stateCookie.nonce,
+      codeVerifier: stateCookie.codeVerifier,
+    }
+
+    if (stateCookie.intent === 'link') {
+      const result = await completeGoogleOidcLink(getSessionTokenFromCookie(c), params, client)
+
+      if (!result.ok) {
+        return c.redirect(withError(failureRedirectUrl, result.error.type.toLowerCase()), 302)
+      }
+
+      return c.redirect(config.loginSuccessRedirectUrl, 302)
+    }
+
     const result = await completeGoogleOidcLogin(
       {
-        code: query.code,
-        state: query.state,
-        expectedState: stateCookie.state,
-        nonce: stateCookie.nonce,
-        codeVerifier: stateCookie.codeVerifier,
+        code: params.code,
+        state: params.state,
+        expectedState: params.expectedState,
+        nonce: params.nonce,
+        codeVerifier: params.codeVerifier,
       },
       client
     )

--- a/apps/kaede/src/routes/auth/oidc-google-link.ts
+++ b/apps/kaede/src/routes/auth/oidc-google-link.ts
@@ -1,4 +1,4 @@
-import { createRoute, z } from '@hono/zod-openapi'
+import { createRoute } from '@hono/zod-openapi'
 import type { OpenAPIHono } from '@hono/zod-openapi'
 import { getOidcRuntimeConfig } from '../../config/runtime.js'
 import {
@@ -7,11 +7,9 @@ import {
   generatePkceCodeVerifier,
   GoogleOidcClient,
 } from '../../services/auth/index.js'
+import { requireActiveSessionUser } from '../../usecases/auth/index.js'
+import { getSessionTokenFromCookie } from './cookie.js'
 import { setGoogleOidcStateCookie } from './oidc-cookie.js'
-
-const loginQuerySchema = z.object({
-  invite_token: z.string().min(1).optional(),
-})
 
 const withError = (url: string, errorCode: string) => {
   const redirectUrl = new URL(url, 'http://localhost')
@@ -21,15 +19,12 @@ const withError = (url: string, errorCode: string) => {
     : redirectUrl.toString()
 }
 
-export const registerGoogleOidcLoginRoute = (app: OpenAPIHono) => {
+export const registerGoogleOidcLinkRoute = (app: OpenAPIHono) => {
   const route = createRoute({
     method: 'get',
-    path: '/oidc/google/login',
+    path: '/oidc/google/link',
     tags: ['Auth'],
-    description: 'Google authorization endpoint へ redirect する',
-    request: {
-      query: loginQuerySchema,
-    },
+    description: 'ログイン中 user の Google identity 連携を開始する',
     responses: {
       302: {
         description: 'redirect to Google authorization endpoint',
@@ -37,14 +32,22 @@ export const registerGoogleOidcLoginRoute = (app: OpenAPIHono) => {
     },
   })
 
-  app.openapi(route, (c) => {
+  app.openapi(route, async (c) => {
     const config = getOidcRuntimeConfig()
 
     if (!config.enabled) {
       return c.redirect(withError(config.loginFailureRedirectUrl, 'oidc_disabled'), 302)
     }
 
-    const query = c.req.valid('query')
+    const activeUser = await requireActiveSessionUser(getSessionTokenFromCookie(c))
+
+    if (!activeUser.ok) {
+      return c.redirect(
+        withError(config.loginFailureRedirectUrl, activeUser.error.type.toLowerCase()),
+        302
+      )
+    }
+
     const state = generateOidcState()
     const nonce = generateOidcNonce()
     const codeVerifier = generatePkceCodeVerifier()
@@ -62,8 +65,7 @@ export const registerGoogleOidcLoginRoute = (app: OpenAPIHono) => {
         nonce,
         codeVerifier,
         expiresAt: expiresAt.toISOString(),
-        intent: 'login',
-        inviteToken: query.invite_token,
+        intent: 'link',
       },
       config.stateCookieSecret
     )

--- a/apps/kaede/src/usecases/auth/index.ts
+++ b/apps/kaede/src/usecases/auth/index.ts
@@ -70,6 +70,13 @@ export type OidcLoginError =
   | { type: 'OIDC_IDENTITY_CONFLICT' }
   | { type: 'AUTH_USER_DISABLED' }
 
+export type OidcLinkError =
+  | { type: 'OIDC_INVALID_STATE' }
+  | { type: 'OIDC_PROVIDER_ERROR' }
+  | { type: 'OIDC_EMAIL_UNVERIFIED' }
+  | { type: 'OIDC_IDENTITY_CONFLICT' }
+  | ActiveSessionUserError
+
 export type OidcLoginResult =
   | {
       ok: true
@@ -80,6 +87,18 @@ export type OidcLoginResult =
   | {
       ok: false
       error: OidcLoginError
+    }
+
+export type OidcLinkResult =
+  | {
+      ok: true
+      value: {
+        ok: true
+      }
+    }
+  | {
+      ok: false
+      error: OidcLinkError
     }
 
 export interface CompleteGoogleOidcLoginParams {
@@ -201,40 +220,10 @@ const findOrCreateGoogleOidcUser = async (
     }
   }
 
-  const existingUser = await findUserByEmail(claims.email, executor)
-
-  if (existingUser) {
-    if (!existingUser.is_active) {
-      return {
-        ok: true,
-        value: existingUser,
-      }
-    }
-
-    const existingIdentity = await findGoogleIdentityByUserId(existingUser.id, executor)
-
-    if (existingIdentity) {
-      return {
-        ok: false,
-        error: { type: 'AUTH_INVALID_CREDENTIALS' },
-      }
-    }
-
-    await insertAuthIdentity(
-      {
-        user_id: existingUser.id,
-        provider: 'google',
-        provider_subject: claims.sub,
-        email: claims.email,
-        email_verified: claims.emailVerified,
-        hosted_domain: claims.hostedDomain,
-      },
-      executor
-    )
-
+  if (await findUserByEmail(claims.email, executor)) {
     return {
-      ok: true,
-      value: existingUser,
+      ok: false,
+      error: { type: 'AUTH_INVALID_CREDENTIALS' },
     }
   }
 
@@ -267,6 +256,60 @@ const findOrCreateGoogleOidcUser = async (
   return {
     ok: true,
     value: createdUser,
+  }
+}
+
+const verifyGoogleOidcClaims = async (
+  params: CompleteGoogleOidcLoginParams,
+  client: GoogleOidcClient
+): Promise<
+  | {
+      ok: true
+      value: GoogleIdTokenClaims
+    }
+  | {
+      ok: false
+      error: Extract<
+        OidcLoginError,
+        { type: 'OIDC_INVALID_STATE' | 'OIDC_PROVIDER_ERROR' | 'OIDC_EMAIL_UNVERIFIED' }
+      >
+    }
+> => {
+  if (!params.code || !params.state || params.state !== params.expectedState) {
+    return {
+      ok: false,
+      error: { type: 'OIDC_INVALID_STATE' },
+    }
+  }
+
+  let claims: GoogleIdTokenClaims
+
+  try {
+    const idToken = await client.exchangeCodeForIdToken({
+      code: params.code,
+      codeVerifier: params.codeVerifier,
+    })
+    claims = await client.verifyIdToken({
+      idToken,
+      nonce: params.nonce,
+    })
+  } catch {
+    return {
+      ok: false,
+      error: { type: 'OIDC_PROVIDER_ERROR' },
+    }
+  }
+
+  if (!claims.emailVerified) {
+    return {
+      ok: false,
+      error: { type: 'OIDC_EMAIL_UNVERIFIED' },
+    }
+  }
+
+  return {
+    ok: true,
+    value: claims,
   }
 }
 
@@ -365,40 +408,14 @@ export const completeGoogleOidcLogin = async (
   now: Date = new Date(),
   executor?: DbExecutor
 ): Promise<OidcLoginResult> => {
-  if (!params.code || !params.state || params.state !== params.expectedState) {
-    return {
-      ok: false,
-      error: { type: 'OIDC_INVALID_STATE' },
-    }
-  }
+  const claimsResult = await verifyGoogleOidcClaims(params, client)
 
-  let claims: GoogleIdTokenClaims
-
-  try {
-    const idToken = await client.exchangeCodeForIdToken({
-      code: params.code,
-      codeVerifier: params.codeVerifier,
-    })
-    claims = await client.verifyIdToken({
-      idToken,
-      nonce: params.nonce,
-    })
-  } catch {
-    return {
-      ok: false,
-      error: { type: 'OIDC_PROVIDER_ERROR' },
-    }
-  }
-
-  if (!claims.emailVerified) {
-    return {
-      ok: false,
-      error: { type: 'OIDC_EMAIL_UNVERIFIED' },
-    }
+  if (!claimsResult.ok) {
+    return claimsResult
   }
 
   const userResult = await runInTransaction(executor, async (trx) => {
-    return findOrCreateGoogleOidcUser(claims, trx)
+    return findOrCreateGoogleOidcUser(claimsResult.value, trx)
   })
 
   if (!userResult.ok) {
@@ -426,6 +443,64 @@ export const completeGoogleOidcLogin = async (
       sessionToken: token,
     },
   }
+}
+
+export const completeGoogleOidcLink = async (
+  sessionToken: string | undefined,
+  params: CompleteGoogleOidcLoginParams,
+  client: GoogleOidcClient,
+  now: Date = new Date(),
+  executor?: DbExecutor
+): Promise<OidcLinkResult> => {
+  const activeUser = await requireActiveSessionUser(sessionToken, executor, now)
+
+  if (!activeUser.ok) {
+    return activeUser
+  }
+
+  const claimsResult = await verifyGoogleOidcClaims(params, client)
+
+  if (!claimsResult.ok) {
+    return claimsResult
+  }
+
+  const result = await runInTransaction(executor, async (trx) => {
+    const identityBySubject = await findGoogleIdentityBySubject(claimsResult.value.sub, trx)
+
+    if (identityBySubject) {
+      return identityBySubject.user_id === activeUser.value.id
+        ? ({ ok: true, value: { ok: true } } as const)
+        : ({ ok: false, error: { type: 'OIDC_IDENTITY_CONFLICT' } } as const)
+    }
+
+    const identityByUserId = await findGoogleIdentityByUserId(activeUser.value.id, trx)
+
+    if (identityByUserId) {
+      return {
+        ok: false,
+        error: { type: 'OIDC_IDENTITY_CONFLICT' },
+      } as const
+    }
+
+    await insertAuthIdentity(
+      {
+        user_id: activeUser.value.id,
+        provider: 'google',
+        provider_subject: claimsResult.value.sub,
+        email: claimsResult.value.email,
+        email_verified: claimsResult.value.emailVerified,
+        hosted_domain: claimsResult.value.hostedDomain,
+      },
+      trx
+    )
+
+    return {
+      ok: true,
+      value: { ok: true },
+    } as const
+  })
+
+  return result
 }
 
 export const getMe = async (

--- a/apps/kaede/tests/services/auth/auth-usecase.test.ts
+++ b/apps/kaede/tests/services/auth/auth-usecase.test.ts
@@ -4,6 +4,7 @@ import { createDb } from '../../../src/services/db/client.js'
 import { createAdminUser } from '../../../src/usecases/auth/create-admin-user.js'
 import {
   changePassword,
+  completeGoogleOidcLink,
   completeGoogleOidcLogin,
   getMe,
   login,
@@ -289,67 +290,44 @@ describe('auth usecase', () => {
     })
   })
 
-  it('Google OIDC callback は既存 admin user に Google identity を紐づけて session を発行する', async () => {
-    const admin = await insertUser({
-      email: 'admin@example.com',
-      displayName: 'Admin',
-      globalRole: 'admin',
-      passwordMustChange: false,
-      temporaryPasswordExpiresAt: null,
+  it('Google OIDC callback は既存 user と email が一致しても自動紐付けしない', async () => {
+    await insertUser({
+      email: 'user@example.com',
     })
     const client = {
       exchangeCodeForIdToken: vi.fn().mockResolvedValue('id-token'),
       verifyIdToken: vi.fn().mockResolvedValue({
-        sub: 'admin-google-subject',
-        email: 'admin@example.com',
+        sub: 'google-subject',
+        email: 'user@example.com',
         emailVerified: true,
-        name: 'Admin From Google',
+        name: 'OIDC User',
         hostedDomain: null,
       }),
     }
 
-    const result = await completeGoogleOidcLogin(
-      {
-        code: 'authorization-code',
-        state: 'state-value',
-        expectedState: 'state-value',
-        nonce: 'nonce-value',
-        codeVerifier: 'code-verifier',
-      },
-      client as never,
-      new Date('2026-06-10T00:00:00.000Z'),
-      db
-    )
-
-    expect(result.ok).toBe(true)
-    if (!result.ok) {
-      return
-    }
-
-    expect(result.value.sessionToken).toEqual(expect.any(String))
-
-    const identity = await db
-      .selectFrom('auth_identities')
-      .selectAll()
-      .where('user_id', '=', admin.id)
-      .executeTakeFirstOrThrow()
-    expect(identity).toMatchObject({
-      provider: 'google',
-      provider_subject: 'admin-google-subject',
-      email: 'admin@example.com',
-      email_verified: true,
-      hosted_domain: null,
+    await expect(
+      completeGoogleOidcLogin(
+        {
+          code: 'authorization-code',
+          state: 'state-value',
+          expectedState: 'state-value',
+          nonce: 'nonce-value',
+          codeVerifier: 'code-verifier',
+        },
+        client as never,
+        new Date('2026-06-10T00:00:00.000Z'),
+        db
+      )
+    ).resolves.toEqual({
+      ok: false,
+      error: { type: 'OIDC_IDENTITY_CONFLICT' },
     })
 
-    const session = await db
-      .selectFrom('sessions')
-      .selectAll()
-      .where('user_id', '=', admin.id)
-      .executeTakeFirstOrThrow()
-    expect(session.session_hash).toEqual(expect.any(String))
+    const identities = await db.selectFrom('auth_identities').selectAll().execute()
+    expect(identities).toHaveLength(0)
   })
 
-  it('Google OIDC callback は bootstrap CLI で作成した admin user に Google identity を紐づける', async () => {
+  it('Google OIDC link は bootstrap CLI で作成した admin user に Google identity を紐づける', async () => {
     const adminResult = await createAdminUser(
       {
         email: 'admin@example.com',
@@ -386,6 +364,13 @@ describe('auth usecase', () => {
         .where('user_id', '=', adminResult.value.userId)
         .executeTakeFirst()
     ).resolves.toBeUndefined()
+    const { token } = await createSession(
+      {
+        userId: adminResult.value.userId,
+        now: new Date('2026-06-10T00:00:00.000Z'),
+      },
+      db
+    )
 
     const client = {
       exchangeCodeForIdToken: vi.fn().mockResolvedValue('id-token'),
@@ -398,7 +383,8 @@ describe('auth usecase', () => {
       }),
     }
 
-    const result = await completeGoogleOidcLogin(
+    const result = await completeGoogleOidcLink(
+      token,
       {
         code: 'authorization-code',
         state: 'state-value',
@@ -411,11 +397,10 @@ describe('auth usecase', () => {
       db
     )
 
-    expect(result.ok).toBe(true)
-    if (!result.ok) {
-      return
-    }
-    expect(result.value.sessionToken).toEqual(expect.any(String))
+    expect(result).toEqual({
+      ok: true,
+      value: { ok: true },
+    })
 
     const identity = await db
       .selectFrom('auth_identities')
@@ -447,6 +432,116 @@ describe('auth usecase', () => {
       .execute()
     expect(users).toHaveLength(1)
     expect(users[0].id).toBe(adminResult.value.userId)
+  })
+
+  it('Google OIDC link はログイン済み user に Google subject を紐付ける', async () => {
+    const user = await insertUser({
+      email: 'user@example.com',
+    })
+    const { token } = await createSession(
+      {
+        userId: user.id,
+        now: new Date('2026-06-10T00:00:00.000Z'),
+      },
+      db
+    )
+    const client = {
+      exchangeCodeForIdToken: vi.fn().mockResolvedValue('id-token'),
+      verifyIdToken: vi.fn().mockResolvedValue({
+        sub: 'google-subject',
+        email: 'changed-google-email@example.com',
+        emailVerified: true,
+        name: 'OIDC User',
+        hostedDomain: null,
+      }),
+    }
+
+    const result = await completeGoogleOidcLink(
+      token,
+      {
+        code: 'authorization-code',
+        state: 'state-value',
+        expectedState: 'state-value',
+        nonce: 'nonce-value',
+        codeVerifier: 'code-verifier',
+      },
+      client as never,
+      new Date('2026-06-10T00:00:00.000Z'),
+      db
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      value: { ok: true },
+    })
+
+    const identity = await db
+      .selectFrom('auth_identities')
+      .selectAll()
+      .where('user_id', '=', user.id)
+      .executeTakeFirstOrThrow()
+    expect(identity).toMatchObject({
+      provider: 'google',
+      provider_subject: 'google-subject',
+      email: 'changed-google-email@example.com',
+      email_verified: true,
+    })
+  })
+
+  it('Google OIDC link は他 user に紐付いた Google subject を拒否する', async () => {
+    const linkedUser = await insertUser({
+      email: 'linked@example.com',
+    })
+    const user = await insertUser({
+      email: 'user@example.com',
+    })
+    await db
+      .insertInto('auth_identities')
+      .values({
+        user_id: linkedUser.id,
+        provider: 'google',
+        provider_subject: 'google-subject',
+        email: 'linked@example.com',
+        email_verified: true,
+        hosted_domain: null,
+      })
+      .execute()
+    const { token } = await createSession(
+      {
+        userId: user.id,
+        now: new Date('2026-06-10T00:00:00.000Z'),
+      },
+      db
+    )
+    const client = {
+      exchangeCodeForIdToken: vi.fn().mockResolvedValue('id-token'),
+      verifyIdToken: vi.fn().mockResolvedValue({
+        sub: 'google-subject',
+        email: 'user@example.com',
+        emailVerified: true,
+        name: 'OIDC User',
+        hostedDomain: null,
+      }),
+    }
+
+    await expect(
+      completeGoogleOidcLink(
+        token,
+        {
+          code: 'authorization-code',
+          state: 'state-value',
+          expectedState: 'state-value',
+          nonce: 'nonce-value',
+          codeVerifier: 'code-verifier',
+        },
+        client as never,
+        new Date('2026-06-10T00:00:00.000Z'),
+        db
+      )
+    ).resolves.toEqual({
+      ok: false,
+      error: { type: 'OIDC_IDENTITY_CONFLICT' },
+    })
   })
 
   it('Google OIDC callback は state mismatch を拒否する', async () => {


### PR DESCRIPTION
# issue番号

- https://github.com/kajiLabTeam/okarin/issues/165

# 変更内容(写真か動画も一緒に)

- Google ログイン時はまず claims.sub を auth_identities.provider_subject で検索
  - 見つかれば、その identity の user_id で user を取得してログイン
  - sub が未登録の場合、email が既存 user と一致しても自動紐付けしない
  - 既存 user への Google 連携は、ログイン済み状態の /api/auth/oidc/google/link 経
    由のみ

# 影響範囲(あれば)
