### PR TITLE
floor mapの画像サイズを保存

### DIFF
--- a/apps/kaede/src/schemas/floors.ts
+++ b/apps/kaede/src/schemas/floors.ts
@@ -25,6 +25,12 @@ export const floorSchema = z
     scale: z.number().nullable().openapi({
       description: '縮尺。未設定の場合は null',
     }),
+    map_width_px: z.number().int().positive().nullable().optional().openapi({
+      description: 'floor map画像の幅（px）。移行前の画像は null',
+    }),
+    map_height_px: z.number().int().positive().nullable().optional().openapi({
+      description: 'floor map画像の高さ（px）。移行前の画像は null',
+    }),
     map_image: z
       .object({
         download_url: z.string().url().openapi({

--- a/apps/kaede/src/services/db/generated.ts
+++ b/apps/kaede/src/services/db/generated.ts
@@ -52,6 +52,8 @@ export interface Floors {
   id: Generated<string>
   image_object_path: string
   level: number
+  map_height_px: number | null
+  map_width_px: number | null
   name: string
   organization_id: string
   scale: number | null

--- a/apps/kaede/src/services/floors/floor-repository.ts
+++ b/apps/kaede/src/services/floors/floor-repository.ts
@@ -19,6 +19,8 @@ export interface FloorRow {
   level: number
   name: string
   image_object_path: string
+  map_width_px: number | null
+  map_height_px: number | null
   scale: number | null
   created_at: Date
   updated_at: Date
@@ -36,6 +38,8 @@ const floorRowsQuery = () =>
       'floors.level',
       'floors.name',
       'floors.image_object_path',
+      'floors.map_width_px',
+      'floors.map_height_px',
       'floors.scale',
       'floors.created_at',
       'floors.updated_at',

--- a/apps/kaede/src/usecases/floors/create-floor.ts
+++ b/apps/kaede/src/usecases/floors/create-floor.ts
@@ -16,6 +16,8 @@ import type { AuthorizationError } from '../authorization.js'
 import { requireDashboardWriteAccess } from '../authorization.js'
 
 export const floorMapImageMaxBytes = 10 * 1024 * 1024
+export const floorMapMaxSidePx = 20_000
+export const floorMapMaxPixels = 100_000_000
 
 export interface FloorMapImageUpload {
   bytes: Uint8Array
@@ -58,18 +60,48 @@ const hasPngMagicNumber = (bytes: Uint8Array) => {
   return pngMagicNumber.every((value, index) => bytes[index] === value)
 }
 
-const isValidSvg = (bytes: Uint8Array) => {
+interface FloorMapDimensions {
+  width: number
+  height: number
+}
+
+const areValidDimensions = ({ width, height }: FloorMapDimensions) =>
+  Number.isInteger(width) &&
+  Number.isInteger(height) &&
+  width > 0 &&
+  height > 0 &&
+  width <= floorMapMaxSidePx &&
+  height <= floorMapMaxSidePx &&
+  width * height <= floorMapMaxPixels
+
+const extractPngDimensions = (bytes: Uint8Array): FloorMapDimensions | undefined => {
+  if (!hasPngMagicNumber(bytes) || bytes.byteLength < 24) return undefined
+
+  const chunkType = new TextDecoder('ascii').decode(bytes.slice(12, 16))
+  if (chunkType !== 'IHDR') return undefined
+
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  const dimensions = { width: view.getUint32(16), height: view.getUint32(20) }
+  return areValidDimensions(dimensions) ? dimensions : undefined
+}
+
+const extractSvgDimensions = (bytes: Uint8Array): FloorMapDimensions | undefined => {
   const text = new TextDecoder('utf-8', { fatal: false }).decode(bytes)
 
-  if (!/<\s*svg(?:\s|>)/i.test(text)) {
-    return false
-  }
+  const svgTag = /<\s*svg\b[^>]*>/i.exec(text)?.[0]
+  if (!svgTag) return undefined
 
   if (/<\s*script(?:\s|>)/i.test(text) || /<\s*foreignObject(?:\s|>)/i.test(text)) {
-    return false
+    return undefined
   }
 
-  return !/\son[a-z]+\s*=/i.test(text)
+  if (/\son[a-z]+\s*=/i.test(text)) return undefined
+
+  const viewBox = /\bviewBox\s*=\s*["']\s*0\s+0\s+(\d+)\s+(\d+)\s*["']/i.exec(svgTag)
+  if (!viewBox) return undefined
+
+  const dimensions = { width: Number(viewBox[1]), height: Number(viewBox[2]) }
+  return areValidDimensions(dimensions) ? dimensions : undefined
 }
 
 const validateFloorMapImage = (
@@ -78,6 +110,7 @@ const validateFloorMapImage = (
   | {
       ok: true
       extension: FloorMapImageExtension
+      dimensions: FloorMapDimensions
     }
   | {
       ok: false
@@ -97,13 +130,15 @@ const validateFloorMapImage = (
   }
 
   if (upload.contentType === 'image/png') {
-    return hasPngMagicNumber(upload.bytes)
-      ? { ok: true, extension: 'png' }
+    const dimensions = extractPngDimensions(upload.bytes)
+    return dimensions
+      ? { ok: true, extension: 'png', dimensions }
       : { ok: false, error: { type: 'FLOOR_MAP_IMAGE_INVALID' } }
   }
 
-  return isValidSvg(upload.bytes)
-    ? { ok: true, extension: 'svg' }
+  const dimensions = extractSvgDimensions(upload.bytes)
+  return dimensions
+    ? { ok: true, extension: 'svg', dimensions }
     : { ok: false, error: { type: 'FLOOR_MAP_IMAGE_INVALID' } }
 }
 
@@ -168,6 +203,8 @@ export const createFloor = async (
       level: payload.level,
       name: payload.name,
       image_object_path: imageObjectPath,
+      map_width_px: mapValidation.dimensions.width,
+      map_height_px: mapValidation.dimensions.height,
       scale: payload.scale ?? null,
     })
   } catch (error) {
@@ -196,6 +233,8 @@ export const createFloor = async (
       level: floor.level,
       name: floor.name,
       scale: floor.scale,
+      map_width_px: floor.map_width_px,
+      map_height_px: floor.map_height_px,
       map_image: {
         download_url: mapDownload.url,
         download_expires_at: mapDownload.expiresAt,

--- a/apps/kaede/src/usecases/floors/floor-response.ts
+++ b/apps/kaede/src/usecases/floors/floor-response.ts
@@ -13,6 +13,8 @@ interface FloorResponseRow {
   level: number
   name: string
   image_object_path: string
+  map_width_px: number | null
+  map_height_px: number | null
   scale: number | null
   created_at: Date
   updated_at: Date
@@ -43,6 +45,8 @@ export const toFloorResponse = async (floor: FloorResponseRow): Promise<FloorRes
     level: floor.level,
     name: floor.name,
     scale: floor.scale,
+    map_width_px: floor.map_width_px,
+    map_height_px: floor.map_height_px,
     map_image: {
       download_url: downloadUrl.url,
       download_expires_at: downloadUrl.expiresAt,

--- a/apps/kaede/tests/services/floors/create-floor.test.ts
+++ b/apps/kaede/tests/services/floors/create-floor.test.ts
@@ -24,8 +24,13 @@ vi.mock('../../../src/services/storage/index.js', async (importOriginal) => {
 })
 
 const db = createDb()
-const validSvg = new TextEncoder().encode('<svg xmlns="http://www.w3.org/2000/svg"></svg>')
-const validPng = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+const validSvg = new TextEncoder().encode(
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 720"></svg>'
+)
+const validPng = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x02, 0x80, 0x00, 0x00, 0x01, 0xe0,
+])
 
 const serviceClientActor: RequestActor = {
   type: 'service_client',
@@ -125,6 +130,8 @@ describe('createFloor', () => {
       level: 2,
       name: '2F',
       scale: 25,
+      map_width_px: 1280,
+      map_height_px: 720,
     })
     expect(result.value.map_image.download_expires_at).toEqual(expect.any(String))
     const mapDownloadUrl = new URL(result.value.map_image.download_url)
@@ -154,6 +161,8 @@ describe('createFloor', () => {
       name: '2F',
       scale: 25,
       image_object_path: `organizations/${organization.id}/floors/${result.value.floor_id}/map.svg`,
+      map_width_px: 1280,
+      map_height_px: 720,
     })
   })
 
@@ -369,6 +378,33 @@ describe('createFloor', () => {
     })
     expect(putFloorMapObjectMock).not.toHaveBeenCalled()
     await expect(db.selectFrom('floors').select('id').execute()).resolves.toEqual([])
+  })
+
+  it('viewBox がない SVG は floor を作成しない', async () => {
+    const organization = await db
+      .insertInto('organizations')
+      .values({ name: 'Invalid SVG Dimensions Organization' })
+      .returning(['id'])
+      .executeTakeFirstOrThrow()
+    const building = await db
+      .insertInto('buildings')
+      .values({ organization_id: organization.id, name: 'Invalid SVG Dimensions Building' })
+      .returning(['id'])
+      .executeTakeFirstOrThrow()
+
+    const result = await createFloor(
+      adminActor,
+      organization.id,
+      building.id,
+      { level: 1, name: '1F' },
+      {
+        bytes: new TextEncoder().encode('<svg xmlns="http://www.w3.org/2000/svg"></svg>'),
+        contentType: 'image/svg+xml',
+      }
+    )
+
+    expect(result).toEqual({ ok: false, error: { type: 'FLOOR_MAP_IMAGE_INVALID' } })
+    expect(putFloorMapObjectMock).not.toHaveBeenCalled()
   })
 
   it('10MB を超える floor map image は floor を作成しない', async () => {

--- a/db/migrations/20260804010000_add_floor_map_dimensions.sql
+++ b/db/migrations/20260804010000_add_floor_map_dimensions.sql
@@ -1,0 +1,27 @@
+-- migrate:up
+
+ALTER TABLE floors
+  ADD COLUMN map_width_px integer,
+  ADD COLUMN map_height_px integer,
+  ADD CONSTRAINT floors_map_dimensions_presence_chk CHECK (
+    (map_width_px IS NULL AND map_height_px IS NULL)
+    OR (map_width_px IS NOT NULL AND map_height_px IS NOT NULL)
+  ),
+  ADD CONSTRAINT floors_map_dimensions_bounds_chk CHECK (
+    map_width_px IS NULL
+    OR (
+      map_width_px > 0
+      AND map_height_px > 0
+      AND map_width_px <= 20000
+      AND map_height_px <= 20000
+      AND map_width_px::bigint * map_height_px::bigint <= 100000000
+    )
+  );
+
+-- migrate:down
+
+ALTER TABLE floors
+  DROP CONSTRAINT floors_map_dimensions_bounds_chk,
+  DROP CONSTRAINT floors_map_dimensions_presence_chk,
+  DROP COLUMN map_height_px,
+  DROP COLUMN map_width_px;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -80,6 +80,10 @@ CREATE TABLE public.floors (
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
     organization_id uuid NOT NULL,
+    map_width_px integer,
+    map_height_px integer,
+    CONSTRAINT floors_map_dimensions_bounds_chk CHECK (((map_width_px IS NULL) OR ((map_width_px > 0) AND (map_height_px > 0) AND (map_width_px <= 20000) AND (map_height_px <= 20000) AND (((map_width_px)::bigint * (map_height_px)::bigint) <= 100000000)))),
+    CONSTRAINT floors_map_dimensions_presence_chk CHECK ((((map_width_px IS NULL) AND (map_height_px IS NULL)) OR ((map_width_px IS NOT NULL) AND (map_height_px IS NOT NULL)))),
     CONSTRAINT floors_image_object_path_format_chk CHECK (((image_object_path ~ '^maps/[0-9a-fA-F-]+/[0-9a-fA-F-]+\.(svg|png)$'::text) OR (image_object_path ~ '^organizations/[0-9a-fA-F-]+/floors/[0-9a-fA-F-]+/map\.(svg|png)$'::text)))
 );
 


### PR DESCRIPTION
## 関連Issue

- https://github.com/kajiLabTeam/okarin/issues/200

## 作業内容

- `floors`へ`map_width_px`と`map_height_px`を追加
- PNGのIHDRとSVGのviewBoxから画像サイズを取得
- 各辺20,000px・総画素数1億の検証を追加
- floor作成時に画像サイズを保存
- floorのcreate/list/getレスポンスへ画像サイズを追加

## 検証

- `mise exec -- pnpm lint`
- `mise exec -- pnpm typecheck`
- unit test: 71 files / 403 tests passed
- DB test: 22 files / 196 tests passed
- `git diff --check`

## 後続作業

既存floor mapの寸法backfill・verify CLIと、移行確認後のNOT NULL化は別PRで対応します。
