### PR TITLE
滞在ヒートマップ分析の作成APIを追加

### DIFF
--- a/apps/kaede/src/routes/organizations/create-stay-heatmap.ts
+++ b/apps/kaede/src/routes/organizations/create-stay-heatmap.ts
@@ -1,0 +1,72 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { requireRequestActor } from '../../middleware/request-actor-context.js'
+import type { RequestActorContext } from '../../middleware/request-actor-context.js'
+import {
+  createStayHeatmapErrorResponseSchema,
+  createStayHeatmapRequestSchema,
+  createStayHeatmapResponseSchema,
+} from '../../schemas/analysis-runs.js'
+import { organizationIdParamsSchema } from '../../schemas/organizations.js'
+import { createStayHeatmap } from '../../usecases/analysis-runs/create-stay-heatmap.js'
+
+export const registerCreateStayHeatmapRoute = (app: OpenAPIHono) => {
+  const errorResponse = {
+    description: 'analysis creation failed',
+    content: { 'application/json': { schema: createStayHeatmapErrorResponseSchema } },
+  } as const
+  const route = createRoute({
+    method: 'post',
+    path: '/{organizationId}/analyses/stay-heatmaps',
+    tags: ['Organizations'],
+    request: {
+      params: organizationIdParamsSchema,
+      body: { content: { 'application/json': { schema: createStayHeatmapRequestSchema } } },
+    },
+    responses: {
+      202: {
+        description: 'analysis accepted',
+        content: { 'application/json': { schema: createStayHeatmapResponseSchema } },
+      },
+      400: errorResponse,
+      403: errorResponse,
+      404: errorResponse,
+      409: errorResponse,
+      500: errorResponse,
+      502: errorResponse,
+    },
+  })
+
+  app.openapi(route, async (c) => {
+    const { organizationId } = c.req.valid('param')
+    const result = await createStayHeatmap(
+      requireRequestActor(c as RequestActorContext),
+      organizationId,
+      c.req.valid('json')
+    )
+    if (result.ok) return c.json(result.value, 202)
+
+    const runId = 'analysisRunId' in result.error ? result.error.analysisRunId : undefined
+    const responses = {
+      AUTH_DASHBOARD_FORBIDDEN: [403, 'dashboard write access is required'],
+      AUTH_ORGANIZATION_FORBIDDEN: [403, 'organization access is required'],
+      TRAJECTORY_NOT_FOUND: [404, 'trajectory not found'],
+      FLOOR_NOT_FOUND: [404, 'floor not found'],
+      TRAJECTORY_NOT_COMPLETED: [409, 'trajectory is not completed'],
+      TRAJECTORY_SCOPE_INVALID: [409, 'trajectory scope is invalid'],
+      TRAJECTORY_START_INVALID: [409, 'trajectory start is invalid'],
+      FLOOR_ANALYSIS_METADATA_INVALID: [409, 'floor analysis metadata is invalid'],
+      ANALYSIS_PREPARATION_FAILED: [500, 'failed to prepare analysis request'],
+      NOZOMI_REQUEST_FAILED: [502, 'failed to submit analysis request'],
+    } as const
+    const [status, message] = responses[result.error.type]
+    return c.json(
+      {
+        error_code: result.error.type,
+        error_message: message,
+        ...(runId ? { analysis_run_id: runId } : {}),
+      },
+      status
+    )
+  })
+}

--- a/apps/kaede/src/routes/organizations/index.ts
+++ b/apps/kaede/src/routes/organizations/index.ts
@@ -5,6 +5,7 @@ import { registerCreateOrganizationMembershipRoute } from './create-organization
 import { registerCreateOrganizationUserActivationLinkRoute } from './create-organization-user-activation-link.js'
 import { registerCreateOrganizationUserRoute } from './create-organization-user.js'
 import { registerCreateOrganizationRoute } from './create-organization.js'
+import { registerCreateStayHeatmapRoute } from './create-stay-heatmap.js'
 import { registerGetOrganizationUserRoute } from './get-organization-user.js'
 import { registerGetOrganizationRoute } from './get-organization.js'
 import { registerListOrganizationBuildingFloorsRoute } from './list-organization-building-floors.js'
