### PR TITLE
organization取得のエンドポイント追加

### DIFF
--- a/apps/kaede/src/routes/organization-creation-requests/index.test.ts
+++ b/apps/kaede/src/routes/organization-creation-requests/index.test.ts
@@ -3,19 +3,27 @@ import { createRouteTestApp } from '../create-route-test-app.js'
 import { organizationCreationRequestsRoutes } from './index.js'
 
 const {
+  approveOrganizationCreationRequestForAdminSessionMock,
   createOrganizationCreationRequestForSessionMock,
   getOrganizationCreationRequestForAdminSessionMock,
   listMyOrganizationCreationRequestsForSessionMock,
+  rejectOrganizationCreationRequestForAdminSessionMock,
 } = vi.hoisted(() => ({
+  approveOrganizationCreationRequestForAdminSessionMock: vi.fn(),
   createOrganizationCreationRequestForSessionMock: vi.fn(),
   getOrganizationCreationRequestForAdminSessionMock: vi.fn(),
   listMyOrganizationCreationRequestsForSessionMock: vi.fn(),
+  rejectOrganizationCreationRequestForAdminSessionMock: vi.fn(),
 }))
 
 vi.mock('../../usecases/organizations/index.js', () => ({
+  approveOrganizationCreationRequestForAdminSession:
+    approveOrganizationCreationRequestForAdminSessionMock,
   createOrganizationCreationRequestForSession: createOrganizationCreationRequestForSessionMock,
   getOrganizationCreationRequestForAdminSession: getOrganizationCreationRequestForAdminSessionMock,
   listMyOrganizationCreationRequestsForSession: listMyOrganizationCreationRequestsForSessionMock,
+  rejectOrganizationCreationRequestForAdminSession:
+    rejectOrganizationCreationRequestForAdminSessionMock,
 }))
 
 const requestResponse = {
@@ -170,6 +178,116 @@ describe('organization creation request routes', () => {
     await expect(response.json()).resolves.toEqual({
       error_code: 'ORGANIZATION_CREATION_REQUEST_NOT_FOUND',
       error_message: 'organization creation request not found',
+    })
+  })
+
+  it('POST /api/organization-creation-requests/{requestId}/approve approves request', async () => {
+    approveOrganizationCreationRequestForAdminSessionMock.mockResolvedValue({
+      ok: true,
+      value: {
+        ...requestResponse,
+        status: 'approved',
+        reviewed_by_user_id: '33333333-3333-4333-8333-333333333333',
+        reviewed_at: '2026-06-11T00:00:00.000Z',
+        created_organization_id: '44444444-4444-4444-8444-444444444444',
+      },
+    })
+
+    const app = createRouteTestApp('/organization-creation-requests', (resource) =>
+      resource.route('/', organizationCreationRequestsRoutes)
+    )
+    const response = await app.request(
+      '/api/organization-creation-requests/11111111-1111-4111-8111-111111111111/approve',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          cookie: 'okarin_session=session-token',
+        },
+        body: JSON.stringify({
+          slug: 'approved-org',
+        }),
+      }
+    )
+
+    expect(response.status).toBe(200)
+    expect(approveOrganizationCreationRequestForAdminSessionMock).toHaveBeenCalledWith(
+      'session-token',
+      '11111111-1111-4111-8111-111111111111',
+      {
+        slug: 'approved-org',
+      }
+    )
+  })
+
+  it('POST /api/organization-creation-requests/{requestId}/reject rejects request', async () => {
+    rejectOrganizationCreationRequestForAdminSessionMock.mockResolvedValue({
+      ok: true,
+      value: {
+        ...requestResponse,
+        status: 'rejected',
+        reviewed_by_user_id: '33333333-3333-4333-8333-333333333333',
+        reviewed_at: '2026-06-11T00:00:00.000Z',
+        rejected_reason: 'not enough detail',
+      },
+    })
+
+    const app = createRouteTestApp('/organization-creation-requests', (resource) =>
+      resource.route('/', organizationCreationRequestsRoutes)
+    )
+    const response = await app.request(
+      '/api/organization-creation-requests/11111111-1111-4111-8111-111111111111/reject',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          cookie: 'okarin_session=session-token',
+        },
+        body: JSON.stringify({
+          reason: 'not enough detail',
+        }),
+      }
+    )
+
+    expect(response.status).toBe(200)
+    expect(rejectOrganizationCreationRequestForAdminSessionMock).toHaveBeenCalledWith(
+      'session-token',
+      '11111111-1111-4111-8111-111111111111',
+      {
+        reason: 'not enough detail',
+      }
+    )
+  })
+
+  it('approve returns 409 when slug is already used', async () => {
+    approveOrganizationCreationRequestForAdminSessionMock.mockResolvedValue({
+      ok: false,
+      error: {
+        type: 'ORGANIZATION_SLUG_ALREADY_EXISTS',
+      },
+    })
+
+    const app = createRouteTestApp('/organization-creation-requests', (resource) =>
+      resource.route('/', organizationCreationRequestsRoutes)
+    )
+    const response = await app.request(
+      '/api/organization-creation-requests/11111111-1111-4111-8111-111111111111/approve',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          cookie: 'okarin_session=session-token',
+        },
+        body: JSON.stringify({
+          slug: 'used-slug',
+        }),
+      }
+    )
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({
+      error_code: 'ORGANIZATION_SLUG_ALREADY_EXISTS',
+      error_message: 'organization slug already exists',
     })
   })
 })

