### PR TITLE
滞在ヒートマップ解析エンドポイントを追加

### DIFF
--- a/apps/nozomi/src/analysis/stay_heatmap.py
+++ b/apps/nozomi/src/analysis/stay_heatmap.py
@@ -1,0 +1,213 @@
+import importlib
+import json
+import math
+from io import BytesIO
+from typing import Any, Protocol, cast
+from urllib.request import Request as UrlRequest
+from urllib.request import urlopen
+
+import pandas as pd
+
+from src.schemas.analysis import StayHeatmapAnalyzeRequest, StayHeatmapTrajectory
+
+HTTP_TIMEOUT_SECONDS = 120
+ERROR_MESSAGES = {
+    "TRAJECTORY_DOWNLOAD_FAILED": "trajectory download failed",
+    "INVALID_TRAJECTORY_CSV": "input validation failed",
+    "ANALYSIS_PROCESSING_FAILED": "analysis processing failed",
+    "ARTIFACT_UPLOAD_FAILED": "artifact upload failed",
+}
+
+
+class InvalidTrajectoryCsvError(ValueError):
+    pass
+
+
+class StayHeatmapAnalyzer(Protocol):
+    def enrich_and_aggregate(
+        self,
+        dataframe: pd.DataFrame,
+        request: StayHeatmapAnalyzeRequest,
+        trajectory: StayHeatmapTrajectory,
+    ) -> tuple[pd.DataFrame, list[dict[str, int]]]: ...
+
+
+class RikkaStayHeatmapAnalyzer:
+    """Rikkaの滞在分析公開APIをNozomiから隔離するadapter。"""
+
+    def enrich_and_aggregate(
+        self,
+        dataframe: pd.DataFrame,
+        request: StayHeatmapAnalyzeRequest,
+        trajectory: StayHeatmapTrajectory,
+    ) -> tuple[pd.DataFrame, list[dict[str, int]]]:
+        try:
+            module = importlib.import_module("rikka.stay_analysis")
+        except ImportError as error:
+            raise RuntimeError("rikka stay analysis API is not installed") from error
+
+        enriched = module.enrich_trajectory(
+            dataframe,
+            speed_threshold_mps=request.parameters.speed_threshold_mps,
+        )
+        cells = module.aggregate_trajectory_grid(
+            enriched,
+            map_width_px=request.floor.map_width_px,
+            map_height_px=request.floor.map_height_px,
+            floor_scale=request.floor.scale_m_per_px,
+            grid_size_m=request.parameters.grid_size_m,
+            start_x_px=trajectory.start.x_px,
+            start_y_px=trajectory.start.y_px,
+        )
+        return enriched, cells
+
+
+def get_stay_heatmap_analyzer() -> StayHeatmapAnalyzer:
+    return RikkaStayHeatmapAnalyzer()
+
+
+class StayHeatmapRunner:
+    def __init__(self, analyzer: StayHeatmapAnalyzer) -> None:
+        self.analyzer = analyzer
+
+    def run(self, request: StayHeatmapAnalyzeRequest) -> None:
+        try:
+            trajectories: list[dict[str, Any]] = []
+            for trajectory in request.trajectories:
+                dataframe = self._download_csv(trajectory)
+                enriched, cells = self._analyze(dataframe, request, trajectory)
+                self._upload(
+                    trajectory.output.upload_url,
+                    self._serialize_csv(enriched),
+                    "text/csv; charset=utf-8",
+                )
+                trajectories.append(
+                    {"trajectory_id": str(trajectory.trajectory_id), "cells": cells}
+                )
+
+            self._upload(
+                request.heatmap_output.upload_url,
+                self._serialize_heatmap(request, trajectories),
+                "application/json",
+            )
+            self._callback(request, {"status": "completed"})
+        except Exception as error:
+            code = self._error_code(error)
+            self._callback(
+                request,
+                {
+                    "status": "failed",
+                    "error_code": code,
+                    "error_message": ERROR_MESSAGES[code],
+                },
+            )
+
+    def _download_csv(self, trajectory: StayHeatmapTrajectory) -> pd.DataFrame:
+        try:
+            with urlopen(
+                str(trajectory.source.download_url), timeout=HTTP_TIMEOUT_SECONDS
+            ) as response:
+                if response.status >= 400:
+                    raise RuntimeError(f"download failed with status {response.status}")
+                return pd.read_csv(BytesIO(response.read()))
+        except (ValueError, pd.errors.ParserError) as error:
+            raise InvalidTrajectoryCsvError("input CSV is invalid") from error
+        except Exception as error:
+            raise ConnectionError("trajectory download failed") from error
+
+    def _analyze(
+        self,
+        dataframe: pd.DataFrame,
+        request: StayHeatmapAnalyzeRequest,
+        trajectory: StayHeatmapTrajectory,
+    ) -> tuple[pd.DataFrame, list[dict[str, int]]]:
+        try:
+            return self.analyzer.enrich_and_aggregate(dataframe, request, trajectory)
+        except ValueError as error:
+            raise InvalidTrajectoryCsvError("input CSV validation failed") from error
+
+    def _serialize_csv(self, dataframe: pd.DataFrame) -> bytes:
+        output = dataframe.copy()
+        output["speed_mps"] = output["speed_mps"].map(
+            lambda value: "" if pd.isna(value) else f"{float(value):.6f}"
+        )
+        output["is_stay"] = output["is_stay"].map(
+            lambda value: "true" if bool(value) else "false"
+        )
+        csv_text = cast(str, output.to_csv(index=False, lineterminator="\n"))
+        return csv_text.encode("utf-8")
+
+    def _serialize_heatmap(
+        self,
+        request: StayHeatmapAnalyzeRequest,
+        trajectories: list[dict[str, Any]],
+    ) -> bytes:
+        floor = request.floor
+        grid_size = request.parameters.grid_size_m
+        artifact = {
+            "schema_version": "1.0",
+            "definition_version": request.definition_version,
+            "parameters": request.parameters.model_dump(),
+            "floor_map": {
+                "width_px": floor.map_width_px,
+                "height_px": floor.map_height_px,
+                "scale_m_per_px": floor.scale_m_per_px,
+            },
+            "grid": {
+                "size_m": grid_size,
+                "column_count": math.ceil(
+                    floor.map_width_px * floor.scale_m_per_px / grid_size
+                ),
+                "row_count": math.ceil(
+                    floor.map_height_px * floor.scale_m_per_px / grid_size
+                ),
+            },
+            "input_trajectory_count": len(trajectories),
+            "trajectories": trajectories,
+        }
+        return json.dumps(artifact, ensure_ascii=False, separators=(",", ":")).encode()
+
+    def _upload(self, url: object, body: bytes, content_type: str) -> None:
+        try:
+            upload = UrlRequest(
+                str(url),
+                data=body,
+                headers={"content-type": content_type},
+                method="PUT",
+            )
+            with urlopen(upload, timeout=HTTP_TIMEOUT_SECONDS) as response:
+                if response.status >= 400:
+                    raise RuntimeError(f"upload failed with status {response.status}")
+        except Exception as error:
+            raise OSError("artifact upload failed") from error
+
+    def _callback(
+        self, request: StayHeatmapAnalyzeRequest, result: dict[str, object]
+    ) -> None:
+        payload = {
+            "analysis_run_id": str(request.analysis_run_id),
+            **result,
+            "callback_token": request.callback.token,
+        }
+        callback = UrlRequest(
+            str(request.callback.url),
+            data=json.dumps(payload).encode(),
+            headers={"content-type": "application/json"},
+            method="POST",
+        )
+        with urlopen(callback, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            if response.status >= 400:
+                raise RuntimeError(f"callback failed with status {response.status}")
+
+    def _error_code(self, error: Exception) -> str:
+        if isinstance(error, ConnectionError):
+            return "TRAJECTORY_DOWNLOAD_FAILED"
+        if isinstance(error, InvalidTrajectoryCsvError):
+            return "INVALID_TRAJECTORY_CSV"
+        if isinstance(error, OSError):
+            return "ARTIFACT_UPLOAD_FAILED"
+        return "ANALYSIS_PROCESSING_FAILED"
+
+
+def get_stay_heatmap_runner() -> StayHeatmapRunner:
+    return StayHeatmapRunner(get_stay_heatmap_analyzer())

--- a/apps/nozomi/src/routes/analysis.py
+++ b/apps/nozomi/src/routes/analysis.py
@@ -1,7 +1,13 @@
 from fastapi import APIRouter, BackgroundTasks, status
 
-from src.schemas.analysis import AnalyzeAcceptedResponse, AnalyzeRequest
+from src.schemas.analysis import (
+    AnalyzeAcceptedResponse,
+    AnalyzeRequest,
+    StayHeatmapAcceptedResponse,
+    StayHeatmapAnalyzeRequest,
+)
 from src.usecases.submit_analysis import submit_analysis
+from src.usecases.submit_stay_heatmap import submit_stay_heatmap
 
 analysis_router = APIRouter()
 
@@ -21,3 +27,16 @@ def analyze(
     payload: AnalyzeRequest, background_tasks: BackgroundTasks
 ) -> AnalyzeAcceptedResponse:
     return submit_analysis(payload, background_tasks)
+
+
+@analysis_router.post(
+    "/stay-heatmaps/analyze",
+    response_model=StayHeatmapAcceptedResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="滞在ヒートマップ解析依頼を受け付ける",
+    tags=["analysis"],
+)
+def analyze_stay_heatmap(
+    payload: StayHeatmapAnalyzeRequest, background_tasks: BackgroundTasks
+) -> StayHeatmapAcceptedResponse:
+    return submit_stay_heatmap(payload, background_tasks)

--- a/apps/nozomi/src/schemas/analysis.py
+++ b/apps/nozomi/src/schemas/analysis.py
@@ -166,3 +166,88 @@ class AnalyzeRequest(BaseModel):
 class AnalyzeAcceptedResponse(BaseModel):
     trajectory_id: UUID = Field(description="受理した trajectory の ID")
     status: Literal["accepted"] = Field(description="解析要求を受理した状態")
+
+
+class StayHeatmapParameters(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    speed_threshold_mps: float = Field(ge=0, le=2)
+    grid_size_m: float = Field(ge=0.1, le=10)
+
+
+class StayHeatmapFloor(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    floor_id: UUID
+    map_width_px: int = Field(gt=0)
+    map_height_px: int = Field(gt=0)
+    scale_m_per_px: float = Field(gt=0)
+
+
+class StayHeatmapStart(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    x_px: float
+    y_px: float
+
+
+class StayHeatmapSource(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    download_url: HttpUrl
+
+
+class StayHeatmapOutput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    upload_url: HttpUrl
+
+
+class StayHeatmapTrajectory(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    trajectory_id: UUID
+    seq: int = Field(ge=0)
+    start: StayHeatmapStart
+    source: StayHeatmapSource
+    output: StayHeatmapOutput
+
+
+class StayHeatmapCallback(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    url: HttpUrl
+    token: str = Field(min_length=1)
+
+
+class StayHeatmapAnalyzeRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    analysis_run_id: UUID
+    analysis_type: Literal["stay_heatmap"]
+    definition_version: Literal["original-v1"]
+    parameters: StayHeatmapParameters
+    floor: StayHeatmapFloor
+    trajectories: list[StayHeatmapTrajectory] = Field(min_length=1, max_length=100)
+    heatmap_output: StayHeatmapOutput
+    callback: StayHeatmapCallback
+
+    @model_validator(mode="after")
+    def validate_trajectories(self) -> StayHeatmapAnalyzeRequest:
+        seqs = [trajectory.seq for trajectory in self.trajectories]
+        if seqs != list(range(len(seqs))):
+            raise ValueError("trajectories must be ordered by seq with no gaps")
+        ids = [trajectory.trajectory_id for trajectory in self.trajectories]
+        if len(ids) != len(set(ids)):
+            raise ValueError("trajectory_id must be unique")
+        for trajectory in self.trajectories:
+            if not 0 <= trajectory.start.x_px < self.floor.map_width_px:
+                raise ValueError("start x_px must be inside the floor map")
+            if not 0 <= trajectory.start.y_px < self.floor.map_height_px:
+                raise ValueError("start y_px must be inside the floor map")
+        return self
+
+
+class StayHeatmapAcceptedResponse(BaseModel):
+    analysis_run_id: UUID
+    status: Literal["accepted"]

--- a/apps/nozomi/src/usecases/submit_stay_heatmap.py
+++ b/apps/nozomi/src/usecases/submit_stay_heatmap.py
@@ -1,0 +1,17 @@
+from fastapi import BackgroundTasks
+
+from src.analysis.stay_heatmap import get_stay_heatmap_runner
+from src.schemas.analysis import (
+    StayHeatmapAcceptedResponse,
+    StayHeatmapAnalyzeRequest,
+)
+
+
+def submit_stay_heatmap(
+    payload: StayHeatmapAnalyzeRequest, background_tasks: BackgroundTasks
+) -> StayHeatmapAcceptedResponse:
+    background_tasks.add_task(get_stay_heatmap_runner().run, payload)
+    return StayHeatmapAcceptedResponse(
+        analysis_run_id=payload.analysis_run_id,
+        status="accepted",
+    )

--- a/apps/nozomi/tests/test_stay_heatmap.py
+++ b/apps/nozomi/tests/test_stay_heatmap.py
@@ -1,0 +1,190 @@
+import asyncio
+import json
+from typing import Any
+
+from fastapi import BackgroundTasks
+from fastapi.testclient import TestClient
+
+from src.analysis.stay_heatmap import StayHeatmapRunner
+from src.schemas.analysis import StayHeatmapAnalyzeRequest
+from src.server import app
+from src.usecases.submit_stay_heatmap import submit_stay_heatmap
+
+
+def valid_payload() -> dict[str, object]:
+    return {
+        "analysis_run_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "analysis_type": "stay_heatmap",
+        "definition_version": "original-v1",
+        "parameters": {"speed_threshold_mps": 0.5, "grid_size_m": 1.0},
+        "floor": {
+            "floor_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+            "map_width_px": 101,
+            "map_height_px": 201,
+            "scale_m_per_px": 0.01,
+        },
+        "trajectories": [
+            {
+                "trajectory_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+                "seq": 0,
+                "start": {"x_px": 10.0, "y_px": 20.0},
+                "source": {"download_url": "https://storage.invalid/input.csv"},
+                "output": {"upload_url": "https://storage.invalid/stay.csv"},
+            }
+        ],
+        "heatmap_output": {"upload_url": "https://storage.invalid/stay-heatmap.json"},
+        "callback": {
+            "url": "https://kaede.invalid/api/analysis-runs/callback",
+            "token": "signed-token",
+        },
+    }
+
+
+def test_endpoint_accepts_stay_heatmap_request(monkeypatch: Any) -> None:
+    calls: list[StayHeatmapAnalyzeRequest] = []
+
+    class StubRunner:
+        def run(self, request: StayHeatmapAnalyzeRequest) -> None:
+            calls.append(request)
+
+    monkeypatch.setattr(
+        "src.usecases.submit_stay_heatmap.get_stay_heatmap_runner",
+        lambda: StubRunner(),
+    )
+    response = TestClient(app).post("/stay-heatmaps/analyze", json=valid_payload())
+
+    assert response.status_code == 202
+    assert response.json() == {
+        "analysis_run_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "status": "accepted",
+    }
+    assert len(calls) == 1
+
+
+def test_schema_rejects_unknown_field_and_invalid_sequence() -> None:
+    unknown = valid_payload()
+    unknown["unknown"] = True
+    assert (
+        TestClient(app).post("/stay-heatmaps/analyze", json=unknown).status_code == 422
+    )
+
+    invalid_seq = valid_payload()
+    invalid_seq["trajectories"][0]["seq"] = 1  # type: ignore[index]
+    assert (
+        TestClient(app).post("/stay-heatmaps/analyze", json=invalid_seq).status_code
+        == 422
+    )
+
+
+def test_submit_registers_background_runner(monkeypatch: Any) -> None:
+    request = StayHeatmapAnalyzeRequest.model_validate(valid_payload())
+    background_tasks = BackgroundTasks()
+    calls: list[StayHeatmapAnalyzeRequest] = []
+
+    class StubRunner:
+        def run(self, payload: StayHeatmapAnalyzeRequest) -> None:
+            calls.append(payload)
+
+    monkeypatch.setattr(
+        "src.usecases.submit_stay_heatmap.get_stay_heatmap_runner",
+        lambda: StubRunner(),
+    )
+    response = submit_stay_heatmap(request, background_tasks)
+    for task in background_tasks.tasks:
+        asyncio.run(task())
+
+    assert response.status == "accepted"
+    assert calls == [request]
+
+
+class StubResponse:
+    def __init__(self, body: bytes = b"") -> None:
+        self.body = body
+        self.status = 200
+
+    def __enter__(self) -> StubResponse:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self.body
+
+
+def test_runner_processes_trajectories_and_uploads_artifacts(monkeypatch: Any) -> None:
+    requests: list[tuple[str, str, bytes | None, str | None]] = []
+
+    def fake_urlopen(request: Any, timeout: int) -> StubResponse:
+        assert timeout == 120
+        url = request.full_url if hasattr(request, "full_url") else str(request)
+        method = request.get_method() if hasattr(request, "get_method") else "GET"
+        body = getattr(request, "data", None)
+        content_type = (
+            request.get_header("Content-type")
+            if hasattr(request, "get_header")
+            else None
+        )
+        requests.append((url, method, body, content_type))
+        if url.endswith("input.csv"):
+            return StubResponse(
+                b"step_index,rikka_timestamp_s,rikka_x,rikka_y,x,y\n"
+                b"0,,0,0,10,20\n1,0,0,0,10,20\n2,1,0.1,0,11,20\n"
+            )
+        return StubResponse()
+
+    class StubAnalyzer:
+        def enrich_and_aggregate(self, dataframe, request, trajectory):
+            enriched = dataframe.copy()
+            enriched["speed_mps"] = [float("nan"), float("nan"), 0.1]
+            enriched["is_stay"] = [False, False, True]
+            return enriched, [
+                {"grid_column": 0, "grid_row": 0, "stay_cell_visit_count": 1}
+            ]
+
+    monkeypatch.setattr("src.analysis.stay_heatmap.urlopen", fake_urlopen)
+    StayHeatmapRunner(StubAnalyzer()).run(
+        StayHeatmapAnalyzeRequest.model_validate(valid_payload())
+    )
+
+    assert [request[1] for request in requests] == ["GET", "PUT", "PUT", "POST"]
+    csv_body = requests[1][2]
+    assert csv_body is not None
+    assert csv_body.endswith(b",0.100000,true\n")
+    artifact_body = requests[2][2]
+    assert artifact_body is not None
+    artifact = json.loads(artifact_body)
+    assert artifact["grid"] == {"size_m": 1.0, "column_count": 2, "row_count": 3}
+    assert artifact["trajectories"][0]["cells"][0]["stay_cell_visit_count"] == 1
+    callback = json.loads(requests[3][2])
+    assert callback == {
+        "analysis_run_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "status": "completed",
+        "callback_token": "signed-token",
+    }
+
+
+def test_runner_reports_invalid_csv(monkeypatch: Any) -> None:
+    requests: list[Any] = []
+
+    def fake_urlopen(request: Any, timeout: int) -> StubResponse:
+        requests.append(request)
+        url = request.full_url if hasattr(request, "full_url") else str(request)
+        return (
+            StubResponse(b"not,a,valid,trajectory\n")
+            if url.endswith("input.csv")
+            else StubResponse()
+        )
+
+    class RejectingAnalyzer:
+        def enrich_and_aggregate(self, dataframe, request, trajectory):
+            raise ValueError("missing columns")
+
+    monkeypatch.setattr("src.analysis.stay_heatmap.urlopen", fake_urlopen)
+    StayHeatmapRunner(RejectingAnalyzer()).run(
+        StayHeatmapAnalyzeRequest.model_validate(valid_payload())
+    )
+
+    callback = json.loads(requests[-1].data)
+    assert callback["status"] == "failed"
+    assert callback["error_code"] == "INVALID_TRAJECTORY_CSV"


### PR DESCRIPTION
## 関連Issue

- https://github.com/kajiLabTeam/okarin/issues/200

## 作業内容

- `POST /stay-heatmaps/analyze`を追加
- strictなrequest/accepted response schemaを追加
- BackgroundTasksによる非同期処理を追加
- trajectoryを順番に取得し、Rikka adapterを通して解析
- 派生CSVとsparse heatmap JSONをupload
- 成功・失敗callbackとエラーコード変換を追加

## 検証

- Ruff format/check
- mypy
- pytest: 29 passed
- `git diff --check`

## 注意事項

現行Rikkaには滞在分析APIがないため、adapter境界まで実装しています。Rikka側へ`enrich_trajectory`と`aggregate_trajectory_grid`が追加された後に最終結合が必要です。未導入時は`ANALYSIS_PROCESSING_FAILED`をcallbackします。
