### PR TITLE
分析runのDB基盤を追加

### DIFF
--- a/apps/kaede/src/services/analysis-runs/analysis-run-repository.ts
+++ b/apps/kaede/src/services/analysis-runs/analysis-run-repository.ts
@@ -1,0 +1,107 @@
+import type { Insertable, Selectable } from 'kysely'
+import type { AnalysisRuns, AnalysisRunTrajectories, JsonObject } from '../db/generated.js'
+import { db } from '../db/index.js'
+import type { DbExecutor } from '../executor.js'
+
+export type AnalysisRun = Selectable<AnalysisRuns>
+export type AnalysisRunTrajectory = Selectable<AnalysisRunTrajectories>
+
+type NewAnalysisRun = Omit<Insertable<AnalysisRuns>, 'parameters'> & {
+  parameters: JsonObject
+}
+type NewAnalysisRunTrajectory = Insertable<AnalysisRunTrajectories>
+
+export const insertAnalysisRun = async (
+  run: NewAnalysisRun,
+  executor: DbExecutor = db
+): Promise<AnalysisRun> => {
+  return executor
+    .insertInto('analysis_runs')
+    .values({ ...run, parameters: JSON.stringify(run.parameters) })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+}
+
+export const insertAnalysisRunTrajectories = async (
+  trajectories: NewAnalysisRunTrajectory[],
+  executor: DbExecutor = db
+): Promise<AnalysisRunTrajectory[]> => {
+  if (trajectories.length === 0) return []
+
+  return executor
+    .insertInto('analysis_run_trajectories')
+    .values(trajectories)
+    .returningAll()
+    .execute()
+}
+
+export const findAnalysisRunById = async (
+  analysisRunId: string,
+  executor: DbExecutor = db
+): Promise<AnalysisRun | undefined> => {
+  return executor
+    .selectFrom('analysis_runs')
+    .selectAll()
+    .where('id', '=', analysisRunId)
+    .executeTakeFirst()
+}
+
+export const listAnalysisRunTrajectories = async (
+  analysisRunId: string,
+  executor: DbExecutor = db
+): Promise<AnalysisRunTrajectory[]> => {
+  return executor
+    .selectFrom('analysis_run_trajectories')
+    .selectAll()
+    .where('analysis_run_id', '=', analysisRunId)
+    .orderBy('seq', 'asc')
+    .execute()
+}
+
+export const markAnalysisRunProcessing = async (
+  analysisRunId: string,
+  startedAt: Date = new Date(),
+  executor: DbExecutor = db
+): Promise<AnalysisRun | undefined> => {
+  return executor
+    .updateTable('analysis_runs')
+    .set({ status: 'processing', started_at: startedAt, updated_at: startedAt })
+    .where('id', '=', analysisRunId)
+    .where('status', '=', 'accepted')
+    .returningAll()
+    .executeTakeFirst()
+}
+
+export const markAnalysisRunCompleted = async (
+  analysisRunId: string,
+  finishedAt: Date = new Date(),
+  executor: DbExecutor = db
+): Promise<AnalysisRun | undefined> => {
+  return executor
+    .updateTable('analysis_runs')
+    .set({ status: 'completed', finished_at: finishedAt, updated_at: finishedAt })
+    .where('id', '=', analysisRunId)
+    .where('status', '=', 'processing')
+    .returningAll()
+    .executeTakeFirst()
+}
+
+export const markAnalysisRunFailed = async (
+  analysisRunId: string,
+  errorCode: string,
+  finishedAt: Date = new Date(),
+  executor: DbExecutor = db
+): Promise<AnalysisRun | undefined> => {
+  return executor
+    .updateTable('analysis_runs')
+    .set({
+      status: 'failed',
+      error_code: errorCode,
+      finished_at: finishedAt,
+      updated_at: finishedAt,
+    })
+    .where('id', '=', analysisRunId)
+    .where('status', 'in', ['accepted', 'processing'])
+    .returningAll()
+    .executeTakeFirst()
+}