--- a/apps/kaede/src/routes/organization-creation-requests/index.test.ts
+++ b/apps/kaede/src/routes/organization-creation-requests/index.test.ts
@@ -4,14 +4,17 @@ import { organizationCreationRequestsRoutes } from './index.js'
 
 const {
   createOrganizationCreationRequestForSessionMock,
+  getOrganizationCreationRequestForAdminSessionMock,
   listMyOrganizationCreationRequestsForSessionMock,
 } = vi.hoisted(() => ({
   createOrganizationCreationRequestForSessionMock: vi.fn(),
+  getOrganizationCreationRequestForAdminSessionMock: vi.fn(),
   listMyOrganizationCreationRequestsForSessionMock: vi.fn(),
 }))
 
 vi.mock('../../usecases/organizations/index.js', () => ({
   createOrganizationCreationRequestForSession: createOrganizationCreationRequestForSessionMock,
+  getOrganizationCreationRequestForAdminSession: getOrganizationCreationRequestForAdminSessionMock,
   listMyOrganizationCreationRequestsForSession: listMyOrganizationCreationRequestsForSessionMock,
 }))
 
@@ -115,5 +118,58 @@ describe('organization creation request routes', () => {
       requests: [requestResponse],
     })
     expect(listMyOrganizationCreationRequestsForSessionMock).toHaveBeenCalledWith('session-token')
+  })
+
+  it('GET /api/organization-creation-requests/{requestId} returns request for admin', async () => {
+    getOrganizationCreationRequestForAdminSessionMock.mockResolvedValue({
+      ok: true,
+      value: requestResponse,
+    })
+
+    const app = createRouteTestApp('/organization-creation-requests', (resource) =>
+      resource.route('/', organizationCreationRequestsRoutes)
+    )
+    const response = await app.request(
+      '/api/organization-creation-requests/11111111-1111-4111-8111-111111111111',
+      {
+        headers: {
+          cookie: 'okarin_session=session-token',
+        },
+      }
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual(requestResponse)
+    expect(getOrganizationCreationRequestForAdminSessionMock).toHaveBeenCalledWith(
+      'session-token',
+      '11111111-1111-4111-8111-111111111111'
+    )
+  })
+
+  it('GET /api/organization-creation-requests/{requestId} returns 404 when missing', async () => {
+    getOrganizationCreationRequestForAdminSessionMock.mockResolvedValue({
+      ok: false,
+      error: {
+        type: 'ORGANIZATION_CREATION_REQUEST_NOT_FOUND',
+      },
+    })
+
+    const app = createRouteTestApp('/organization-creation-requests', (resource) =>
+      resource.route('/', organizationCreationRequestsRoutes)
+    )
+    const response = await app.request(
+      '/api/organization-creation-requests/11111111-1111-4111-8111-111111111111',
+      {
+        headers: {
+          cookie: 'okarin_session=session-token',
+        },
+      }
+    )
+
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toEqual({
+      error_code: 'ORGANIZATION_CREATION_REQUEST_NOT_FOUND',
+      error_message: 'organization creation request not found',
+    })
   })
 })