@@ -32,3 +33,4 @@ registerGetOrganizationUserRoute(organizationsRoutes)
 registerCreateOrganizationUserRoute(organizationsRoutes)
 registerCreateOrganizationUserActivationLinkRoute(organizationsRoutes)
 registerCreateOrganizationMembershipRoute(organizationsRoutes)
+registerCreateStayHeatmapRoute(organizationsRoutes)

--- a/apps/kaede/src/schemas/analysis-runs.ts
+++ b/apps/kaede/src/schemas/analysis-runs.ts
@@ -1,0 +1,52 @@
+import { z } from '@hono/zod-openapi'
+import { uuidSchema } from './common.js'
+
+const parameterSchema = (minimum: number, maximum: number, defaultValue: number) =>
+  z
+    .number()
+    .finite()
+    .min(minimum)
+    .max(maximum)
+    .refine((value) => Number.isInteger(value * 1000), 'must have at most 3 decimal places')
+    .default(defaultValue)
+
+export const stayHeatmapParametersSchema = z
+  .object({
+    speed_threshold_mps: parameterSchema(0, 2, 0.5),
+    grid_size_m: parameterSchema(0.1, 10, 1),
+  })
+  .strict()
+  .openapi('StayHeatmapParameters')
+
+export const createStayHeatmapRequestSchema = z
+  .object({
+    trajectory_ids: z
+      .array(uuidSchema)
+      .min(1)
+      .max(100)
+      .refine((ids) => new Set(ids).size === ids.length, 'trajectory_ids must be unique'),
+    parameters: stayHeatmapParametersSchema.default({
+      speed_threshold_mps: 0.5,
+      grid_size_m: 1,
+    }),
+  })
+  .strict()
+  .openapi('CreateStayHeatmapRequest')
+
+export const createStayHeatmapResponseSchema = z
+  .object({
+    analysis_run_id: uuidSchema,
+    status: z.literal('processing'),
+  })
+  .openapi('CreateStayHeatmapResponse')
+
+export const createStayHeatmapErrorResponseSchema = z
+  .object({
+    error_code: z.string(),
+    error_message: z.string(),
+    analysis_run_id: uuidSchema.optional(),
+  })
+  .openapi('CreateStayHeatmapErrorResponse')
+
+export type CreateStayHeatmapRequest = z.infer<typeof createStayHeatmapRequestSchema>
+export type StayHeatmapParameters = z.infer<typeof stayHeatmapParametersSchema>

