### PR TITLE
分析runのcallback処理を追加

### DIFF
--- a/apps/kaede/src/routes/analysis-runs/callback.test.ts
+++ b/apps/kaede/src/routes/analysis-runs/callback.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRouteTestApp } from '../create-route-test-app.js'
+import { registerAnalysisCallbackRoute } from './callback.js'
+
+const { receiveCallbackMock } = vi.hoisted(() => ({ receiveCallbackMock: vi.fn() }))
+
+vi.mock('../../usecases/analysis-runs/receive-callback.js', () => ({
+  receiveAnalysisCallback: receiveCallbackMock,
+}))
+
+const runId = '11111111-1111-4111-8111-111111111111'
+
+describe('POST /api/analysis-runs/callback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('completed callbackを受理する', async () => {
+    receiveCallbackMock.mockResolvedValue({
+      ok: true,
+      value: { analysis_run_id: runId, status: 'completed' },
+    })
+    const app = createRouteTestApp('/analysis-runs', registerAnalysisCallbackRoute)
+    const response = await app.request('/api/analysis-runs/callback', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        analysis_run_id: runId,
+        status: 'completed',
+        callback_token: 'token',
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ analysis_run_id: runId, status: 'completed' })
+  })
+
+  it('不正tokenは401を返す', async () => {
+    receiveCallbackMock.mockResolvedValue({
+      ok: false,
+      error: { type: 'CALLBACK_TOKEN_INVALID' },
+    })
+    const app = createRouteTestApp('/analysis-runs', registerAnalysisCallbackRoute)
+    const response = await app.request('/api/analysis-runs/callback', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        analysis_run_id: runId,
+        status: 'completed',
+        callback_token: 'invalid',
+      }),
+    })
+
+    expect(response.status).toBe(401)
+  })
+
+  it('未知fieldを含むpayloadは400を返す', async () => {
+    const app = createRouteTestApp('/analysis-runs', registerAnalysisCallbackRoute)
+    const response = await app.request('/api/analysis-runs/callback', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        analysis_run_id: runId,
+        status: 'completed',
+        callback_token: 'token',
+        unknown: true,
+      }),
+    })
+
+    expect(response.status).toBe(400)
+    expect(receiveCallbackMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/kaede/src/routes/analysis-runs/callback.ts
+++ b/apps/kaede/src/routes/analysis-runs/callback.ts
@@ -1,0 +1,50 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import {
+  analysisCallbackErrorResponseSchema,
+  analysisCallbackRequestSchema,
+  analysisCallbackResponseSchema,
+} from '../../schemas/analysis-runs.js'
+import { receiveAnalysisCallback } from '../../usecases/analysis-runs/receive-callback.js'
+
+export const registerAnalysisCallbackRoute = (app: OpenAPIHono) => {
+  const errorResponse = {
+    description: 'callback rejected',
+    content: { 'application/json': { schema: analysisCallbackErrorResponseSchema } },
+  } as const
+  const route = createRoute({
+    method: 'post',
+    path: '/callback',
+    tags: ['Analysis runs'],
+    request: {
+      body: { content: { 'application/json': { schema: analysisCallbackRequestSchema } } },
+    },
+    responses: {
+      200: {
+        description: 'callback accepted',
+        content: { 'application/json': { schema: analysisCallbackResponseSchema } },
+      },
+      400: errorResponse,
+      401: errorResponse,
+      404: errorResponse,
+      409: errorResponse,
+      500: errorResponse,
+    },
+  })
+
+  app.openapi(route, async (c) => {
+    const result = await receiveAnalysisCallback(c.req.valid('json'))
+    if (result.ok) return c.json(result.value, 200)
+
+    const responses = {
+      CALLBACK_TOKEN_INVALID: [401, 'callback token is invalid'],
+      CALLBACK_TOKEN_EXPIRED: [401, 'callback token has expired'],
+      ANALYSIS_RUN_NOT_FOUND: [404, 'analysis run not found'],
+      CALLBACK_ANALYSIS_RUN_MISMATCH: [409, 'analysis run ID does not match token'],
+      CALLBACK_ALREADY_FINALIZED: [409, 'analysis run is already finalized'],
+      CALLBACK_ARTIFACT_INVALID: [409, 'analysis artifact is invalid'],
+    } as const
+    const [status, message] = responses[result.error.type]
+    return c.json({ error_code: result.error.type, error_message: message }, status)
+  })
+}

--- a/apps/kaede/src/routes/analysis-runs/index.ts
+++ b/apps/kaede/src/routes/analysis-runs/index.ts
@@ -1,0 +1,6 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { registerAnalysisCallbackRoute } from './callback.js'
+
+export const analysisRunsRoutes = new OpenAPIHono()
+
+registerAnalysisCallbackRoute(analysisRunsRoutes)

--- a/apps/kaede/src/routes/index.ts
+++ b/apps/kaede/src/routes/index.ts
@@ -1,5 +1,6 @@
 import { OpenAPIHono } from '@hono/zod-openapi'
 import { actorRoutes } from './actor/index.js'
+import { analysisRunsRoutes } from './analysis-runs/index.js'
 import { authRoutes } from './auth/index.js'
 import { buildingsRoutes } from './buildings/index.js'
 import { floorsRoutes } from './floors/index.js'
@@ -15,6 +16,7 @@ export const registerApiRoutes = (app: OpenAPIHono) => {
   const api = new OpenAPIHono()
 
   api.route('/actor', actorRoutes)
+  api.route('/analysis-runs', analysisRunsRoutes)
   api.route('/auth', authRoutes)
   api.route('/buildings', buildingsRoutes)
   api.route('/floors', floorsRoutes)

--- a/apps/kaede/src/schemas/analysis-runs.ts
+++ b/apps/kaede/src/schemas/analysis-runs.ts
@@ -1,19 +1,18 @@
 import { z } from '@hono/zod-openapi'
 import { uuidSchema } from './common.js'
 
-const parameterSchema = (minimum: number, maximum: number, defaultValue: number) =>
+const parameterSchema = (minimum: number, maximum: number) =>
   z
     .number()
     .finite()
     .min(minimum)
     .max(maximum)
     .refine((value) => Number.isInteger(value * 1000), 'must have at most 3 decimal places')
-    .default(defaultValue)
 
 export const stayHeatmapParametersSchema = z
   .object({
-    speed_threshold_mps: parameterSchema(0, 2, 0.5),
-    grid_size_m: parameterSchema(0.1, 10, 1),
+    speed_threshold_mps: parameterSchema(0, 2).default(0.5),
+    grid_size_m: parameterSchema(0.1, 10).default(1),
   })
   .strict()
   .openapi('StayHeatmapParameters')
@@ -48,5 +47,111 @@ export const createStayHeatmapErrorResponseSchema = z
   })
   .openapi('CreateStayHeatmapErrorResponse')
 
