### PR TITLE
165/feature admin google linking

### DIFF
--- a/apps/kaede/src/middleware/request-actor.test.ts
+++ b/apps/kaede/src/middleware/request-actor.test.ts
@@ -39,13 +39,16 @@ const createTestApp = (sharedToken = 'shared-token') => {
 }
 
 const mockActiveSessionUser = ({
+  authMethod = 'password',
   passwordMustChange = false,
 }: {
+  authMethod?: 'password' | 'oidc'
   passwordMustChange?: boolean
 } = {}) => {
   findValidSessionByTokenMock.mockResolvedValue({
     ok: true,
     session: {
+      auth_method: authMethod,
       user_id: '11111111-1111-4111-8111-111111111111',
     },
   })
@@ -170,7 +173,7 @@ describe('requestActorMiddleware', () => {
     })
   })
 
-  it('password_must_change user は非 auth API を拒否される', async () => {
+  it('password session の password_must_change user は非 auth API を拒否される', async () => {
     mockActiveSessionUser({ passwordMustChange: true })
     const app = createTestApp()
 
@@ -185,6 +188,21 @@ describe('requestActorMiddleware', () => {
       error_code: 'AUTH_PASSWORD_CHANGE_REQUIRED',
       error_message: 'password change required',
     })
+  })
+
+  it('oidc session の password_must_change user は非 auth API を利用できる', async () => {
+    mockActiveSessionUser({ authMethod: 'oidc', passwordMustChange: true })
+    const app = createTestApp()
+
+    const response = await app.request('/api/ping', {
+      headers: {
+        cookie: 'okarin_session=session-token',
+      },
+    })
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.actor.password_must_change).toBe(true)
   })
 
   it('membership がない user は pending_membership actor として設定する', async () => {

--- a/apps/kaede/src/middleware/request-actor.ts
+++ b/apps/kaede/src/middleware/request-actor.ts
@@ -129,7 +129,7 @@ export const requestActorMiddleware = ({
       return authError(c, 'AUTH_USER_DISABLED')
     }
 
-    if (user.password_must_change) {
+    if (sessionResult.session.auth_method === 'password' && user.password_must_change) {
       return authError(c, 'AUTH_PASSWORD_CHANGE_REQUIRED')
     }
 

--- a/apps/kaede/src/routes/auth/auth.test.ts
+++ b/apps/kaede/src/routes/auth/auth.test.ts
@@ -61,6 +61,7 @@ const createAuthTestApp = () => {
 }
 
 const userResponse = {
+  session_auth_method: 'password',
   user: {
     user_id: '11111111-1111-4111-8111-111111111111',
     email: 'user@example.com',

--- a/apps/kaede/src/routes/auth/login.ts
+++ b/apps/kaede/src/routes/auth/login.ts
@@ -73,6 +73,7 @@ export const registerLoginRoute = (app: OpenAPIHono) => {
 
     return c.json(
       {
+        session_auth_method: result.value.session_auth_method,
         user: result.value.user,
       },
       200

--- a/apps/kaede/src/schemas/auth.ts
+++ b/apps/kaede/src/schemas/auth.ts
@@ -30,6 +30,7 @@ export const loginRequestSchema = z.object({
 })
 
 export const authUserResponseSchema = z.object({
+  session_auth_method: z.enum(['password', 'oidc']),
   user: authUserSchema,
 })
 

--- a/apps/kaede/src/services/auth/session-repository.ts
+++ b/apps/kaede/src/services/auth/session-repository.ts
@@ -6,10 +6,12 @@ import { generateSessionToken, hashSessionToken } from './session-token.js'
 type DbExecutor = Kysely<DB> | Transaction<DB>
 
 export type Session = Selectable<Sessions>
+export type SessionAuthMethod = 'password' | 'oidc'
 
 const defaultSessionTtlMs = 7 * 24 * 60 * 60 * 1000
 
 export interface CreateSessionParams {
+  authMethod?: SessionAuthMethod
   userId: string
   now?: Date
   ttlMs?: number
@@ -31,7 +33,12 @@ export type FindValidSessionResult =
     }
 
 export const createSession = async (
-  { userId, now = new Date(), ttlMs = defaultSessionTtlMs }: CreateSessionParams,
+  {
+    authMethod = 'password',
+    userId,
+    now = new Date(),
+    ttlMs = defaultSessionTtlMs,
+  }: CreateSessionParams,
   executor: DbExecutor = db
 ): Promise<CreateSessionResult> => {
   const token = generateSessionToken()
@@ -41,6 +48,7 @@ export const createSession = async (
   const values: Insertable<Sessions> = {
     user_id: userId,
     session_hash: sessionHash,
+    auth_method: authMethod,
     expires_at: expiresAt,
     revoked_at: null,
     last_seen_at: null,

--- a/apps/kaede/src/services/db/generated.ts
+++ b/apps/kaede/src/services/db/generated.ts
@@ -137,6 +137,7 @@ export interface Recordings {
 }
 
 export interface Sessions {
+  auth_method: Generated<string>
   created_at: Generated<Timestamp>
   expires_at: Timestamp
   id: Generated<string>

--- a/apps/kaede/src/usecases/auth/index.ts
+++ b/apps/kaede/src/usecases/auth/index.ts
@@ -139,11 +139,13 @@ const mapActiveSessionError = (
 
 const buildAuthUserResponse = async (
   user: User,
+  sessionAuthMethod: 'password' | 'oidc',
   executor?: DbExecutor
 ): Promise<AuthUserResponse> => {
   const memberships = await listUserOrganizationMemberships(user.id, executor)
 
   return {
+    session_auth_method: sessionAuthMethod,
     user: {
       user_id: user.id,
       email: user.email,
@@ -198,6 +200,26 @@ const createOidcPasswordHash = async () => {
   return hashPassword(`oidc:${randomUUID()}:${randomUUID()}`)
 }
 
+const attachGoogleIdentityToUser = async (
+  user: User,
+  claims: GoogleIdTokenClaims,
+  executor: DbExecutor
+): Promise<User> => {
+  await insertAuthIdentity(
+    {
+      user_id: user.id,
+      provider: 'google',
+      provider_subject: claims.sub,
+      email: claims.email,
+      email_verified: claims.emailVerified,
+      hosted_domain: claims.hostedDomain,
+    },
+    executor
+  )
+
+  return user
+}
+
 const findOrCreateGoogleOidcUser = async (
   claims: GoogleIdTokenClaims,
   executor: DbExecutor
@@ -232,17 +254,7 @@ const findOrCreateGoogleOidcUser = async (
       }
     }
 
-    await insertAuthIdentity(
-      {
-        user_id: existingUser.id,
-        provider: 'google',
-        provider_subject: claims.sub,
-        email: claims.email,
-        email_verified: claims.emailVerified,
-        hosted_domain: claims.hostedDomain,
-      },
-      executor
-    )
+    await attachGoogleIdentityToUser(existingUser, claims, executor)
 
     return {
       ok: true,
@@ -413,8 +425,8 @@ export const login = async (
     executor
   )
 
-  const { token } = await createSession({ userId: user.id, now }, executor)
-  const response = await buildAuthUserResponse(user, executor)
+  const { token } = await createSession({ authMethod: 'password', userId: user.id, now }, executor)
+  const response = await buildAuthUserResponse(user, 'password', executor)
 
   return {
     ok: true,
@@ -458,7 +470,10 @@ export const completeGoogleOidcLogin = async (
     }
   }
 
-  const { token } = await createSession({ userId: userResult.value.id, now }, executor)
+  const { token } = await createSession(
+    { authMethod: 'oidc', userId: userResult.value.id, now },
+    executor
+  )
 
   return {
     ok: true,
@@ -505,17 +520,7 @@ export const completeGoogleOidcLink = async (
       } as const
     }
 
-    await insertAuthIdentity(
-      {
-        user_id: activeUser.value.id,
-        provider: 'google',
-        provider_subject: claimsResult.value.sub,
-        email: claimsResult.value.email,
-        email_verified: claimsResult.value.emailVerified,
-        hosted_domain: claimsResult.value.hostedDomain,
-      },
-      trx
-    )
+    await attachGoogleIdentityToUser(activeUser.value, claimsResult.value, trx)
 
     return {
       ok: true,
@@ -565,7 +570,11 @@ export const getMe = async (
 
   return {
     ok: true,
-    value: await buildAuthUserResponse(user, executor),
+    value: await buildAuthUserResponse(
+      user,
+      sessionResult.session.auth_method as 'password' | 'oidc',
+      executor
+    ),
   }
 }
 

--- a/apps/kaede/tests/services/auth/auth-usecase.test.ts
+++ b/apps/kaede/tests/services/auth/auth-usecase.test.ts
@@ -94,6 +94,7 @@ describe('auth usecase', () => {
     }
 
     expect(result.value.sessionToken).toEqual(expect.any(String))
+    expect(result.value.session_auth_method).toBe('password')
     expect(result.value.user).toEqual({
       user_id: user.id,
       email: 'user@example.com',
@@ -119,6 +120,7 @@ describe('auth usecase', () => {
       .executeTakeFirstOrThrow()
 
     expect(session.expires_at).toEqual(new Date('2026-06-17T00:00:00.000Z'))
+    expect(session.auth_method).toBe('password')
   })
 
   it('login は password 不一致なら failed_login_attempts を増やし AUTH_INVALID_CREDENTIALS を返す', async () => {
@@ -288,6 +290,13 @@ describe('auth usecase', () => {
       email_verified: true,
       hosted_domain: null,
     })
+
+    const session = await db
+      .selectFrom('sessions')
+      .selectAll()
+      .where('user_id', '=', user.id)
+      .executeTakeFirstOrThrow()
+    expect(session.auth_method).toBe('oidc')
   })
 
   it('Google OIDC callback は既存 user と email が一致すれば Google identity を紐づける', async () => {
@@ -335,6 +344,24 @@ describe('auth usecase', () => {
       email_verified: true,
       hosted_domain: null,
     })
+
+    const updatedUser = await db
+      .selectFrom('users')
+      .selectAll()
+      .where('id', '=', user.id)
+      .executeTakeFirstOrThrow()
+    expect(updatedUser).toMatchObject({
+      password_must_change: true,
+      password_changed_at: null,
+      temporary_password_expires_at: new Date('2026-06-11T00:00:00.000Z'),
+    })
+
+    const session = await db
+      .selectFrom('sessions')
+      .selectAll()
+      .where('user_id', '=', user.id)
+      .executeTakeFirstOrThrow()
+    expect(session.auth_method).toBe('oidc')
   })
 
   it('Google OIDC callback は既存 user に別 Google identity があれば conflict を返す', async () => {
@@ -478,6 +505,8 @@ describe('auth usecase', () => {
     expect(adminAfterOidc).toMatchObject({
       global_role: 'admin',
       password_must_change: true,
+      password_changed_at: null,
+      temporary_password_expires_at: new Date('2026-06-11T00:00:00.000Z'),
     })
 
     const users = await db
@@ -487,6 +516,82 @@ describe('auth usecase', () => {
       .execute()
     expect(users).toHaveLength(1)
     expect(users[0].id).toBe(adminResult.value.userId)
+  })
+
+  it('Google OIDC callback は bootstrap CLI で作成した admin user を oidc session でログインする', async () => {
+    const adminResult = await createAdminUser(
+      {
+        email: 'admin@example.com',
+        displayName: 'Bootstrap Admin',
+        password: 'temporary-password',
+        resetPassword: false,
+      },
+      new Date('2026-06-10T00:00:00.000Z'),
+      db
+    )
+    expect(adminResult.ok).toBe(true)
+    if (!adminResult.ok) {
+      return
+    }
+    const client = {
+      exchangeCodeForIdToken: vi.fn().mockResolvedValue('id-token'),
+      verifyIdToken: vi.fn().mockResolvedValue({
+        sub: 'bootstrap-admin-google-subject',
+        email: 'admin@example.com',
+        emailVerified: true,
+        name: 'Admin From Google',
+        hostedDomain: null,
+      }),
+    }
+
+    const result = await completeGoogleOidcLogin(
+      {
+        code: 'authorization-code',
+        state: 'state-value',
+        expectedState: 'state-value',
+        nonce: 'nonce-value',
+        codeVerifier: 'code-verifier',
+      },
+      client as never,
+      new Date('2026-06-10T00:00:00.000Z'),
+      db
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      return
+    }
+
+    const adminAfterOidc = await db
+      .selectFrom('users')
+      .selectAll()
+      .where('id', '=', adminResult.value.userId)
+      .executeTakeFirstOrThrow()
+    expect(adminAfterOidc).toMatchObject({
+      global_role: 'admin',
+      password_must_change: true,
+      password_changed_at: null,
+      temporary_password_expires_at: new Date('2026-06-11T00:00:00.000Z'),
+    })
+
+    const identity = await db
+      .selectFrom('auth_identities')
+      .selectAll()
+      .where('user_id', '=', adminResult.value.userId)
+      .executeTakeFirstOrThrow()
+    expect(identity).toMatchObject({
+      provider: 'google',
+      provider_subject: 'bootstrap-admin-google-subject',
+      email: 'admin@example.com',
+      email_verified: true,
+    })
+
+    const session = await db
+      .selectFrom('sessions')
+      .selectAll()
+      .where('user_id', '=', adminResult.value.userId)
+      .executeTakeFirstOrThrow()
+    expect(session.auth_method).toBe('oidc')
   })
 
   it('Google OIDC link はログイン済み user に Google subject を紐付ける', async () => {
@@ -540,6 +645,17 @@ describe('auth usecase', () => {
       provider_subject: 'google-subject',
       email: 'changed-google-email@example.com',
       email_verified: true,
+    })
+
+    const updatedUser = await db
+      .selectFrom('users')
+      .selectAll()
+      .where('id', '=', user.id)
+      .executeTakeFirstOrThrow()
+    expect(updatedUser).toMatchObject({
+      password_must_change: true,
+      password_changed_at: null,
+      temporary_password_expires_at: new Date('2026-06-11T00:00:00.000Z'),
     })
   })
 
@@ -698,8 +814,31 @@ describe('auth usecase', () => {
     }
 
     expect(result.value.user.user_id).toBe(user.id)
+    expect(result.value.session_auth_method).toBe('password')
     expect(result.value.user.account_state).toBe('pending_membership')
     expect(result.value.user.password_must_change).toBe(false)
+  })
+
+  it('getMe は oidc session の auth method を返す', async () => {
+    const user = await insertUser()
+    const { token } = await createSession(
+      {
+        authMethod: 'oidc',
+        userId: user.id,
+        now: new Date('2026-06-10T00:00:00.000Z'),
+      },
+      db
+    )
+
+    const result = await getMe(token, new Date('2026-06-11T00:00:00.000Z'), db)
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      return
+    }
+
+    expect(result.value.session_auth_method).toBe('oidc')
+    expect(result.value.user.password_must_change).toBe(true)
   })
 
   it('logout は session を revoke する', async () => {

--- a/apps/kaede/tests/services/auth/session-repository.test.ts
+++ b/apps/kaede/tests/services/auth/session-repository.test.ts
@@ -40,10 +40,19 @@ describe('session repository', () => {
     const { token, session } = await createSession({ userId: user.id, now }, db)
 
     expect(token).not.toBe(session.session_hash)
+    expect(session.auth_method).toBe('password')
     expect(session.session_hash).toBe(hashSessionToken(token))
     expect(session.expires_at).toEqual(new Date('2026-06-17T00:00:00.000Z'))
     expect(session.revoked_at).toBeNull()
     expect(session.last_seen_at).toBeNull()
+  })
+
+  it('session の auth method を保存する', async () => {
+    const user = await insertUser()
+
+    const { session } = await createSession({ authMethod: 'oidc', userId: user.id }, db)
+
+    expect(session.auth_method).toBe('oidc')
   })
 
   it('token から session を取得できる', async () => {

--- a/db/migrations/20260623010000_add_session_auth_method.sql
+++ b/db/migrations/20260623010000_add_session_auth_method.sql
@@ -1,0 +1,12 @@
+-- migrate:up
+
+ALTER TABLE sessions
+  ADD COLUMN auth_method text NOT NULL DEFAULT 'password',
+  ADD CONSTRAINT sessions_auth_method_chk
+    CHECK (auth_method IN ('password', 'oidc'));
+
+-- migrate:down
+
+ALTER TABLE sessions
+  DROP CONSTRAINT IF EXISTS sessions_auth_method_chk,
+  DROP COLUMN IF EXISTS auth_method;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -234,10 +234,12 @@ CREATE TABLE public.sessions (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     user_id uuid NOT NULL,
     session_hash text NOT NULL,
+    auth_method text DEFAULT 'password'::text NOT NULL,
     expires_at timestamp with time zone NOT NULL,
     revoked_at timestamp with time zone,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     last_seen_at timestamp with time zone,
+    CONSTRAINT sessions_auth_method_chk CHECK ((auth_method = ANY (ARRAY['password'::text, 'oidc'::text]))),
     CONSTRAINT sessions_session_hash_nonempty_chk CHECK ((length(btrim(session_hash)) > 0))
 );
 


### PR DESCRIPTION
# issue番号

- https://github.com/kajiLabTeam/okarin/issues/165

# 変更内容(写真か動画も一緒に)

  - Google OIDC login で作成した session は auth_method = oidc
  - requestActorMiddleware の password change 強制を password session のみに限定
      - password session + password_must_change=true は従来通り
        AUTH_PASSWORD_CHANGE_REQUIRED

      - OIDC session + password_must_change=true は API 利用可能

  - GET /api/auth/me / POST /api/auth/login の response に session_auth_method を
    追加
      - dashboard が password_must_change=true でも OIDC session なら pending/
        admin dashboard に進める判断ができる

  - bootstrap CLI で作成した admin user が Google OIDC login した場合に、既存
    admin user へ Google identity を紐づけて OIDC session を発行

  - completeGoogleOidcLink の email 不一致許可は維持
      - ログイン済み user session を安全条件とするため

# 影響範囲(あれば)
