### PR TITLE
分析成果物の署名URLを追加

### DIFF
--- a/apps/kaede/src/services/storage/index.ts
+++ b/apps/kaede/src/services/storage/index.ts
@@ -7,6 +7,8 @@ export {
 } from './object-store.js'
 export {
   buildFloorMapObjectKey,
+  buildAnalysisHeatmapObjectKey,
+  buildAnalysisTrajectoryCsvObjectKey,
   buildTrajectoryAnalyzedResultObjectKey,
   buildRecordingRawObjectPrefix,
   buildRecordingRawObjectKey,
@@ -14,10 +16,14 @@ export {
   getFloorMapContentType,
   getFloorMapExtensionFromObjectKey,
   issueInternalRecordingRawDownloadUrls,
+  issueInternalAnalysisHeatmapUploadUrl,
+  issueInternalAnalysisTrajectoryDownloadUrl,
+  issueInternalAnalysisTrajectoryUploadUrl,
   issueInternalTrajectoryResultUploadUrl,
   issueRecordingRawDownloadUrls,
   issueRecordingUploadUrls,
   issueTrajectoryResultDownloadUrl,
+  issueAnalysisTrajectoryCsvDownloadUrl,
 } from './presigned-url.js'
 export { resetS3ClientForTests } from './s3-client.js'
 export type {

--- a/apps/kaede/src/services/storage/presigned-url.test.ts
+++ b/apps/kaede/src/services/storage/presigned-url.test.ts
@@ -1,12 +1,18 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { StorageRuntimeConfig } from '../../config/runtime.js'
 import {
+  buildAnalysisHeatmapObjectKey,
+  buildAnalysisTrajectoryCsvObjectKey,
   buildFloorMapObjectKey,
   buildRecordingRawObjectKey,
   buildTrajectoryAnalyzedResultObjectKey,
   getFloorMapContentType,
   getFloorMapExtensionFromObjectKey,
   issueFloorMapDownloadUrl,
+  issueAnalysisTrajectoryCsvDownloadUrl,
+  issueInternalAnalysisHeatmapUploadUrl,
+  issueInternalAnalysisTrajectoryDownloadUrl,
+  issueInternalAnalysisTrajectoryUploadUrl,
   issueRecordingRawDownloadUrls,
   issueRecordingUploadUrls,
   issueTrajectoryResultDownloadUrl,
@@ -28,6 +34,87 @@ afterEach(() => {
 })
 
 describe('storage presigned url service', () => {
+  const analysisOrganizationId = '22222222-2222-4222-8222-222222222222'
+  const analysisRunId = '33333333-3333-4333-8333-333333333333'
+  const analysisTrajectoryId = '44444444-4444-4444-8444-444444444444'
+
+  const mockStorageConfig = () => {
+    getStorageRuntimeConfigMock.mockReturnValue({
+      accessKeyId: 'kaede-test',
+      secretAccessKey: 'kaede-secret',
+      internalEndpoint: 'http://seaweedfs:8333',
+      publicEndpoint: 'http://127.0.0.1:8333',
+      region: 'us-east-1',
+      bucket: 'okarin-local',
+      floorMapDownloadUrlTtlSeconds: 3600,
+      recordingRawDownloadUrlTtlSeconds: 900,
+      recordingUploadUrlTtlSeconds: 900,
+      trajectoryRawDownloadUrlTtlSeconds: 86400,
+      trajectoryResultDownloadUrlTtlSeconds: 900,
+      trajectoryResultUploadUrlTtlSeconds: 86400,
+    })
+  }
+
+  it('analysis artifact key をrun単位の保存規約どおりに組み立てる', () => {
+    expect(
+      buildAnalysisTrajectoryCsvObjectKey(
+        analysisOrganizationId,
+        analysisRunId,
+        analysisTrajectoryId
+      )
+    ).toBe(
+      `organizations/${analysisOrganizationId}/analysis-runs/${analysisRunId}/artifacts/trajectories/${analysisTrajectoryId}/stay.csv`
+    )
+    expect(buildAnalysisHeatmapObjectKey(analysisOrganizationId, analysisRunId)).toBe(
+      `organizations/${analysisOrganizationId}/analysis-runs/${analysisRunId}/artifacts/stay-heatmap.json`
+    )
+  })
+
+  it('Nozomi用analysis URLを既存の24時間設定で生成できる', async () => {
+    mockStorageConfig()
+    const now = new Date('2026-08-04T00:00:00.000Z')
+
+    const [source, trajectoryOutput, heatmapOutput] = await Promise.all([
+      issueInternalAnalysisTrajectoryDownloadUrl(analysisOrganizationId, analysisTrajectoryId, now),
+      issueInternalAnalysisTrajectoryUploadUrl(
+        analysisOrganizationId,
+        analysisRunId,
+        analysisTrajectoryId,
+        now
+      ),
+      issueInternalAnalysisHeatmapUploadUrl(analysisOrganizationId, analysisRunId, now),
+    ])
+
+    expect(source.expiresAt).toBe('2026-08-05T00:00:00.000Z')
+    expect(trajectoryOutput.expiresAt).toBe('2026-08-05T00:00:00.000Z')
+    expect(heatmapOutput.expiresAt).toBe('2026-08-05T00:00:00.000Z')
+    expect(new URL(source.downloadUrl).origin).toBe('http://seaweedfs:8333')
+    expect(new URL(source.downloadUrl).searchParams.get('X-Amz-Expires')).toBe('86400')
+    expect(new URL(trajectoryOutput.uploadUrl).pathname).toBe(
+      `/okarin-local/${trajectoryOutput.objectKey}`
+    )
+    expect(new URL(heatmapOutput.uploadUrl).pathname).toBe(
+      `/okarin-local/${heatmapOutput.objectKey}`
+    )
+  })
+
+  it('公開用analysis CSV URLを15分設定で生成できる', async () => {
+    mockStorageConfig()
+    const now = new Date('2026-08-04T00:00:00.000Z')
+
+    const result = await issueAnalysisTrajectoryCsvDownloadUrl(
+      analysisOrganizationId,
+      analysisRunId,
+      analysisTrajectoryId,
+      now
+    )
+
+    expect(result.expiresAt).toBe('2026-08-04T00:15:00.000Z')
+    expect(new URL(result.downloadUrl).origin).toBe('http://127.0.0.1:8333')
+    expect(new URL(result.downloadUrl).searchParams.get('X-Amz-Expires')).toBe('900')
+    expect(new URL(result.downloadUrl).pathname).toBe(`/okarin-local/${result.objectKey}`)
+  })
+
   it('recording raw object key を保存規約どおりに組み立てる', () => {
     expect(
       buildRecordingRawObjectKey(

--- a/apps/kaede/src/services/storage/presigned-url.ts
+++ b/apps/kaede/src/services/storage/presigned-url.ts
@@ -91,6 +91,18 @@ export const buildTrajectoryAnalyzedResultObjectKey = (
   return `organizations/${validateObjectKeyUuid(organizationId, 'organizationId')}/trajectories/${validateObjectKeyUuid(trajectoryId, 'trajectoryId')}/analyzed/result.csv`
 }
 
+export const buildAnalysisTrajectoryCsvObjectKey = (
+  organizationId: string,
+  analysisRunId: string,
+  trajectoryId: string
+) => {
+  return `organizations/${validateObjectKeyUuid(organizationId, 'organizationId')}/analysis-runs/${validateObjectKeyUuid(analysisRunId, 'analysisRunId')}/artifacts/trajectories/${validateObjectKeyUuid(trajectoryId, 'trajectoryId')}/stay.csv`
+}
+
+export const buildAnalysisHeatmapObjectKey = (organizationId: string, analysisRunId: string) => {
+  return `organizations/${validateObjectKeyUuid(organizationId, 'organizationId')}/analysis-runs/${validateObjectKeyUuid(analysisRunId, 'analysisRunId')}/artifacts/stay-heatmap.json`
+}
+
 export const issueRecordingUploadUrls = async (
   organizationId: string,
   recordingId: string,
@@ -272,6 +284,96 @@ export const issueTrajectoryResultDownloadUrl = async (
       Bucket: config.bucket,
       Key: objectKey,
     }),
+    { expiresIn: config.trajectoryResultDownloadUrlTtlSeconds }
+  )
+
+  return {
+    downloadUrl,
+    expiresAt: new Date(
+      now.getTime() + config.trajectoryResultDownloadUrlTtlSeconds * 1000
+    ).toISOString(),
+    objectKey,
+  }
+}
+
+export const issueInternalAnalysisTrajectoryDownloadUrl = async (
+  organizationId: string,
+  trajectoryId: string,
+  now: Date = new Date()
+) => {
+  const { config, internalClient } = getS3Context()
+  const objectKey = buildTrajectoryAnalyzedResultObjectKey(organizationId, trajectoryId)
+  const downloadUrl = await getSignedUrl(
+    internalClient,
+    new GetObjectCommand({ Bucket: config.bucket, Key: objectKey }),
+    { expiresIn: config.trajectoryRawDownloadUrlTtlSeconds }
+  )
+
+  return {
+    downloadUrl,
+    expiresAt: new Date(
+      now.getTime() + config.trajectoryRawDownloadUrlTtlSeconds * 1000
+    ).toISOString(),
+    objectKey,
+  }
+}
+
+export const issueInternalAnalysisTrajectoryUploadUrl = async (
+  organizationId: string,
+  analysisRunId: string,
+  trajectoryId: string,
+  now: Date = new Date()
+) => {
+  const { config, internalClient } = getS3Context()
+  const objectKey = buildAnalysisTrajectoryCsvObjectKey(organizationId, analysisRunId, trajectoryId)
+  const uploadUrl = await getSignedUrl(
+    internalClient,
+    new PutObjectCommand({ Bucket: config.bucket, Key: objectKey }),
+    { expiresIn: config.trajectoryResultUploadUrlTtlSeconds }
+  )
+
+  return {
+    expiresAt: new Date(
+      now.getTime() + config.trajectoryResultUploadUrlTtlSeconds * 1000
+    ).toISOString(),
+    objectKey,
+    uploadUrl,
+  }
+}
+
+export const issueInternalAnalysisHeatmapUploadUrl = async (
+  organizationId: string,
+  analysisRunId: string,
+  now: Date = new Date()
+) => {
+  const { config, internalClient } = getS3Context()
+  const objectKey = buildAnalysisHeatmapObjectKey(organizationId, analysisRunId)
+  const uploadUrl = await getSignedUrl(
+    internalClient,
+    new PutObjectCommand({ Bucket: config.bucket, Key: objectKey }),
+    { expiresIn: config.trajectoryResultUploadUrlTtlSeconds }
+  )
+
+  return {
+    expiresAt: new Date(
+      now.getTime() + config.trajectoryResultUploadUrlTtlSeconds * 1000
+    ).toISOString(),
+    objectKey,
+    uploadUrl,
+  }
+}
+
+export const issueAnalysisTrajectoryCsvDownloadUrl = async (
+  organizationId: string,
+  analysisRunId: string,
+  trajectoryId: string,
+  now: Date = new Date()
+) => {
+  const { config, presignClient } = getS3Context()
+  const objectKey = buildAnalysisTrajectoryCsvObjectKey(organizationId, analysisRunId, trajectoryId)
+  const downloadUrl = await getSignedUrl(
+    presignClient,
+    new GetObjectCommand({ Bucket: config.bucket, Key: objectKey }),
     { expiresIn: config.trajectoryResultDownloadUrlTtlSeconds }
   )
 

--- a/apps/kaede/tests/storage/presigned-upload.test.ts
+++ b/apps/kaede/tests/storage/presigned-upload.test.ts
@@ -1,5 +1,8 @@
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 import {
+  issueAnalysisTrajectoryCsvDownloadUrl,
+  issueInternalAnalysisHeatmapUploadUrl,
+  issueInternalAnalysisTrajectoryUploadUrl,
   putFloorMapObject,
   issueRecordingUploadUrls,
   resetS3ClientForTests,
@@ -80,5 +83,36 @@ describe('presigned upload integration', () => {
     await putFloorMapObject(objectKey, 'svg', new TextEncoder().encode(svg))
 
     await expect(readObjectText(s3, objectKey)).resolves.toBe(svg)
+  }, 30000)
+
+  it('analysis artifact を署名URLで保存してCSVを公開取得できる', async () => {
+    const organizationId = '77777777-7777-4777-8777-777777777777'
+    const analysisRunId = '66666666-6666-4666-8666-666666666666'
+    const trajectoryId = '55555555-5555-4555-8555-555555555555'
+    const csv = 'timestamp,x,y,speed_mps,is_stay\n0,1,2,,false\n'
+    const heatmap = '{"schema_version":"1","trajectories":[]}\n'
+
+    const [csvOutput, heatmapOutput] = await Promise.all([
+      issueInternalAnalysisTrajectoryUploadUrl(organizationId, analysisRunId, trajectoryId),
+      issueInternalAnalysisHeatmapUploadUrl(organizationId, analysisRunId),
+    ])
+
+    const [csvUploadResponse, heatmapUploadResponse] = await Promise.all([
+      fetch(csvOutput.uploadUrl, { method: 'PUT', body: csv }),
+      fetch(heatmapOutput.uploadUrl, { method: 'PUT', body: heatmap }),
+    ])
+    expect(csvUploadResponse.ok).toBe(true)
+    expect(heatmapUploadResponse.ok).toBe(true)
+
+    const csvDownload = await issueAnalysisTrajectoryCsvDownloadUrl(
+      organizationId,
+      analysisRunId,
+      trajectoryId
+    )
+    const csvDownloadResponse = await fetch(csvDownload.downloadUrl)
+
+    expect(csvDownloadResponse.ok).toBe(true)
+    await expect(csvDownloadResponse.text()).resolves.toBe(csv)
+    await expect(readObjectText(s3, heatmapOutput.objectKey)).resolves.toBe(heatmap)
   }, 30000)
 })


### PR DESCRIPTION
## 関連Issue

- https://github.com/kajiLabTeam/okarin/issues/200

## 作業内容

- run IDとtrajectory IDから派生CSV・heatmap JSONのobject keyを生成
- Nozomi向け入力CSV download URLを追加
- 派生CSVとheatmap JSONのupload URLを追加
- Mio向け派生CSV download URLを追加
- 既存TTL設定を再利用し、内部URLを24時間、公開URLを15分に設定
- PoC方針に従いETag、条件付きPUT、versioningは追加しない

## 検証

- `mise exec -- pnpm typecheck`
- `mise exec -- pnpm lint`
- unit test: 71 files / 406 tests passed
- S3 integration test: 2 files / 7 tests passed