+const heatmapCellSchema = z
+  .object({
+    grid_column: z.number().int().min(0),
+    grid_row: z.number().int().min(0),
+    stay_cell_visit_count: z.number().int().positive(),
+  })
+  .strict()
+
+export const stayHeatmapArtifactSchema = z
+  .object({
+    schema_version: z.literal('1.0'),
+    definition_version: z.literal('original-v1'),
+    parameters: z
+      .object({
+        speed_threshold_mps: parameterSchema(0, 2),
+        grid_size_m: parameterSchema(0.1, 10),
+      })
+      .strict(),
+    floor_map: z
+      .object({
+        width_px: z.number().int().positive(),
+        height_px: z.number().int().positive(),
+        scale_m_per_px: z.number().positive().finite(),
+      })
+      .strict(),
+    grid: z
+      .object({
+        size_m: z.number().positive().finite(),
+        column_count: z.number().int().positive(),
+        row_count: z.number().int().positive(),
+      })
+      .strict(),
+    input_trajectory_count: z.number().int().positive(),
+    trajectories: z.array(
+      z
+        .object({
+          trajectory_id: uuidSchema,
+          cells: z.array(heatmapCellSchema),
+        })
+        .strict()
+        .superRefine((trajectory, ctx) => {
+          const cells = trajectory.cells.map((cell) => `${cell.grid_row}:${cell.grid_column}`)
+          if (new Set(cells).size !== cells.length) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'cells must be unique' })
+          }
+        })
+    ),
+  })
+  .strict()
+  .superRefine((artifact, ctx) => {
+    const ids = artifact.trajectories.map((trajectory) => trajectory.trajectory_id)
+    if (artifact.input_trajectory_count !== artifact.trajectories.length) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'trajectory count does not match' })
+    }
+    if (new Set(ids).size !== ids.length) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'trajectory IDs must be unique' })
+    }
+    for (const trajectory of artifact.trajectories) {
+      for (const cell of trajectory.cells) {
+        if (
+          cell.grid_column >= artifact.grid.column_count ||
+          cell.grid_row >= artifact.grid.row_count
+        ) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'cell must be inside the grid' })
+        }
+      }
+    }
+  })
+  .openapi('StayHeatmapArtifact')
+
+export const analysisCallbackRequestSchema = z
+  .discriminatedUnion('status', [
+    z
+      .object({
+        analysis_run_id: uuidSchema,
+        status: z.literal('completed'),
+        callback_token: z.string().min(1),
+      })
+      .strict(),
+    z
+      .object({
+        analysis_run_id: uuidSchema,
+        status: z.literal('failed'),
+        callback_token: z.string().min(1),
+        error_code: z.string().min(1).max(100),
+        error_message: z.string().min(1).max(500),
+      })
+      .strict(),
+  ])
+  .openapi('AnalysisCallbackRequest')
+
+export const analysisCallbackResponseSchema = z
+  .object({
+    analysis_run_id: uuidSchema,
+    status: z.enum(['completed', 'failed']),
+  })
+  .openapi('AnalysisCallbackResponse')
+
+export const analysisCallbackErrorResponseSchema = z
+  .object({
+    error_code: z.string(),
+    error_message: z.string(),
+  })
+  .openapi('AnalysisCallbackErrorResponse')
+
 export type CreateStayHeatmapRequest = z.infer<typeof createStayHeatmapRequestSchema>
 export type StayHeatmapParameters = z.infer<typeof stayHeatmapParametersSchema>
