### PR TITLE
期限超過した分析処理を失敗に更新

### DIFF
--- a/apps/kaede/src/index.ts
+++ b/apps/kaede/src/index.ts
@@ -2,8 +2,10 @@ import '../instrument.mjs'
 import { serve } from '@hono/node-server'
 import { validateRuntimeConfig } from './config/runtime.js'
 import { createApp } from './server.js'
+import { expireTimedOutAnalysisRuns } from './services/analysis-runs/index.js'
 
 const runtimeConfig = validateRuntimeConfig()
+await expireTimedOutAnalysisRuns()
 const app = createApp()
 const port = runtimeConfig.app.port
 const host = runtimeConfig.app.host

--- a/apps/kaede/src/services/analysis-runs/analysis-run-repository.ts
+++ b/apps/kaede/src/services/analysis-runs/analysis-run-repository.ts
@@ -105,3 +105,23 @@ export const markAnalysisRunFailed = async (
     .returningAll()
     .executeTakeFirst()
 }
+
+export const markTimedOutAnalysisRunsFailed = async (
+  now: Date = new Date(),
+  executor: DbExecutor = db
+): Promise<number> => {
+  const runs = await executor
+    .updateTable('analysis_runs')
+    .set({
+      status: 'failed',
+      error_code: 'ANALYSIS_TIMEOUT',
+      finished_at: now,
+      updated_at: now,
+    })
+    .where('status', 'in', ['accepted', 'processing'])
+    .where('deadline_at', '<=', now)
+    .returning('id')
+    .execute()
+
+  return runs.length
+}

--- a/apps/kaede/src/services/analysis-runs/index.ts
+++ b/apps/kaede/src/services/analysis-runs/index.ts
@@ -6,5 +6,7 @@ export {
   markAnalysisRunCompleted,
   markAnalysisRunFailed,
   markAnalysisRunProcessing,
+  markTimedOutAnalysisRunsFailed,
 } from './analysis-run-repository.js'
+export { expireTimedOutAnalysisRuns } from './timeout-service.js'
 export type { AnalysisRun, AnalysisRunTrajectory } from './analysis-run-repository.js'

--- a/apps/kaede/src/services/analysis-runs/timeout-service.ts
+++ b/apps/kaede/src/services/analysis-runs/timeout-service.ts
@@ -1,0 +1,11 @@
+import { markTimedOutAnalysisRunsFailed } from './analysis-run-repository.js'
+
+export const expireTimedOutAnalysisRuns = async (now: Date = new Date()): Promise<number> => {
+  const expiredCount = await markTimedOutAnalysisRunsFailed(now)
+
+  if (expiredCount > 0) {
+    console.info(`Marked ${expiredCount} analysis run(s) as timed out`)
+  }
+
+  return expiredCount
+}

--- a/apps/kaede/tests/services/analysis-runs/analysis-run-repository.test.ts
+++ b/apps/kaede/tests/services/analysis-runs/analysis-run-repository.test.ts
@@ -7,6 +7,7 @@ import {
   markAnalysisRunCompleted,
   markAnalysisRunFailed,
   markAnalysisRunProcessing,
+  markTimedOutAnalysisRunsFailed,
 } from '../../../src/services/analysis-runs/index.js'
 import { createDb } from '../../../src/services/db/client.js'
 import { insertTrajectory } from '../../../src/services/trajectories/index.js'
@@ -172,5 +173,57 @@ describe('analysis run repository', () => {
         db
       )
     ).rejects.toMatchObject({ code: '23505' })
+  })
+
+  it('期限超過したacceptedとprocessingだけをfailedへ更新する', async () => {
+    const { floor, organization } = await createRecordingFixture(db)
+    const deadlineAt = new Date('2026-08-04T01:00:00.000Z')
+    const futureDeadlineAt = new Date('2026-08-04T03:00:00.000Z')
+    const now = new Date('2026-08-04T02:00:00.000Z')
+    const createRun = (deadline_at: Date) =>
+      insertAnalysisRun(
+        {
+          organization_id: organization.id,
+          floor_id: floor.id,
+          analysis_type: 'stay_heatmap',
+          parameters: {},
+          definition_version: 'original-v1',
+          deadline_at,
+        },
+        db
+      )
+    const [accepted, processing, future, completed] = await Promise.all([
+      createRun(deadlineAt),
+      createRun(deadlineAt),
+      createRun(futureDeadlineAt),
+      createRun(deadlineAt),
+    ])
+    await markAnalysisRunProcessing(processing.id, new Date('2026-08-04T00:30:00.000Z'), db)
+    await markAnalysisRunProcessing(completed.id, new Date('2026-08-04T00:30:00.000Z'), db)
+    await markAnalysisRunCompleted(completed.id, new Date('2026-08-04T00:45:00.000Z'), db)
+
+    const expiredCount = await markTimedOutAnalysisRunsFailed(now, db)
+    const [expiredAccepted, expiredProcessing, activeFuture, terminalCompleted] = await Promise.all(
+      [
+        findAnalysisRunById(accepted.id, db),
+        findAnalysisRunById(processing.id, db),
+        findAnalysisRunById(future.id, db),
+        findAnalysisRunById(completed.id, db),
+      ]
+    )
+
+    expect(expiredCount).toBe(2)
+    expect(expiredAccepted).toMatchObject({
+      status: 'failed',
+      error_code: 'ANALYSIS_TIMEOUT',
+      finished_at: now,
+    })
+    expect(expiredProcessing).toMatchObject({
+      status: 'failed',
+      error_code: 'ANALYSIS_TIMEOUT',
+      finished_at: now,
+    })
+    expect(activeFuture).toMatchObject({ status: 'accepted', finished_at: null })
+    expect(terminalCompleted).toMatchObject({ status: 'completed' })
   })
 })


### PR DESCRIPTION
## 関連Issue

- https://github.com/kajiLabTeam/okarin/issues/200

## 作業内容

- 期限超過した`accepted`・`processing` runを単一UPDATEで`failed`へ更新
- `error_code=ANALYSIS_TIMEOUT`と`finished_at`を保存
- timeout確定serviceを追加
- Kaede起動時に期限超過runを確定
- PoC方針に従いobject cleanupと管理CLIは追加しない

## 検証

- `mise exec -- pnpm typecheck`
- `mise exec -- pnpm lint`
- unit test: 71 files / 406 tests passed
- DB test: 23 files / 201 tests passed