--- a/apps/kaede/src/services/floors/floor-repository.ts
+++ b/apps/kaede/src/services/floors/floor-repository.ts
@@ -95,10 +95,12 @@ export const insertFloor = async (
 export const findFloorById = async (
   floorId: string,
   executor: DbExecutor = db
-): Promise<Pick<Floor, 'id' | 'organization_id' | 'scale'> | undefined> => {
+): Promise<
+  Pick<Floor, 'id' | 'organization_id' | 'scale' | 'map_width_px' | 'map_height_px'> | undefined
+> => {
   return executor
     .selectFrom('floors')
-    .select(['id', 'organization_id', 'scale'])
+    .select(['id', 'organization_id', 'scale', 'map_width_px', 'map_height_px'])
     .where('id', '=', floorId)
     .executeTakeFirst()
 }

--- a/apps/kaede/src/services/nozomi/analyze-client.ts
+++ b/apps/kaede/src/services/nozomi/analyze-client.ts
@@ -6,6 +6,11 @@ const analyzeAcceptedResponseSchema = z.object({
   status: z.literal('accepted'),
 })
 
+const stayHeatmapAcceptedResponseSchema = z.object({
+  analysis_run_id: z.string().uuid(),
+  status: z.literal('accepted'),
+})
+
 export interface AnalyzeConstraint {
   seq: number
   point_type: 'start' | 'waypoint' | 'goal'
@@ -60,4 +65,47 @@ export const submitAnalyzeRequest = async (payload: AnalyzeRequestPayload) => {
 
   const raw = await response.json()
   return analyzeAcceptedResponseSchema.parse(raw)
+}
+
+export interface StayHeatmapAnalyzeRequestPayload {
+  analysis_run_id: string
+  analysis_type: 'stay_heatmap'
+  definition_version: 'original-v1'
+  parameters: {
+    speed_threshold_mps: number
+    grid_size_m: number
+  }
+  floor: {
+    floor_id: string
+    map_width_px: number
+    map_height_px: number
+    scale_m_per_px: number
+  }
+  trajectories: {
+    trajectory_id: string
+    seq: number
+    start: { x_px: number; y_px: number }
+    source: { download_url: string }
+    output: { upload_url: string }
+  }[]
+  heatmap_output: { upload_url: string }
+  callback: { url: string; token: string }
+}
+
+export const submitStayHeatmapAnalyzeRequest = async (
+  payload: StayHeatmapAnalyzeRequestPayload
+) => {
+  const config = getNozomiRuntimeConfig()
+  const response = await fetch(`${config.internalEndpoint}/stay-heatmaps/analyze`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(config.requestTimeoutMs),
+  })
+
+  if (!response.ok) {
+    throw new Error(`nozomi stay heatmap request failed with status ${response.status}`)
+  }
+
+  return stayHeatmapAcceptedResponseSchema.parse(await response.json())
 }

--- a/apps/kaede/src/services/nozomi/index.ts
+++ b/apps/kaede/src/services/nozomi/index.ts
@@ -1,3 +1,3 @@
-export { submitAnalyzeRequest } from './analyze-client.js'
-export type { AnalyzeRequestPayload } from './analyze-client.js'
+export { submitAnalyzeRequest, submitStayHeatmapAnalyzeRequest } from './analyze-client.js'
+export type { AnalyzeRequestPayload, StayHeatmapAnalyzeRequestPayload } from './analyze-client.js'
 export { pingNozomi } from './ping-client.js'

--- a/apps/kaede/src/services/trajectories/callback-token.ts
+++ b/apps/kaede/src/services/trajectories/callback-token.ts
@@ -9,6 +9,21 @@ interface CallbackTokenPayload {
   exp: number
 }
 
+interface AnalysisCallbackTokenPayload {
+  analysis_run_id: string
+  analysis_type: 'stay_heatmap'
+  exp: number
+}
+
+const signCallbackPayload = (payload: CallbackTokenPayload | AnalysisCallbackTokenPayload) => {
+  const encodedPayload = base64UrlEncode(JSON.stringify(payload))
+  const signature = createHmac('sha256', getCallbackRuntimeConfig().tokenSecret)
+    .update(encodedPayload)
+    .digest('base64url')
+
+  return `${encodedPayload}.${signature}`
+}
+
 export type VerifyCallbackTokenResult =
   | {
       ok: true
@@ -25,18 +40,20 @@ export type VerifyCallbackTokenResult =
 export const generateCallbackToken = (trajectoryId: string, now: Date = new Date()): string => {
   const callbackConfig = getCallbackRuntimeConfig()
   const exp = Math.floor(now.getTime() / 1000) + callbackConfig.tokenTtlSeconds
-  const payload = base64UrlEncode(
-    JSON.stringify({
-      trajectory_id: trajectoryId,
-      exp,
-    })
-  )
+  return signCallbackPayload({ trajectory_id: trajectoryId, exp })
+}
 
-  const signature = createHmac('sha256', callbackConfig.tokenSecret)
-    .update(payload)
-    .digest('base64url')
-
-  return `${payload}.${signature}`
+export const generateAnalysisCallbackToken = (
+  analysisRunId: string,
+  now: Date = new Date()
+): string => {
+  const callbackConfig = getCallbackRuntimeConfig()
+  const exp = Math.floor(now.getTime() / 1000) + callbackConfig.tokenTtlSeconds
+  return signCallbackPayload({
+    analysis_run_id: analysisRunId,
+    analysis_type: 'stay_heatmap',
+    exp,
+  })
 }
 
 export const verifyCallbackToken = (

--- a/apps/kaede/src/usecases/analysis-runs/create-stay-heatmap.test.ts
+++ b/apps/kaede/src/usecases/analysis-runs/create-stay-heatmap.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import { createStayHeatmap } from './create-stay-heatmap.js'
+
+const mocks = vi.hoisted(() => ({
+  findTrajectoryById: vi.fn(),
+  findFloorById: vi.fn(),
+  insertAnalysisRun: vi.fn(),
+  insertInputs: vi.fn(),
+  markProcessing: vi.fn(),
+  markFailed: vi.fn(),
+  sourceUrl: vi.fn(),
+  outputUrl: vi.fn(),
+  heatmapUrl: vi.fn(),
+  callbackToken: vi.fn(),
+  submit: vi.fn(),
+  transaction: vi.fn(),
+}))
+
+vi.mock('../../services/db/index.js', () => ({
+  db: { transaction: () => ({ execute: mocks.transaction }) },
+}))
+vi.mock('../../services/analysis-runs/index.js', () => ({
+  insertAnalysisRun: mocks.insertAnalysisRun,
+  insertAnalysisRunTrajectories: mocks.insertInputs,
+  markAnalysisRunProcessing: mocks.markProcessing,
+  markAnalysisRunFailed: mocks.markFailed,
+}))
+vi.mock('../../services/trajectories/index.js', () => ({
+  findTrajectoryById: mocks.findTrajectoryById,
+}))
+vi.mock('../../services/trajectories/callback-token.js', () => ({
+  generateAnalysisCallbackToken: mocks.callbackToken,
+}))
+vi.mock('../../services/floors/index.js', () => ({ findFloorById: mocks.findFloorById }))
+vi.mock('../../services/nozomi/index.js', () => ({
+  submitStayHeatmapAnalyzeRequest: mocks.submit,
+}))
+vi.mock('../../services/storage/index.js', () => ({
+  issueInternalAnalysisTrajectoryDownloadUrl: mocks.sourceUrl,
+  issueInternalAnalysisTrajectoryUploadUrl: mocks.outputUrl,
+  issueInternalAnalysisHeatmapUploadUrl: mocks.heatmapUrl,
+}))
+vi.mock('../../config/runtime.js', () => ({
+  getCallbackRuntimeConfig: () => ({ baseUrl: 'https://kaede.test' }),
+}))
+
+const organizationId = '11111111-1111-4111-8111-111111111111'
+const floorId = '22222222-2222-4222-8222-222222222222'
+const trajectoryId = '33333333-3333-4333-8333-333333333333'
+const runId = '44444444-4444-4444-8444-444444444444'
+const actor: RequestActor = {
+  type: 'user',
+  user_id: '55555555-5555-4555-8555-555555555555',
+  email: 'manager@example.com',
+  global_role: 'none',
+  account_state: 'active',
+  memberships: [{ organization_id: organizationId, organization_name: 'Test', role: 'manager' }],
+}
+
+describe('createStayHeatmap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.findTrajectoryById.mockResolvedValue({
+      id: trajectoryId,
+      organization_id: organizationId,
+      floor_id: floorId,
+      status: 'completed',
+      constraints: [
+        { seq: 0, point_type: 'start', x: 10, y: 20 },
+        { seq: 1, point_type: 'goal', x: 30, y: 40 },
+      ],
+    })
+    mocks.findFloorById.mockResolvedValue({
+      id: floorId,
+      organization_id: organizationId,
+      scale: 0.01,
+      map_width_px: 100,
+      map_height_px: 200,
+    })
+    mocks.insertAnalysisRun.mockResolvedValue({ id: runId })
+    mocks.insertInputs.mockResolvedValue([])
+    mocks.markProcessing.mockResolvedValue({ id: runId })
+    mocks.markFailed.mockResolvedValue({ id: runId, status: 'failed' })
+    mocks.transaction.mockImplementation((callback) => callback({}))
+    mocks.sourceUrl.mockResolvedValue({ downloadUrl: 'https://storage.test/input.csv' })
+    mocks.outputUrl.mockResolvedValue({ uploadUrl: 'https://storage.test/stay.csv' })
+    mocks.heatmapUrl.mockResolvedValue({ uploadUrl: 'https://storage.test/heatmap.json' })
+    mocks.callbackToken.mockReturnValue('token')
+    mocks.submit.mockResolvedValue({ analysis_run_id: runId, status: 'accepted' })
+  })
+
+  it('runを作成してNozomiへ滞在ヒートマップ分析を依頼する', async () => {
+    const result = await createStayHeatmap(actor, organizationId, {
+      trajectory_ids: [trajectoryId],
+      parameters: { speed_threshold_mps: 0.5, grid_size_m: 1 },
+    })
+
+    expect(result).toEqual({ ok: true, value: { analysis_run_id: runId, status: 'processing' } })
+    expect(mocks.insertInputs).toHaveBeenCalledWith(
+      [{ analysis_run_id: runId, trajectory_id: trajectoryId, seq: 0 }],
+      {}
+    )
+    expect(mocks.submit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        analysis_run_id: runId,
+        floor: {
+          floor_id: floorId,
+          map_width_px: 100,
+          map_height_px: 200,
+          scale_m_per_px: 0.01,
+        },
+        trajectories: [
+          expect.objectContaining({
+            trajectory_id: trajectoryId,
+            seq: 0,
+            start: { x_px: 10, y_px: 20 },
+          }),
+        ],
+      })
+    )
+  })
+
+  it('開始点が画像外の場合はrunを作成しない', async () => {
+    mocks.findTrajectoryById.mockResolvedValueOnce({
+      id: trajectoryId,
+      organization_id: organizationId,
+      floor_id: floorId,
+      status: 'completed',
+      constraints: [{ seq: 0, point_type: 'start', x: 100, y: 20 }],
+    })
+
+    const result = await createStayHeatmap(actor, organizationId, {
+      trajectory_ids: [trajectoryId],
+      parameters: { speed_threshold_mps: 0.5, grid_size_m: 1 },
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      error: { type: 'TRAJECTORY_START_INVALID', trajectoryId },
+    })
+    expect(mocks.insertAnalysisRun).not.toHaveBeenCalled()
+  })
+
+  it('Nozomi依頼失敗時はrunをfailedにする', async () => {
+    mocks.submit.mockRejectedValueOnce(new Error('nozomi unavailable'))
+
+    const result = await createStayHeatmap(actor, organizationId, {
+      trajectory_ids: [trajectoryId],
+      parameters: { speed_threshold_mps: 0.5, grid_size_m: 1 },
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      error: { type: 'NOZOMI_REQUEST_FAILED', analysisRunId: runId },
+    })
+    expect(mocks.markFailed).toHaveBeenCalledWith(runId, 'NOZOMI_REQUEST_FAILED')
+  })
+
+  it('署名URLの準備失敗時はNozomiへ依頼せずrunをfailedにする', async () => {
+    mocks.sourceUrl.mockRejectedValueOnce(new Error('storage unavailable'))
+
+    const result = await createStayHeatmap(actor, organizationId, {
+      trajectory_ids: [trajectoryId],
+      parameters: { speed_threshold_mps: 0.5, grid_size_m: 1 },
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      error: { type: 'ANALYSIS_PREPARATION_FAILED', analysisRunId: runId },
+    })
+    expect(mocks.markFailed).toHaveBeenCalledWith(runId, 'ANALYSIS_PREPARATION_FAILED')
+    expect(mocks.submit).not.toHaveBeenCalled()
+  })
+})