+export type AnalysisCallbackRequest = z.infer<typeof analysisCallbackRequestSchema>

--- a/apps/kaede/src/services/storage/index.ts
+++ b/apps/kaede/src/services/storage/index.ts
@@ -1,7 +1,9 @@
 export {
   deleteFloorMapObject,
+  doesAnalysisTrajectoryCsvObjectExist,
   doesTrajectoryAnalyzedResultObjectExist,
   getTrajectoryAnalyzedResultObjectText,
+  getAnalysisHeatmapObjectText,
   listRecordingRawObjectKeys,
   putFloorMapObject,
 } from './object-store.js'

--- a/apps/kaede/src/services/storage/object-store.ts
+++ b/apps/kaede/src/services/storage/object-store.ts
@@ -6,6 +6,8 @@ import {
   PutObjectCommand,
 } from '@aws-sdk/client-s3'
 import {
+  buildAnalysisHeatmapObjectKey,
+  buildAnalysisTrajectoryCsvObjectKey,
   buildRecordingRawObjectPrefix,
   buildTrajectoryAnalyzedResultObjectKey,
   getFloorMapContentType,
@@ -128,6 +130,55 @@ export const getTrajectoryAnalyzedResultObjectText = async (
       return undefined
     }
 
+    throw error
+  }
+}
+
+const doesObjectExist = async (objectKey: string) => {
+  const { config, internalClient } = getS3Context()
+  try {
+    await internalClient.send(new HeadObjectCommand({ Bucket: config.bucket, Key: objectKey }))
+    return true
+  } catch (error) {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'name' in error &&
+      (error.name === 'NotFound' || error.name === 'NoSuchKey')
+    ) {
+      return false
+    }
+    throw error
+  }
+}
+
+export const doesAnalysisTrajectoryCsvObjectExist = (
+  organizationId: string,
+  analysisRunId: string,
+  trajectoryId: string
+) =>
+  doesObjectExist(buildAnalysisTrajectoryCsvObjectKey(organizationId, analysisRunId, trajectoryId))
+
+export const getAnalysisHeatmapObjectText = async (
+  organizationId: string,
+  analysisRunId: string
+): Promise<string | undefined> => {
+  const objectKey = buildAnalysisHeatmapObjectKey(organizationId, analysisRunId)
+  const { config, internalClient } = getS3Context()
+  try {
+    const response = await internalClient.send(
+      new GetObjectCommand({ Bucket: config.bucket, Key: objectKey })
+    )
+    return response.Body ? await response.Body.transformToString() : ''
+  } catch (error) {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'name' in error &&
+      (error.name === 'NotFound' || error.name === 'NoSuchKey')
+    ) {
+      return undefined
+    }
     throw error
   }
 }