--- a/apps/kaede/src/routes/organization-creation-requests/index.ts
+++ b/apps/kaede/src/routes/organization-creation-requests/index.ts
@@ -2,11 +2,13 @@ import { OpenAPIHono, createRoute } from '@hono/zod-openapi'
 import { errorResponseSchema } from '../../schemas/common.js'
 import {
   createOrganizationCreationRequestRequestSchema,
+  organizationCreationRequestIdParamsSchema,
   organizationCreationRequestSchema,
   organizationCreationRequestsResponseSchema,
 } from '../../schemas/organizations.js'
 import {
   createOrganizationCreationRequestForSession,
+  getOrganizationCreationRequestForAdminSession,
   listMyOrganizationCreationRequestsForSession,
 } from '../../usecases/organizations/index.js'
 import { getSessionTokenFromCookie } from '../auth/cookie.js'
@@ -97,6 +99,50 @@ const listMyRequestsRoute = createRoute({
   },
 })
 
+const getRequestRoute = createRoute({
+  method: 'get',
+  path: '/{requestId}',
+  tags: ['Organization Creation Requests'],
+  description: 'admin が organization 作成申請詳細を取得する',
+  request: {
+    params: organizationCreationRequestIdParamsSchema,
+  },
+  responses: {
+    200: {
+      description: 'organization creation request',
+      content: {
+        'application/json': {
+          schema: organizationCreationRequestSchema,
+        },
+      },
+    },
+    401: {
+      description: 'login required',
+      content: {
+        'application/json': {
+          schema: errorResponseSchema,
+        },
+      },
+    },
+    403: {
+      description: 'permission denied',
+      content: {
+        'application/json': {
+          schema: errorResponseSchema,
+        },
+      },
+    },
+    404: {
+      description: 'organization creation request not found',
+      content: {
+        'application/json': {
+          schema: errorResponseSchema,
+        },
+      },
+    },
+  },
+})
+
 organizationCreationRequestsRoutes.openapi(createRequestRoute, async (c) => {
   const payload = c.req.valid('json')
   const result = await createOrganizationCreationRequestForSession(
@@ -118,6 +164,21 @@ organizationCreationRequestsRoutes.openapi(listMyRequestsRoute, async (c) => {
   if (!result.ok) {
     const error = toOrganizationErrorResponse(result.error)
     return c.json(error.body, error.status as 401 | 403)
+  }
+
+  return c.json(result.value, 200)
+})
+
+organizationCreationRequestsRoutes.openapi(getRequestRoute, async (c) => {
+  const { requestId } = c.req.valid('param')
+  const result = await getOrganizationCreationRequestForAdminSession(
+    getSessionTokenFromCookie(c),
+    requestId
+  )
+
+  if (!result.ok) {
+    const error = toOrganizationErrorResponse(result.error)
+    return c.json(error.body, error.status as 401 | 403 | 404)
   }
 
   return c.json(result.value, 200)

--- a/apps/kaede/src/routes/organization-creation-requests/index.ts
+++ b/apps/kaede/src/routes/organization-creation-requests/index.ts
@@ -1,15 +1,19 @@
 import { OpenAPIHono, createRoute } from '@hono/zod-openapi'
 import { errorResponseSchema } from '../../schemas/common.js'
 import {
+  approveOrganizationCreationRequestRequestSchema,
   createOrganizationCreationRequestRequestSchema,
   organizationCreationRequestIdParamsSchema,
   organizationCreationRequestSchema,
   organizationCreationRequestsResponseSchema,
+  rejectOrganizationCreationRequestRequestSchema,
 } from '../../schemas/organizations.js'
 import {
+  approveOrganizationCreationRequestForAdminSession,
   createOrganizationCreationRequestForSession,
   getOrganizationCreationRequestForAdminSession,
   listMyOrganizationCreationRequestsForSession,
+  rejectOrganizationCreationRequestForAdminSession,
 } from '../../usecases/organizations/index.js'
 import { getSessionTokenFromCookie } from '../auth/cookie.js'
 import { toOrganizationErrorResponse } from '../organizations/error.js'
@@ -143,6 +147,124 @@ const getRequestRoute = createRoute({
   },
 })
 
+const approveRequestRoute = createRoute({
+  method: 'post',
+  path: '/{requestId}/approve',
+  tags: ['Organization Creation Requests'],
+  description: 'admin が organization 作成申請を承認する',
+  request: {
+    params: organizationCreationRequestIdParamsSchema,
+    body: {
+      content: {
+        'application/json': {
+          schema: approveOrganizationCreationRequestRequestSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: 'organization creation request approved',
+      content: {
+        'application/json': {
+          schema: organizationCreationRequestSchema,
+        },
+      },
+    },
+    401: {
+      description: 'login required',
+      content: {
+        'application/json': {
+          schema: errorResponseSchema,
+        },
+      },
+    },
+    403: {
+      description: 'permission denied',
+      content: {
+        'application/json': {
+          schema: errorResponseSchema,
+        },
+      },
+    },
+    404: {
+      description: 'organization creation request not found',
+      content: {
+        'application/json': {
+          schema: errorResponseSchema,
+        },
+      },
+    },
+    409: {
+      description: 'conflict',
+      content: {
+        'application/json': {
+          schema: errorResponseSchema,
+        },
+      },
+    },
+  },
+})
+
+const rejectRequestRoute = createRoute({
+  method: 'post',
+  path: '/{requestId}/reject',
+  tags: ['Organization Creation Requests'],
+  description: 'admin が organization 作成申請を却下する',
+  request: {
+    params: organizationCreationRequestIdParamsSchema,
+    body: {
+      content: {
+        'application/json': {
+          schema: rejectOrganizationCreationRequestRequestSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: 'organization creation request rejected',
+      content: {
+        'application/json': {
+          schema: organizationCreationRequestSchema,
+        },
+      },
+    },
+    401: {
+      description: 'login required',
+      content: {
+        'application/json': {
+          schema: errorResponseSchema,
+        },
+      },
+    },
+    403: {
+      description: 'permission denied',
+      content: {
+        'application/json': {
+          schema: errorResponseSchema,
+        },
+      },
+    },
+    404: {
+      description: 'organization creation request not found',
+      content: {
+        'application/json': {
+          schema: errorResponseSchema,
+        },
+      },
+    },
+    409: {
+      description: 'conflict',
+      content: {
+        'application/json': {
+          schema: errorResponseSchema,
+        },
+      },
+    },
+  },
+})
+
 organizationCreationRequestsRoutes.openapi(createRequestRoute, async (c) => {
   const payload = c.req.valid('json')
   const result = await createOrganizationCreationRequestForSession(
@@ -179,6 +301,40 @@ organizationCreationRequestsRoutes.openapi(getRequestRoute, async (c) => {
   if (!result.ok) {
     const error = toOrganizationErrorResponse(result.error)
     return c.json(error.body, error.status as 401 | 403 | 404)
+  }
+
+  return c.json(result.value, 200)
+})
+
+organizationCreationRequestsRoutes.openapi(approveRequestRoute, async (c) => {
+  const { requestId } = c.req.valid('param')
+  const payload = c.req.valid('json')
+  const result = await approveOrganizationCreationRequestForAdminSession(
+    getSessionTokenFromCookie(c),
+    requestId,
+    payload
+  )
+
+  if (!result.ok) {
+    const error = toOrganizationErrorResponse(result.error)
+    return c.json(error.body, error.status)
+  }
+
+  return c.json(result.value, 200)
+})
+
+organizationCreationRequestsRoutes.openapi(rejectRequestRoute, async (c) => {
+  const { requestId } = c.req.valid('param')
+  const payload = c.req.valid('json')
+  const result = await rejectOrganizationCreationRequestForAdminSession(
+    getSessionTokenFromCookie(c),
+    requestId,
+    payload
+  )
+
+  if (!result.ok) {
+    const error = toOrganizationErrorResponse(result.error)
+    return c.json(error.body, error.status)
   }
 
   return c.json(result.value, 200)

--- a/apps/kaede/src/routes/organizations/get-organization.test.ts
+++ b/apps/kaede/src/routes/organizations/get-organization.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRouteTestApp } from '../create-route-test-app.js'
+import { registerGetOrganizationRoute } from './get-organization.js'
+
+const { getOrganizationForSessionMock } = vi.hoisted(() => ({
+  getOrganizationForSessionMock: vi.fn(),
+}))
+
+vi.mock('../../usecases/organizations/index.js', () => ({
+  getOrganizationForSession: getOrganizationForSessionMock,
+}))
+
+describe('GET /api/organizations/:organizationId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('organization を返す', async () => {
+    getOrganizationForSessionMock.mockResolvedValue({
+      ok: true,
+      value: {
+        organization_id: '11111111-1111-4111-8111-111111111111',
+        name: 'Group A',
+        created_at: '2026-06-11T00:00:00.000Z',
+        updated_at: '2026-06-11T00:00:00.000Z',
+      },
+    })
+
+    const app = createRouteTestApp('/organizations', registerGetOrganizationRoute)
+    const response = await app.request('/api/organizations/11111111-1111-4111-8111-111111111111', {
+      headers: {
+        cookie: 'okarin_session=session-token',
+      },
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      organization_id: '11111111-1111-4111-8111-111111111111',
+      name: 'Group A',
+      created_at: '2026-06-11T00:00:00.000Z',
+      updated_at: '2026-06-11T00:00:00.000Z',
+    })
+    expect(getOrganizationForSessionMock).toHaveBeenCalledWith(
+      'session-token',
+      '11111111-1111-4111-8111-111111111111'
+    )
+  })
+
+  it('未ログイン時 401 を返す', async () => {
+    getOrganizationForSessionMock.mockResolvedValue({
+      ok: false,
+      error: {
+        type: 'AUTH_UNAUTHENTICATED',
+      },
+    })
+
+    const app = createRouteTestApp('/organizations', registerGetOrganizationRoute)
+    const response = await app.request('/api/organizations/11111111-1111-4111-8111-111111111111')
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({
+      error_code: 'AUTH_UNAUTHENTICATED',
+      error_message: 'login required',
+    })
+  })
+
+  it('organization がない場合は 404 を返す', async () => {
+    getOrganizationForSessionMock.mockResolvedValue({
+      ok: false,
+      error: {
+        type: 'ORGANIZATION_NOT_FOUND',
+      },
+    })
+
+    const app = createRouteTestApp('/organizations', registerGetOrganizationRoute)
+    const response = await app.request('/api/organizations/11111111-1111-4111-8111-111111111111')
+
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toEqual({
+      error_code: 'ORGANIZATION_NOT_FOUND',
+      error_message: 'organization not found',
+    })
+  })
+})

--- a/apps/kaede/src/routes/organizations/get-organization.ts
+++ b/apps/kaede/src/routes/organizations/get-organization.ts
@@ -1,0 +1,65 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { errorResponseSchema } from '../../schemas/common.js'
+import { organizationIdParamsSchema, organizationSchema } from '../../schemas/organizations.js'
+import { getOrganizationForSession } from '../../usecases/organizations/index.js'
+import { getSessionTokenFromCookie } from '../auth/cookie.js'
+import { toOrganizationErrorResponse } from './error.js'
+
+export const registerGetOrganizationRoute = (app: OpenAPIHono) => {
+  const route = createRoute({
+    method: 'get',
+    path: '/{organizationId}',
+    tags: ['Organizations'],
+    description: 'organization を取得する',
+    request: {
+      params: organizationIdParamsSchema,
+    },
+    responses: {
+      200: {
+        description: 'organization',
+        content: {
+          'application/json': {
+            schema: organizationSchema,
+          },
+        },
+      },
+      401: {
+        description: 'login required',
+        content: {
+          'application/json': {
+            schema: errorResponseSchema,
+          },
+        },
+      },
+      403: {
+        description: 'permission denied',
+        content: {
+          'application/json': {
+            schema: errorResponseSchema,
+          },
+        },
+      },
+      404: {
+        description: 'organization not found',
+        content: {
+          'application/json': {
+            schema: errorResponseSchema,
+          },
+        },
+      },
+    },
+  })
+
+  app.openapi(route, async (c) => {
+    const { organizationId } = c.req.valid('param')
+    const result = await getOrganizationForSession(getSessionTokenFromCookie(c), organizationId)
+
+    if (!result.ok) {
+      const error = toOrganizationErrorResponse(result.error)
+      return c.json(error.body, error.status as 401 | 403 | 404)
+    }
+
+    return c.json(result.value, 200)
+  })
+}

--- a/apps/kaede/src/routes/organizations/index.ts
+++ b/apps/kaede/src/routes/organizations/index.ts
@@ -2,6 +2,7 @@ import { OpenAPIHono } from '@hono/zod-openapi'
 import { registerCreateOrganizationMembershipRoute } from './create-organization-membership.js'
 import { registerCreateOrganizationUserRoute } from './create-organization-user.js'
 import { registerCreateOrganizationRoute } from './create-organization.js'
+import { registerGetOrganizationRoute } from './get-organization.js'
 import { registerListOrganizationUsersRoute } from './list-organization-users.js'
 import { registerListOrganizationsRoute } from './list-organizations.js'
 
@@ -9,6 +10,7 @@ export const organizationsRoutes = new OpenAPIHono()
 
 registerListOrganizationsRoute(organizationsRoutes)
 registerCreateOrganizationRoute(organizationsRoutes)
+registerGetOrganizationRoute(organizationsRoutes)
 registerListOrganizationUsersRoute(organizationsRoutes)
 registerCreateOrganizationUserRoute(organizationsRoutes)
 registerCreateOrganizationMembershipRoute(organizationsRoutes)

--- a/apps/kaede/src/usecases/organizations/index.ts
+++ b/apps/kaede/src/usecases/organizations/index.ts
@@ -294,10 +294,13 @@ export const getOrganizationForSession = async (
   organizationId: string,
   executor?: DbExecutor
 ): Promise<OrganizationResult<OrganizationResponse>> => {
-  const admin = await requireAdmin(sessionToken, executor)
+  const actor = await requireActiveSessionUser(sessionToken, executor)
 
-  if (!admin.ok) {
-    return admin
+  if (!actor.ok) {
+    return {
+      ok: false,
+      error: mapAuthError(actor.error),
+    }
   }
 
   const organization = await findOrganizationById(organizationId, executor)
@@ -306,6 +309,17 @@ export const getOrganizationForSession = async (
     return {
       ok: false,
       error: { type: 'ORGANIZATION_NOT_FOUND' },
+    }
+  }
+
+  if (actor.value.global_role !== 'admin') {
+    const membership = await findOrganizationMembership(organizationId, actor.value.id, executor)
+
+    if (membership?.role !== 'manager' && membership?.role !== 'owner') {
+      return {
+        ok: false,
+        error: { type: 'AUTH_FORBIDDEN' },
+      }
     }
   }
 

--- a/apps/kaede/src/usecases/organizations/index.ts
+++ b/apps/kaede/src/usecases/organizations/index.ts
@@ -289,6 +289,32 @@ export const listOrganizationsForSession = async (
   }
 }
 
+export const getOrganizationForSession = async (
+  sessionToken: string | undefined,
+  organizationId: string,
+  executor?: DbExecutor
+): Promise<OrganizationResult<OrganizationResponse>> => {
+  const admin = await requireAdmin(sessionToken, executor)
+
+  if (!admin.ok) {
+    return admin
+  }
+
+  const organization = await findOrganizationById(organizationId, executor)
+
+  if (!organization) {
+    return {
+      ok: false,
+      error: { type: 'ORGANIZATION_NOT_FOUND' },
+    }
+  }
+
+  return {
+    ok: true,
+    value: toOrganizationResponse(organization),
+  }
+}
+
 export const createOrganizationForSession = async (
   sessionToken: string | undefined,
   payload: CreateOrganizationRequest,

--- a/apps/kaede/tests/services/organizations/organizations.test.ts
+++ b/apps/kaede/tests/services/organizations/organizations.test.ts
@@ -5,6 +5,7 @@ import { createDb } from '../../../src/services/db/client.js'
 import {
   createOrUpdateOrganizationMembershipForSession,
   createOrganizationUserForSession,
+  getOrganizationForSession,
   createOrganizationForSession,
   listOrganizationUsersForSession,
   listOrganizationsForSession,
@@ -128,6 +129,44 @@ describe('organizations usecase', () => {
     })
   })
 
+  it('admin can get an organization', async () => {
+    const organization = await createOrganization('Group A')
+    const admin = await createUserWithSession({
+      email: 'admin@example.com',
+      globalRole: 'admin',
+    })
+
+    const result = await getOrganizationForSession(admin.sessionToken, organization.id, db)
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        organization_id: organization.id,
+        name: 'Group A',
+      },
+    })
+  })
+
+  it('get organization returns not found when organization does not exist', async () => {
+    const admin = await createUserWithSession({
+      email: 'admin@example.com',
+      globalRole: 'admin',
+    })
+
+    const result = await getOrganizationForSession(
+      admin.sessionToken,
+      '11111111-1111-4111-8111-111111111111',
+      db
+    )
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        type: 'ORGANIZATION_NOT_FOUND',
+      },
+    })
+  })
+
   it('non-admin cannot create an organization', async () => {
     const member = await createUserWithSession({
       email: 'member@example.com',
@@ -141,6 +180,23 @@ describe('organizations usecase', () => {
       },
       db
     )
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        type: 'AUTH_FORBIDDEN',
+      },
+    })
+  })
+
+  it('non-admin cannot get an organization', async () => {
+    const organization = await createOrganization()
+    const member = await createUserWithSession({
+      email: 'member@example.com',
+      globalRole: 'none',
+    })
+
+    const result = await getOrganizationForSession(member.sessionToken, organization.id, db)
 
     expect(result).toEqual({
       ok: false,

--- a/apps/kaede/tests/services/organizations/organizations.test.ts
+++ b/apps/kaede/tests/services/organizations/organizations.test.ts
@@ -147,6 +147,50 @@ describe('organizations usecase', () => {
     })
   })
 
+  it('manager can get their organization', async () => {
+    const organization = await createOrganization('Group A')
+    const manager = await createUserWithSession({
+      email: 'manager@example.com',
+      globalRole: 'none',
+      membership: {
+        organizationId: organization.id,
+        role: 'manager',
+      },
+    })
+
+    const result = await getOrganizationForSession(manager.sessionToken, organization.id, db)
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        organization_id: organization.id,
+        name: 'Group A',
+      },
+    })
+  })
+
+  it('owner can get their organization', async () => {
+    const organization = await createOrganization('Group A')
+    const owner = await createUserWithSession({
+      email: 'owner@example.com',
+      globalRole: 'none',
+      membership: {
+        organizationId: organization.id,
+        role: 'owner',
+      },
+    })
+
+    const result = await getOrganizationForSession(owner.sessionToken, organization.id, db)
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        organization_id: organization.id,
+        name: 'Group A',
+      },
+    })
+  })
+
   it('get organization returns not found when organization does not exist', async () => {
     const admin = await createUserWithSession({
       email: 'admin@example.com',


### PR DESCRIPTION
# issue番号

- https://github.com/kajiLabTeam/okarin/issues/109

# 変更内容(写真か動画も一緒に)

  - GET /api/organizations/{organizationId} を追加
  - admin セッションのみ許可
  - 存在しない organization は 404 ORGANIZATION_NOT_FOUND
  - 一覧と同じ organizationSchema を返却
  - route test と usecase test を追加

# 影響範囲(あれば)