--- a/apps/kaede/src/services/analysis-runs/index.ts
+++ b/apps/kaede/src/services/analysis-runs/index.ts
@@ -1,0 +1,10 @@
+export {
+  findAnalysisRunById,
+  insertAnalysisRun,
+  insertAnalysisRunTrajectories,
+  listAnalysisRunTrajectories,
+  markAnalysisRunCompleted,
+  markAnalysisRunFailed,
+  markAnalysisRunProcessing,
+} from './analysis-run-repository.js'
+export type { AnalysisRun, AnalysisRunTrajectory } from './analysis-run-repository.js'

--- a/apps/kaede/src/services/db/generated.ts
+++ b/apps/kaede/src/services/db/generated.ts
@@ -36,6 +36,28 @@ export interface AuthIdentities {
   user_id: string
 }
 
+export interface AnalysisRuns {
+  analysis_type: string
+  created_at: Generated<Timestamp>
+  deadline_at: Generated<Timestamp>
+  definition_version: string
+  error_code: string | null
+  finished_at: Timestamp | null
+  floor_id: string
+  id: Generated<string>
+  organization_id: string
+  parameters: Json
+  started_at: Timestamp | null
+  status: Generated<string>
+  updated_at: Generated<Timestamp>
+}
+
+export interface AnalysisRunTrajectories {
+  analysis_run_id: string
+  seq: number
+  trajectory_id: string
+}
+
 export interface Buildings {
   created_at: Generated<Timestamp>
   id: Generated<string>
@@ -192,6 +214,8 @@ export interface Users {
 }
 
 export interface DB {
+  analysis_run_trajectories: AnalysisRunTrajectories
+  analysis_runs: AnalysisRuns
   auth_identities: AuthIdentities
   buildings: Buildings
   floors: Floors

--- a/apps/kaede/tests/services/analysis-runs/analysis-run-repository.test.ts
+++ b/apps/kaede/tests/services/analysis-runs/analysis-run-repository.test.ts
@@ -1,0 +1,176 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import {
+  findAnalysisRunById,
+  insertAnalysisRun,
+  insertAnalysisRunTrajectories,
+  listAnalysisRunTrajectories,
+  markAnalysisRunCompleted,
+  markAnalysisRunFailed,
+  markAnalysisRunProcessing,
+} from '../../../src/services/analysis-runs/index.js'
+import { createDb } from '../../../src/services/db/client.js'
+import { insertTrajectory } from '../../../src/services/trajectories/index.js'
+import { resetDatabase } from '../../db/helpers.js'
+import { createRecordingFixture } from '../../fixtures/recordings.js'
+
+const db = createDb()
+
+describe('analysis run repository', () => {
+  beforeEach(async () => {
+    await resetDatabase(db)
+  })
+
+  afterAll(async () => {
+    await db.destroy()
+  })
+
+  it('runと入力trajectoryを順序付きで保存できる', async () => {
+    const { floor, organization, recording } = await createRecordingFixture(db)
+    const trajectories = await Promise.all(
+      [0, 1].map(() =>
+        insertTrajectory(
+          {
+            recording_id: recording.id,
+            floor_id: floor.id,
+            organization_id: organization.id,
+            status: 'completed',
+          },
+          db
+        )
+      )
+    )
+    const run = await insertAnalysisRun(
+      {
+        organization_id: organization.id,
+        floor_id: floor.id,
+        analysis_type: 'stay_heatmap',
+        parameters: { speed_threshold_mps: 0.5, grid_size_m: 1 },
+        definition_version: 'original-v1',
+      },
+      db
+    )
+
+    await insertAnalysisRunTrajectories(
+      [
+        { analysis_run_id: run.id, trajectory_id: trajectories[1].id, seq: 1 },
+        { analysis_run_id: run.id, trajectory_id: trajectories[0].id, seq: 0 },
+      ],
+      db
+    )
+
+    const storedRun = await findAnalysisRunById(run.id, db)
+    const inputs = await listAnalysisRunTrajectories(run.id, db)
+
+    expect(storedRun).toMatchObject({
+      status: 'accepted',
+      parameters: { speed_threshold_mps: 0.5, grid_size_m: 1 },
+      error_code: null,
+      started_at: null,
+      finished_at: null,
+    })
+    expect(inputs.map(({ trajectory_id, seq }) => ({ trajectory_id, seq }))).toEqual([
+      { trajectory_id: trajectories[0].id, seq: 0 },
+      { trajectory_id: trajectories[1].id, seq: 1 },
+    ])
+  })
+
+  it('acceptedからprocessingを経てcompletedへ更新できる', async () => {
+    const { floor, organization } = await createRecordingFixture(db)
+    const run = await insertAnalysisRun(
+      {
+        organization_id: organization.id,
+        floor_id: floor.id,
+        analysis_type: 'stay_heatmap',
+        parameters: {},
+        definition_version: 'original-v1',
+      },
+      db
+    )
+    const startedAt = new Date('2026-08-04T01:00:00.000Z')
+    const finishedAt = new Date('2026-08-04T01:01:00.000Z')
+
+    const processing = await markAnalysisRunProcessing(run.id, startedAt, db)
+    const completed = await markAnalysisRunCompleted(run.id, finishedAt, db)
+    const failed = await markAnalysisRunFailed(run.id, 'ANALYSIS_PROCESSING_FAILED', finishedAt, db)
+
+    expect(processing).toMatchObject({ status: 'processing', started_at: startedAt })
+    expect(completed).toMatchObject({ status: 'completed', finished_at: finishedAt })
+    expect(failed).toBeUndefined()
+  })
+
+  it('acceptedからfailedへ更新し終端状態から遷移しない', async () => {
+    const { floor, organization } = await createRecordingFixture(db)
+    const run = await insertAnalysisRun(
+      {
+        organization_id: organization.id,
+        floor_id: floor.id,
+        analysis_type: 'stay_heatmap',
+        parameters: {},
+        definition_version: 'original-v1',
+      },
+      db
+    )
+    const finishedAt = new Date('2026-08-04T01:01:00.000Z')
+
+    const failed = await markAnalysisRunFailed(
+      run.id,
+      'ANALYSIS_PREPARATION_FAILED',
+      finishedAt,
+      db
+    )
+    const processing = await markAnalysisRunProcessing(run.id, finishedAt, db)
+
+    expect(failed).toMatchObject({
+      status: 'failed',
+      error_code: 'ANALYSIS_PREPARATION_FAILED',
+      started_at: null,
+      finished_at: finishedAt,
+    })
+    expect(processing).toBeUndefined()
+  })
+
+  it('同じrun内でtrajectoryとseqを重複できない', async () => {
+    const { floor, organization, recording } = await createRecordingFixture(db)
+    const [trajectory, anotherTrajectory] = await Promise.all(
+      [0, 1].map(() =>
+        insertTrajectory(
+          {
+            recording_id: recording.id,
+            floor_id: floor.id,
+            organization_id: organization.id,
+            status: 'completed',
+          },
+          db
+        )
+      )
+    )
+    const run = await insertAnalysisRun(
+      {
+        organization_id: organization.id,
+        floor_id: floor.id,
+        analysis_type: 'stay_heatmap',
+        parameters: {},
+        definition_version: 'original-v1',
+      },
+      db
+    )
+
+    await insertAnalysisRunTrajectories(
+      [{ analysis_run_id: run.id, trajectory_id: trajectory.id, seq: 0 }],
+      db
+    )
+
+    await expect(
+      insertAnalysisRunTrajectories(
+        [{ analysis_run_id: run.id, trajectory_id: trajectory.id, seq: 1 }],
+        db
+      )
+    ).rejects.toMatchObject({ code: '23505' })
+    await expect(
+      insertAnalysisRunTrajectories(
+        [{ analysis_run_id: run.id, trajectory_id: anotherTrajectory.id, seq: 0 }],
+        db
+      )
+    ).rejects.toMatchObject({ code: '23505' })
+  })
+})

--- a/db/migrations/20260804020000_add_analysis_runs.sql
+++ b/db/migrations/20260804020000_add_analysis_runs.sql
@@ -1,0 +1,62 @@
+-- migrate:up
+
+CREATE TABLE analysis_runs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid NOT NULL REFERENCES organizations(id),
+  floor_id uuid NOT NULL REFERENCES floors(id),
+  analysis_type text NOT NULL,
+  status text NOT NULL DEFAULT 'accepted',
+  parameters jsonb NOT NULL,
+  definition_version text NOT NULL,
+  error_code text,
+  started_at timestamptz,
+  deadline_at timestamptz NOT NULL DEFAULT (now() + interval '60 minutes'),
+  finished_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT analysis_runs_analysis_type_nonempty_chk CHECK (length(btrim(analysis_type)) > 0),
+  CONSTRAINT analysis_runs_definition_version_nonempty_chk
+    CHECK (length(btrim(definition_version)) > 0),
+  CONSTRAINT analysis_runs_parameters_object_chk CHECK (jsonb_typeof(parameters) = 'object'),
+  CONSTRAINT analysis_runs_status_chk
+    CHECK (status IN ('accepted', 'processing', 'completed', 'failed')),
+  CONSTRAINT analysis_runs_state_chk CHECK (
+    (status = 'accepted' AND started_at IS NULL AND finished_at IS NULL AND error_code IS NULL)
+    OR (
+      status = 'processing'
+      AND started_at IS NOT NULL
+      AND finished_at IS NULL
+      AND error_code IS NULL
+    )
+    OR (
+      status = 'completed'
+      AND started_at IS NOT NULL
+      AND finished_at IS NOT NULL
+      AND error_code IS NULL
+    )
+    OR (
+      status = 'failed'
+      AND finished_at IS NOT NULL
+      AND length(btrim(error_code)) > 0
+    )
+  )
+);
+
+CREATE INDEX analysis_runs_organization_created_at_id_idx
+  ON analysis_runs (organization_id, created_at DESC, id DESC);
+
+CREATE TABLE analysis_run_trajectories (
+  analysis_run_id uuid NOT NULL REFERENCES analysis_runs(id) ON DELETE CASCADE,
+  trajectory_id uuid NOT NULL REFERENCES trajectories(id),
+  seq integer NOT NULL CHECK (seq >= 0),
+  PRIMARY KEY (analysis_run_id, trajectory_id),
+  UNIQUE (analysis_run_id, seq)
+);
+
+CREATE INDEX analysis_run_trajectories_trajectory_id_idx
+  ON analysis_run_trajectories (trajectory_id);
+
+-- migrate:down
+
+DROP TABLE analysis_run_trajectories;
+DROP TABLE analysis_runs;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -34,6 +34,44 @@ SET default_tablespace = '';
 SET default_table_access_method = heap;
 
 --
+-- Name: analysis_runs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.analysis_runs (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    floor_id uuid NOT NULL,
+    analysis_type text NOT NULL,
+    status text DEFAULT 'accepted'::text NOT NULL,
+    parameters jsonb NOT NULL,
+    definition_version text NOT NULL,
+    error_code text,
+    started_at timestamp with time zone,
+    deadline_at timestamp with time zone DEFAULT (now() + '01:00:00'::interval) NOT NULL,
+    finished_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT analysis_runs_analysis_type_nonempty_chk CHECK ((length(btrim(analysis_type)) > 0)),
+    CONSTRAINT analysis_runs_definition_version_nonempty_chk CHECK ((length(btrim(definition_version)) > 0)),
+    CONSTRAINT analysis_runs_parameters_object_chk CHECK ((jsonb_typeof(parameters) = 'object'::text)),
+    CONSTRAINT analysis_runs_state_chk CHECK ((((status = 'accepted'::text) AND (started_at IS NULL) AND (finished_at IS NULL) AND (error_code IS NULL)) OR ((status = 'processing'::text) AND (started_at IS NOT NULL) AND (finished_at IS NULL) AND (error_code IS NULL)) OR ((status = 'completed'::text) AND (started_at IS NOT NULL) AND (finished_at IS NOT NULL) AND (error_code IS NULL)) OR ((status = 'failed'::text) AND (finished_at IS NOT NULL) AND (length(btrim(error_code)) > 0)))),
+    CONSTRAINT analysis_runs_status_chk CHECK ((status = ANY (ARRAY['accepted'::text, 'processing'::text, 'completed'::text, 'failed'::text])))
+);
+
+
+--
+-- Name: analysis_run_trajectories; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.analysis_run_trajectories (
+    analysis_run_id uuid NOT NULL,
+    trajectory_id uuid NOT NULL,
+    seq integer NOT NULL,
+    CONSTRAINT analysis_run_trajectories_seq_check CHECK ((seq >= 0))
+);
+
+
+--
 -- Name: auth_identities; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -319,6 +357,22 @@ CREATE TABLE public.users (
 -- Name: auth_identities auth_identities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY public.analysis_runs
+    ADD CONSTRAINT analysis_runs_pkey PRIMARY KEY (id);
+
+
+ALTER TABLE ONLY public.analysis_run_trajectories
+    ADD CONSTRAINT analysis_run_trajectories_pkey PRIMARY KEY (analysis_run_id, trajectory_id);
+
+
+ALTER TABLE ONLY public.analysis_run_trajectories
+    ADD CONSTRAINT analysis_run_trajectories_analysis_run_id_seq_key UNIQUE (analysis_run_id, seq);
+
+
+--
+-- Name: auth_identities auth_identities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.auth_identities
     ADD CONSTRAINT auth_identities_pkey PRIMARY KEY (id);
 
@@ -497,6 +551,16 @@ ALTER TABLE ONLY public.users
 
 ALTER TABLE ONLY public.users
     ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: auth_identities_one_google_identity_per_user; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX analysis_runs_organization_created_at_id_idx ON public.analysis_runs USING btree (organization_id, created_at DESC, id DESC);
+
+
+CREATE INDEX analysis_run_trajectories_trajectory_id_idx ON public.analysis_run_trajectories USING btree (trajectory_id);
 
 
 --
@@ -805,6 +869,26 @@ CREATE TRIGGER set_updated_at_trajectories BEFORE UPDATE ON public.trajectories 
 --
 
 CREATE TRIGGER set_updated_at_users BEFORE UPDATE ON public.users FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+
+--
+-- Name: auth_identities auth_identities_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.analysis_runs
+    ADD CONSTRAINT analysis_runs_floor_id_fkey FOREIGN KEY (floor_id) REFERENCES public.floors(id);
+
+
+ALTER TABLE ONLY public.analysis_runs
+    ADD CONSTRAINT analysis_runs_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+ALTER TABLE ONLY public.analysis_run_trajectories
+    ADD CONSTRAINT analysis_run_trajectories_analysis_run_id_fkey FOREIGN KEY (analysis_run_id) REFERENCES public.analysis_runs(id) ON DELETE CASCADE;
+
+
+ALTER TABLE ONLY public.analysis_run_trajectories
+    ADD CONSTRAINT analysis_run_trajectories_trajectory_id_fkey FOREIGN KEY (trajectory_id) REFERENCES public.trajectories(id);
 
 
 --


### PR DESCRIPTION
## 関連Issue

- https://github.com/kajiLabTeam/okarin/issues/200

## 作業内容

- `analysis_runs`と`analysis_run_trajectories`を追加
- analysis run repositoryを追加
- `accepted`から`processing`、`completed`または`failed`への状態遷移を実装
- 終端状態からの更新を防止
- trajectory外部キー、複合主キー、run内`seq`の非負・一意制約を追加
- PoC方針に従い`analysis_artifacts`は追加しない
- 失敗情報は`error_code`、終了日時は`finished_at`へ集約

## 検証

- `mise exec -- pnpm lint`
- `mise exec -- pnpm typecheck`
- unit test: 71 files / 403 tests passed
- DB test: 23 files / 200 tests passed
- `git diff --check`