--- a/apps/kaede/src/services/trajectories/callback-token.ts
+++ b/apps/kaede/src/services/trajectories/callback-token.ts
@@ -37,6 +37,20 @@ export type VerifyCallbackTokenResult =
       error: 'CALLBACK_TOKEN_INVALID' | 'CALLBACK_TOKEN_EXPIRED'
     }
 
+export type VerifyAnalysisCallbackTokenResult =
+  | {
+      ok: true
+      value: {
+        analysisRunId: string
+        analysisType: 'stay_heatmap'
+        exp: number
+      }
+    }
+  | {
+      ok: false
+      error: 'CALLBACK_TOKEN_INVALID' | 'CALLBACK_TOKEN_EXPIRED'
+    }
+
 export const generateCallbackToken = (trajectoryId: string, now: Date = new Date()): string => {
   const callbackConfig = getCallbackRuntimeConfig()
   const exp = Math.floor(now.getTime() / 1000) + callbackConfig.tokenTtlSeconds
@@ -123,6 +137,59 @@ export const verifyCallbackToken = (
     value: {
       trajectoryId: parsedPayload.trajectory_id,
       exp: parsedPayload.exp,
+    },
+  }
+}
+
+export const verifyAnalysisCallbackToken = (
+  token: string,
+  now: Date = new Date()
+): VerifyAnalysisCallbackTokenResult => {
+  const callbackConfig = getCallbackRuntimeConfig()
+  const [payload, signature, ...rest] = token.split('.')
+  if (!payload || !signature || rest.length > 0) {
+    return { ok: false, error: 'CALLBACK_TOKEN_INVALID' }
+  }
+
+  const expectedSignature = createHmac('sha256', callbackConfig.tokenSecret)
+    .update(payload)
+    .digest('base64url')
+  if (
+    signature.length !== expectedSignature.length ||
+    !timingSafeEqual(Buffer.from(signature), Buffer.from(expectedSignature))
+  ) {
+    return { ok: false, error: 'CALLBACK_TOKEN_INVALID' }
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(base64UrlDecode(payload)) as unknown
+  } catch {
+    return { ok: false, error: 'CALLBACK_TOKEN_INVALID' }
+  }
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    !('analysis_run_id' in parsed) ||
+    !('analysis_type' in parsed) ||
+    !('exp' in parsed) ||
+    typeof parsed.analysis_run_id !== 'string' ||
+    parsed.analysis_type !== 'stay_heatmap' ||
+    typeof parsed.exp !== 'number' ||
+    !Number.isFinite(parsed.exp)
+  ) {
+    return { ok: false, error: 'CALLBACK_TOKEN_INVALID' }
+  }
+  if (parsed.exp <= Math.floor(now.getTime() / 1000)) {
+    return { ok: false, error: 'CALLBACK_TOKEN_EXPIRED' }
+  }
+
+  return {
+    ok: true,
+    value: {
+      analysisRunId: parsed.analysis_run_id,
+      analysisType: parsed.analysis_type,
+      exp: parsed.exp,
     },
   }
 }