--- a/apps/kaede/src/usecases/analysis-runs/create-stay-heatmap.ts
+++ b/apps/kaede/src/usecases/analysis-runs/create-stay-heatmap.ts
@@ -1,0 +1,200 @@
+import * as Sentry from '@sentry/node'
+import { getCallbackRuntimeConfig } from '../../config/runtime.js'
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import type { CreateStayHeatmapRequest } from '../../schemas/analysis-runs.js'
+import { trajectoryConstraintsSchema } from '../../schemas/trajectories.js'
+import {
+  insertAnalysisRun,
+  insertAnalysisRunTrajectories,
+  markAnalysisRunFailed,
+  markAnalysisRunProcessing,
+} from '../../services/analysis-runs/index.js'
+import { db } from '../../services/db/index.js'
+import { findFloorById } from '../../services/floors/index.js'
+import { submitStayHeatmapAnalyzeRequest } from '../../services/nozomi/index.js'
+import {
+  issueInternalAnalysisHeatmapUploadUrl,
+  issueInternalAnalysisTrajectoryDownloadUrl,
+  issueInternalAnalysisTrajectoryUploadUrl,
+} from '../../services/storage/index.js'
+import { generateAnalysisCallbackToken } from '../../services/trajectories/callback-token.js'
+import { findTrajectoryById } from '../../services/trajectories/index.js'
+import type { AuthorizationError } from '../authorization.js'
+import { requireOrganizationManager } from '../authorization.js'
+
+type ValidationError =
+  | { type: 'TRAJECTORY_NOT_FOUND'; trajectoryId: string }
+  | { type: 'TRAJECTORY_NOT_COMPLETED'; trajectoryId: string }
+  | { type: 'TRAJECTORY_SCOPE_INVALID'; trajectoryId: string }
+  | { type: 'TRAJECTORY_START_INVALID'; trajectoryId: string }
+  | { type: 'FLOOR_NOT_FOUND'; floorId: string }
+  | { type: 'FLOOR_ANALYSIS_METADATA_INVALID'; floorId: string }
+
+export type CreateStayHeatmapResult =
+  | { ok: true; value: { analysis_run_id: string; status: 'processing' } }
+  | { ok: false; error: AuthorizationError | ValidationError }
+  | {
+      ok: false
+      error: {
+        type: 'ANALYSIS_PREPARATION_FAILED' | 'NOZOMI_REQUEST_FAILED'
+        analysisRunId: string
+      }
+    }
+
+const callbackUrl = () => `${getCallbackRuntimeConfig().baseUrl}/api/analysis-runs/callback`
+
+export const createStayHeatmap = async (
+  actor: RequestActor,
+  organizationId: string,
+  payload: CreateStayHeatmapRequest
+): Promise<CreateStayHeatmapResult> => {
+  const authorization = requireOrganizationManager(actor, organizationId)
+  if (!authorization.ok) return authorization
+
+  const trajectories = await Promise.all(
+    payload.trajectory_ids.map((trajectoryId) => findTrajectoryById(trajectoryId))
+  )
+  const validatedTrajectories = []
+  for (const [index, trajectory] of trajectories.entries()) {
+    if (!trajectory) {
+      return {
+        ok: false,
+        error: { type: 'TRAJECTORY_NOT_FOUND', trajectoryId: payload.trajectory_ids[index] },
+      }
+    }
+    if (trajectory.status !== 'completed') {
+      return { ok: false, error: { type: 'TRAJECTORY_NOT_COMPLETED', trajectoryId: trajectory.id } }
+    }
+    validatedTrajectories.push(trajectory)
+  }
+
+  const first = validatedTrajectories[0]
+  for (const trajectory of validatedTrajectories) {
+    if (trajectory.organization_id !== organizationId || trajectory.floor_id !== first.floor_id) {
+      return { ok: false, error: { type: 'TRAJECTORY_SCOPE_INVALID', trajectoryId: trajectory.id } }
+    }
+  }
+
+  const floor = await findFloorById(first.floor_id)
+  if (floor?.organization_id !== organizationId) {
+    return { ok: false, error: { type: 'FLOOR_NOT_FOUND', floorId: first.floor_id } }
+  }
+  if (
+    floor.scale === null ||
+    floor.scale <= 0 ||
+    floor.map_width_px === null ||
+    floor.map_width_px <= 0 ||
+    floor.map_height_px === null ||
+    floor.map_height_px <= 0
+  ) {
+    return {
+      ok: false,
+      error: { type: 'FLOOR_ANALYSIS_METADATA_INVALID', floorId: floor.id },
+    }
+  }
+
+  const preparedTrajectories: {
+    trajectory: (typeof validatedTrajectories)[number]
+    seq: number
+    start: { x: number; y: number }
+  }[] = []
+  for (const [seq, trajectory] of validatedTrajectories.entries()) {
+    const constraints = trajectoryConstraintsSchema.safeParse(trajectory.constraints)
+    const start = constraints.success
+      ? constraints.data.find((constraint) => constraint.point_type === 'start')
+      : undefined
+    if (
+      !start ||
+      start.x < 0 ||
+      start.y < 0 ||
+      start.x >= floor.map_width_px ||
+      start.y >= floor.map_height_px
+    ) {
+      return { ok: false, error: { type: 'TRAJECTORY_START_INVALID', trajectoryId: trajectory.id } }
+    }
+    preparedTrajectories.push({ trajectory, seq, start })
+  }
+
+  const processing = await db.transaction().execute(async (transaction) => {
+    const run = await insertAnalysisRun(
+      {
+        organization_id: organizationId,
+        floor_id: floor.id,
+        analysis_type: 'stay_heatmap',
+        parameters: payload.parameters,
+        definition_version: 'original-v1',
+      },
+      transaction
+    )
+    await insertAnalysisRunTrajectories(
+      preparedTrajectories.map(({ trajectory, seq }) => ({
+        analysis_run_id: run.id,
+        trajectory_id: trajectory.id,
+        seq,
+      })),
+      transaction
+    )
+    const updated = await markAnalysisRunProcessing(run.id, new Date(), transaction)
+    if (!updated) throw new Error('failed to mark analysis run processing')
+    return updated
+  })
+
+  let request: Parameters<typeof submitStayHeatmapAnalyzeRequest>[0]
+  try {
+    const [trajectoryUrls, heatmapOutput, token] = await Promise.all([
+      Promise.all(
+        preparedTrajectories.map(async ({ trajectory, seq, start }) => {
+          const [source, output] = await Promise.all([
+            issueInternalAnalysisTrajectoryDownloadUrl(organizationId, trajectory.id),
+            issueInternalAnalysisTrajectoryUploadUrl(organizationId, processing.id, trajectory.id),
+          ])
+          return {
+            trajectory_id: trajectory.id,
+            seq,
+            start: { x_px: start.x, y_px: start.y },
+            source: { download_url: source.downloadUrl },
+            output: { upload_url: output.uploadUrl },
+          }
+        })
+      ),
+      issueInternalAnalysisHeatmapUploadUrl(organizationId, processing.id),
+      Promise.resolve(generateAnalysisCallbackToken(processing.id)),
+    ])
+    request = {
+      analysis_run_id: processing.id,
+      analysis_type: 'stay_heatmap',
+      definition_version: 'original-v1',
+      parameters: payload.parameters,
+      floor: {
+        floor_id: floor.id,
+        map_width_px: floor.map_width_px,
+        map_height_px: floor.map_height_px,
+        scale_m_per_px: floor.scale,
+      },
+      trajectories: trajectoryUrls,
+      heatmap_output: { upload_url: heatmapOutput.uploadUrl },
+      callback: { url: callbackUrl(), token },
+    }
+  } catch (error) {
+    Sentry.captureException(error)
+    await markAnalysisRunFailed(processing.id, 'ANALYSIS_PREPARATION_FAILED')
+    return {
+      ok: false,
+      error: { type: 'ANALYSIS_PREPARATION_FAILED', analysisRunId: processing.id },
+    }
+  }
+
+  try {
+    const accepted = await submitStayHeatmapAnalyzeRequest(request)
+    if (accepted.analysis_run_id !== processing.id) throw new Error('unexpected analysis run id')
+  } catch (error) {
+    Sentry.captureException(error)
+    await markAnalysisRunFailed(processing.id, 'NOZOMI_REQUEST_FAILED')
+    return {
+      ok: false,
+      error: { type: 'NOZOMI_REQUEST_FAILED', analysisRunId: processing.id },
+    }
+  }
+
+  return { ok: true, value: { analysis_run_id: processing.id, status: 'processing' } }
+}


### PR DESCRIPTION
## 関連Issue

- https://github.com/kajiLabTeam/okarin/issues/200

## 作業内容

- 滞在ヒートマップ分析runの作成APIを追加
- manager以上およびglobal adminの認可を適用
- 1〜100件のtrajectory、同一organization・floor、status、開始点、scale、画像寸法を検証
- parameterの既定値補完、範囲、小数精度を検証
- runと入力trajectoryをtransactionで登録
- 分析用署名URLとcallback tokenを生成
- Nozomiの`/stay-heatmaps/analyze`へ依頼
- 準備失敗・Nozomi依頼失敗時にrunをfailedへ更新

## 検証

- Prettier
- `mise exec -- pnpm lint`
- `mise exec -- pnpm typecheck`
- unit test: 72 files / 410 tests passed
- `git diff --check`