--- a/apps/kaede/src/usecases/analysis-runs/receive-callback.test.ts
+++ b/apps/kaede/src/usecases/analysis-runs/receive-callback.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { receiveAnalysisCallback } from './receive-callback.js'
+
+const mocks = vi.hoisted(() => ({
+  verifyToken: vi.fn(),
+  findRun: vi.fn(),
+  listInputs: vi.fn(),
+  markCompleted: vi.fn(),
+  markFailed: vi.fn(),
+  getHeatmap: vi.fn(),
+  csvExists: vi.fn(),
+}))
+
+vi.mock('../../services/trajectories/callback-token.js', () => ({
+  verifyAnalysisCallbackToken: mocks.verifyToken,
+}))
+vi.mock('../../services/analysis-runs/index.js', () => ({
+  findAnalysisRunById: mocks.findRun,
+  listAnalysisRunTrajectories: mocks.listInputs,
+  markAnalysisRunCompleted: mocks.markCompleted,
+  markAnalysisRunFailed: mocks.markFailed,
+}))
+vi.mock('../../services/storage/index.js', () => ({
+  getAnalysisHeatmapObjectText: mocks.getHeatmap,
+  doesAnalysisTrajectoryCsvObjectExist: mocks.csvExists,
+}))
+
+const runId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const trajectoryId = '33333333-3333-4333-8333-333333333333'
+const now = new Date('2026-08-04T03:00:00.000Z')
+const artifact = {
+  schema_version: '1.0',
+  definition_version: 'original-v1',
+  parameters: { speed_threshold_mps: 0.5, grid_size_m: 1 },
+  floor_map: { width_px: 100, height_px: 200, scale_m_per_px: 0.01 },
+  grid: { size_m: 1, column_count: 1, row_count: 2 },
+  input_trajectory_count: 1,
+  trajectories: [{ trajectory_id: trajectoryId, cells: [] }],
+}
+
+describe('receiveAnalysisCallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyToken.mockReturnValue({
+      ok: true,
+      value: { analysisRunId: runId, analysisType: 'stay_heatmap', exp: 1 },
+    })
+    mocks.findRun.mockResolvedValue({
+      id: runId,
+      organization_id: organizationId,
+      analysis_type: 'stay_heatmap',
+      status: 'processing',
+      error_code: null,
+    })
+    mocks.listInputs.mockResolvedValue([
+      { analysis_run_id: runId, trajectory_id: trajectoryId, seq: 0 },
+    ])
+    mocks.getHeatmap.mockResolvedValue(JSON.stringify(artifact))
+    mocks.csvExists.mockResolvedValue(true)
+    mocks.markCompleted.mockResolvedValue({ id: runId, status: 'completed' })
+    mocks.markFailed.mockResolvedValue({ id: runId, status: 'failed' })
+  })
+
+  it('成果物を検証してrunをcompletedにする', async () => {
+    const result = await receiveAnalysisCallback(
+      { analysis_run_id: runId, status: 'completed', callback_token: 'token' },
+      now
+    )
+
+    expect(result).toEqual({ ok: true, value: { analysis_run_id: runId, status: 'completed' } })
+    expect(mocks.markCompleted).toHaveBeenCalledWith(runId, now)
+  })
+
+  it('成果物のtrajectory集合が異なる場合はrunをfailedにする', async () => {
+    mocks.getHeatmap.mockResolvedValueOnce(
+      JSON.stringify({ ...artifact, trajectories: [], input_trajectory_count: 1 })
+    )
+
+    const result = await receiveAnalysisCallback(
+      { analysis_run_id: runId, status: 'completed', callback_token: 'token' },
+      now
+    )
+
+    expect(result).toEqual({ ok: false, error: { type: 'CALLBACK_ARTIFACT_INVALID' } })
+    expect(mocks.markFailed).toHaveBeenCalledWith(runId, 'ARTIFACT_VALIDATION_FAILED', now)
+  })
+
+  it('未知の失敗codeを正規化してfailedにする', async () => {
+    const result = await receiveAnalysisCallback(
+      {
+        analysis_run_id: runId,
+        status: 'failed',
+        callback_token: 'token',
+        error_code: 'UNKNOWN',
+        error_message: 'detail',
+      },
+      now
+    )
+
+    expect(result).toEqual({ ok: true, value: { analysis_run_id: runId, status: 'failed' } })
+    expect(mocks.markFailed).toHaveBeenCalledWith(runId, 'ANALYSIS_PROCESSING_FAILED', now)
+  })
+
+  it('同じcompleted callbackの再送は成功する', async () => {
+    mocks.findRun.mockResolvedValueOnce({ id: runId, status: 'completed' })
+
+    const result = await receiveAnalysisCallback(
+      { analysis_run_id: runId, status: 'completed', callback_token: 'token' },
+      now
+    )
+
+    expect(result).toEqual({ ok: true, value: { analysis_run_id: runId, status: 'completed' } })
+    expect(mocks.getHeatmap).not.toHaveBeenCalled()
+  })
+
+  it('不正tokenは401相当のerrorにする', async () => {
+    mocks.verifyToken.mockReturnValueOnce({ ok: false, error: 'CALLBACK_TOKEN_INVALID' })
+
+    const result = await receiveAnalysisCallback(
+      { analysis_run_id: runId, status: 'completed', callback_token: 'invalid' },
+      now
+    )
+
+    expect(result).toEqual({ ok: false, error: { type: 'CALLBACK_TOKEN_INVALID' } })
+    expect(mocks.findRun).not.toHaveBeenCalled()
+  })
+})

--- a/apps/kaede/src/usecases/analysis-runs/receive-callback.ts
+++ b/apps/kaede/src/usecases/analysis-runs/receive-callback.ts
@@ -1,0 +1,108 @@
+import type { AnalysisCallbackRequest } from '../../schemas/analysis-runs.js'
+import { stayHeatmapArtifactSchema } from '../../schemas/analysis-runs.js'
+import {
+  findAnalysisRunById,
+  listAnalysisRunTrajectories,
+  markAnalysisRunCompleted,
+  markAnalysisRunFailed,
+} from '../../services/analysis-runs/index.js'
+import {
+  doesAnalysisTrajectoryCsvObjectExist,
+  getAnalysisHeatmapObjectText,
+} from '../../services/storage/index.js'
+import { verifyAnalysisCallbackToken } from '../../services/trajectories/callback-token.js'
+
+const nozomiErrorCodes = new Set([
+  'TRAJECTORY_DOWNLOAD_FAILED',
+  'INVALID_TRAJECTORY_CSV',
+  'ANALYSIS_PROCESSING_FAILED',
+  'ARTIFACT_UPLOAD_FAILED',
+])
+
+type CallbackError =
+  | { type: 'CALLBACK_TOKEN_INVALID' | 'CALLBACK_TOKEN_EXPIRED' }
+  | { type: 'ANALYSIS_RUN_NOT_FOUND' }
+  | { type: 'CALLBACK_ANALYSIS_RUN_MISMATCH' }
+  | { type: 'CALLBACK_ALREADY_FINALIZED' }
+  | { type: 'CALLBACK_ARTIFACT_INVALID' }
+
+export type ReceiveAnalysisCallbackResult =
+  | { ok: true; value: { analysis_run_id: string; status: 'completed' | 'failed' } }
+  | { ok: false; error: CallbackError }
+
+const normalizedErrorCode = (code: string) =>
+  nozomiErrorCodes.has(code) ? code : 'ANALYSIS_PROCESSING_FAILED'
+
+export const receiveAnalysisCallback = async (
+  payload: AnalysisCallbackRequest,
+  now: Date = new Date()
+): Promise<ReceiveAnalysisCallbackResult> => {
+  const verified = verifyAnalysisCallbackToken(payload.callback_token, now)
+  if (!verified.ok) return { ok: false, error: { type: verified.error } }
+  if (verified.value.analysisRunId !== payload.analysis_run_id) {
+    return { ok: false, error: { type: 'CALLBACK_ANALYSIS_RUN_MISMATCH' } }
+  }
+
+  const run = await findAnalysisRunById(payload.analysis_run_id)
+  if (!run) return { ok: false, error: { type: 'ANALYSIS_RUN_NOT_FOUND' } }
+
+  if (payload.status === 'failed') {
+    const errorCode = normalizedErrorCode(payload.error_code)
+    if (run.status === 'failed' && run.error_code === errorCode) {
+      return { ok: true, value: { analysis_run_id: run.id, status: 'failed' } }
+    }
+    if (run.status === 'completed' || run.status === 'failed') {
+      return { ok: false, error: { type: 'CALLBACK_ALREADY_FINALIZED' } }
+    }
+    const failed = await markAnalysisRunFailed(run.id, errorCode, now)
+    if (!failed) return { ok: false, error: { type: 'CALLBACK_ALREADY_FINALIZED' } }
+    return { ok: true, value: { analysis_run_id: failed.id, status: 'failed' } }
+  }
+
+  if (run.status === 'completed') {
+    return { ok: true, value: { analysis_run_id: run.id, status: 'completed' } }
+  }
+  if (run.status !== 'processing') {
+    return { ok: false, error: { type: 'CALLBACK_ALREADY_FINALIZED' } }
+  }
+
+  const inputs = await listAnalysisRunTrajectories(run.id)
+  const heatmapText = await getAnalysisHeatmapObjectText(run.organization_id, run.id)
+  let heatmap: unknown
+  try {
+    heatmap = heatmapText === undefined ? undefined : JSON.parse(heatmapText)
+  } catch {
+    heatmap = undefined
+  }
+  const parsed = stayHeatmapArtifactSchema.safeParse(heatmap)
+  const expectedIds = new Set(inputs.map((input) => input.trajectory_id))
+  const artifactIds = parsed.success
+    ? new Set(parsed.data.trajectories.map((trajectory) => trajectory.trajectory_id))
+    : new Set<string>()
+  const idsMatch =
+    parsed.success &&
+    expectedIds.size === artifactIds.size &&
+    [...expectedIds].every((id) => artifactIds.has(id))
+  const csvObjectsExist = idsMatch
+    ? await Promise.all(
+        inputs.map((input) =>
+          doesAnalysisTrajectoryCsvObjectExist(run.organization_id, run.id, input.trajectory_id)
+        )
+      )
+    : []
+
+  if (!idsMatch || csvObjectsExist.some((exists) => !exists)) {
+    await markAnalysisRunFailed(run.id, 'ARTIFACT_VALIDATION_FAILED', now)
+    return { ok: false, error: { type: 'CALLBACK_ARTIFACT_INVALID' } }
+  }
+
+  const completed = await markAnalysisRunCompleted(run.id, now)
+  if (completed) {
+    return { ok: true, value: { analysis_run_id: completed.id, status: 'completed' } }
+  }
+  const latest = await findAnalysisRunById(run.id)
+  if (latest?.status === 'completed') {
+    return { ok: true, value: { analysis_run_id: latest.id, status: 'completed' } }
+  }
+  return { ok: false, error: { type: 'CALLBACK_ALREADY_FINALIZED' } }
+}


### PR DESCRIPTION
## 関連Issue

- https://github.com/kajiLabTeam/okarin/issues/200

## 作業内容

- analysis run用callback endpointを追加
- HMAC callback tokenを検証
- heatmap JSONのschemaと入力trajectory ID集合を検証
- 全派生CSV objectの存在を確認
- completed・failed状態を更新
- 未知のNozomiエラーコードを正規化
- 同一callback再送を冪等に処理
- PoC方針に従いSHA-256・size・Content-Typeの厳密検証は追加しない

## 検証

- `mise exec -- pnpm lint`
- `mise exec -- pnpm typecheck`
- unit test: 74 files / 418 tests passed
- `git diff --check`
