### PR TITLE
分析結果の参照APIを追加

### DIFF
--- a/apps/kaede/src/routes/organizations/analysis-runs.ts
+++ b/apps/kaede/src/routes/organizations/analysis-runs.ts
@@ -1,0 +1,150 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { requireRequestActor } from '../../middleware/request-actor-context.js'
+import type { RequestActorContext } from '../../middleware/request-actor-context.js'
+import {
+  analysisRunDetailResponseSchema,
+  analysisRunListResponseSchema,
+  analysisRunParamsSchema,
+  analysisRunResultResponseSchema,
+  listAnalysisRunsQuerySchema,
+} from '../../schemas/analysis-runs.js'
+import { errorResponseSchema } from '../../schemas/common.js'
+import { organizationIdParamsSchema } from '../../schemas/organizations.js'
+import {
+  getAnalysisRun,
+  getAnalysisRunResult,
+  listAnalysisRuns,
+} from '../../usecases/analysis-runs/get-analysis-runs.js'
+
+const errorResponse = {
+  description: 'analysis run request failed',
+  content: { 'application/json': { schema: errorResponseSchema } },
+} as const
+
+const toError = (error: {
+  type: string
+  status?: string
+  errorCode?: string | null
+}): { status: 400 | 403 | 404 | 409; body: { error_code: string; error_message: string } } => {
+  switch (error.type) {
+    case 'AUTH_DASHBOARD_FORBIDDEN':
+    case 'AUTH_ORGANIZATION_FORBIDDEN':
+      return { status: 403, body: { error_code: error.type, error_message: 'permission denied' } }
+    case 'ANALYSIS_RUN_NOT_FOUND':
+      return {
+        status: 404,
+        body: { error_code: error.type, error_message: 'analysis run not found' },
+      }
+    case 'ANALYSIS_RESULT_NOT_READY':
+      return {
+        status: 409,
+        body: {
+          error_code: error.errorCode ?? error.type,
+          error_message: `analysis result is not available (${error.status})`,
+        },
+      }
+    case 'ANALYSIS_RESULT_INVALID':
+      return {
+        status: 409,
+        body: { error_code: error.type, error_message: 'analysis result is invalid' },
+      }
+    default:
+      return { status: 400, body: { error_code: error.type, error_message: 'invalid request' } }
+  }
+}
+
+export const registerAnalysisRunRoutes = (app: OpenAPIHono) => {
+  const listRoute = createRoute({
+    method: 'get',
+    path: '/{organizationId}/analysis-runs',
+    tags: ['Organizations'],
+    request: { params: organizationIdParamsSchema, query: listAnalysisRunsQuerySchema },
+    responses: {
+      200: {
+        description: 'analysis runs',
+        content: { 'application/json': { schema: analysisRunListResponseSchema } },
+      },
+      400: errorResponse,
+      403: errorResponse,
+      404: errorResponse,
+      409: errorResponse,
+    },
+  })
+  app.openapi(listRoute, async (c) => {
+    const { organizationId } = c.req.valid('param')
+    const result = await listAnalysisRuns(
+      requireRequestActor(c as RequestActorContext),
+      organizationId,
+      c.req.valid('query')
+    )
+    if (result.ok) return c.json(result.value, 200)
+    const error = toError(result.error)
+    if (error.status === 403) return c.json(error.body, 403)
+    if (error.status === 404) return c.json(error.body, 404)
+    if (error.status === 409) return c.json(error.body, 409)
+    return c.json(error.body, 400)
+  })
+
+  const detailRoute = createRoute({
+    method: 'get',
+    path: '/{organizationId}/analysis-runs/{analysisRunId}',
+    tags: ['Organizations'],
+    request: { params: analysisRunParamsSchema },
+    responses: {
+      200: {
+        description: 'analysis run',
+        content: { 'application/json': { schema: analysisRunDetailResponseSchema } },
+      },
+      403: errorResponse,
+      404: errorResponse,
+      400: errorResponse,
+      409: errorResponse,
+    },
+  })
+  app.openapi(detailRoute, async (c) => {
+    const { organizationId, analysisRunId } = c.req.valid('param')
+    const result = await getAnalysisRun(
+      requireRequestActor(c as RequestActorContext),
+      organizationId,
+      analysisRunId
+    )
+    if (result.ok) return c.json(result.value, 200)
+    const error = toError(result.error)
+    if (error.status === 403) return c.json(error.body, 403)
+    if (error.status === 404) return c.json(error.body, 404)
+    if (error.status === 409) return c.json(error.body, 409)
+    return c.json(error.body, 400)
+  })
+
+  const resultRoute = createRoute({
+    method: 'get',
+    path: '/{organizationId}/analysis-runs/{analysisRunId}/result',
+    tags: ['Organizations'],
+    request: { params: analysisRunParamsSchema },
+    responses: {
+      200: {
+        description: 'analysis result',
+        content: { 'application/json': { schema: analysisRunResultResponseSchema } },
+      },
+      403: errorResponse,
+      404: errorResponse,
+      409: errorResponse,
+      400: errorResponse,
+    },
+  })
+  app.openapi(resultRoute, async (c) => {
+    const { organizationId, analysisRunId } = c.req.valid('param')
+    const result = await getAnalysisRunResult(
+      requireRequestActor(c as RequestActorContext),
+      organizationId,
+      analysisRunId
+    )
+    if (result.ok) return c.json(result.value, 200)
+    const error = toError(result.error)
+    if (error.status === 403) return c.json(error.body, 403)
+    if (error.status === 404) return c.json(error.body, 404)
+    if (error.status === 409) return c.json(error.body, 409)
+    return c.json(error.body, 400)
+  })
+}

--- a/apps/kaede/src/routes/organizations/index.ts
+++ b/apps/kaede/src/routes/organizations/index.ts
@@ -1,4 +1,5 @@
 import { OpenAPIHono } from '@hono/zod-openapi'
+import { registerAnalysisRunRoutes } from './analysis-runs.js'
 import { registerCreateOrganizationBuildingFloorRoute } from './create-organization-building-floor.js'
 import { registerCreateOrganizationBuildingRoute } from './create-organization-building.js'
 import { registerCreateOrganizationMembershipRoute } from './create-organization-membership.js'
@@ -34,3 +35,4 @@ registerCreateOrganizationUserRoute(organizationsRoutes)
 registerCreateOrganizationUserActivationLinkRoute(organizationsRoutes)
 registerCreateOrganizationMembershipRoute(organizationsRoutes)
 registerCreateStayHeatmapRoute(organizationsRoutes)
+registerAnalysisRunRoutes(organizationsRoutes)

--- a/apps/kaede/src/schemas/analysis-runs.ts
+++ b/apps/kaede/src/schemas/analysis-runs.ts
@@ -1,5 +1,6 @@
 import { z } from '@hono/zod-openapi'
 import { uuidSchema } from './common.js'
+import { paginationMetadataSchema, paginationQuerySchema } from './pagination.js'
 
 const parameterSchema = (minimum: number, maximum: number, defaultValue: number) =>
   z
@@ -50,3 +51,116 @@ export const createStayHeatmapErrorResponseSchema = z
 
 export type CreateStayHeatmapRequest = z.infer<typeof createStayHeatmapRequestSchema>
 export type StayHeatmapParameters = z.infer<typeof stayHeatmapParametersSchema>
+
+const analysisRunStatusSchema = z.enum(['accepted', 'processing', 'completed', 'failed'])
+const trajectoryCountsSchema = z.object({
+  input: z.number().int().nonnegative(),
+  included: z.number().int().nonnegative(),
+  excluded_deleted: z.number().int().nonnegative(),
+})
+const analysisRunErrorSchema = z.object({ code: z.string(), message: z.string() }).nullable()
+const nullableDateTimeSchema = z.string().datetime().nullable()
+
+export const analysisRunParamsSchema = z.object({
+  organizationId: uuidSchema,
+  analysisRunId: uuidSchema,
+})
+
+export const listAnalysisRunsQuerySchema = paginationQuerySchema
+  .extend({
+    analysis_type: z.string().min(1).optional(),
+    status: analysisRunStatusSchema.optional(),
+    floor_id: uuidSchema.optional(),
+  })
+  .strict()
+
+const analysisRunSummarySchema = z.object({
+  analysis_run_id: uuidSchema,
+  analysis_type: z.string(),
+  status: analysisRunStatusSchema,
+  floor_id: uuidSchema,
+  parameters: stayHeatmapParametersSchema,
+  definition_version: z.string(),
+  trajectory_counts: trajectoryCountsSchema,
+  error: analysisRunErrorSchema,
+  created_at: z.string().datetime(),
+  updated_at: z.string().datetime(),
+  finished_at: nullableDateTimeSchema,
+})
+
+export const analysisRunListResponseSchema = z.object({
+  analysis_runs: z.array(analysisRunSummarySchema),
+  pagination: paginationMetadataSchema,
+})
+
+export const analysisRunDetailResponseSchema = analysisRunSummarySchema.extend({
+  trajectories: z.array(
+    z.object({
+      trajectory_id: uuidSchema,
+      seq: z.number().int().nonnegative(),
+      deleted: z.boolean(),
+    })
+  ),
+  started_at: nullableDateTimeSchema,
+  deadline_at: z.string().datetime(),
+})
+
+const heatmapCellSchema = z.object({
+  grid_column: z.number().int().nonnegative(),
+  grid_row: z.number().int().nonnegative(),
+  stay_cell_visit_count: z.number().int().positive(),
+})
+
+export const stayHeatmapArtifactSchema = z
+  .object({
+    schema_version: z.literal('1.0'),
+    definition_version: z.string(),
+    parameters: stayHeatmapParametersSchema,
+    floor_map: z.object({
+      width_px: z.number().int().positive(),
+      height_px: z.number().int().positive(),
+      scale_m_per_px: z.number().positive(),
+    }),
+    grid: z.object({
+      size_m: z.number().positive(),
+      column_count: z.number().int().positive(),
+      row_count: z.number().int().positive(),
+    }),
+    input_trajectory_count: z.number().int().nonnegative(),
+    trajectories: z.array(
+      z.object({ trajectory_id: uuidSchema, cells: z.array(heatmapCellSchema) })
+    ),
+  })
+  .strict()
+
+export const analysisRunResultResponseSchema = z.object({
+  analysis_run_id: uuidSchema,
+  analysis_type: z.literal('stay_heatmap'),
+  status: z.literal('completed'),
+  definition_version: z.string(),
+  floor: z.object({
+    id: uuidSchema,
+    map_width_px: z.number().int().positive(),
+    map_height_px: z.number().int().positive(),
+    scale_m_per_px: z.number().positive(),
+  }),
+  parameters: stayHeatmapParametersSchema,
+  grid: z.object({
+    column_count: z.number().int().positive(),
+    row_count: z.number().int().positive(),
+    cells: z.array(
+      z.object({
+        grid_column: z.number().int().nonnegative(),
+        grid_row: z.number().int().nonnegative(),
+        total_stay_cell_visit_count: z.number().int().positive(),
+        mean_stay_cell_visit_count: z.number().nonnegative(),
+      })
+    ),
+  }),
+  trajectory_counts: trajectoryCountsSchema,
+  trajectory_csvs: z.array(
+    z.object({ trajectory_id: uuidSchema, download_url: z.string().url(), expires_at: z.string() })
+  ),
+})
+
+export type ListAnalysisRunsQuery = z.infer<typeof listAnalysisRunsQuerySchema>

--- a/apps/kaede/src/services/analysis-runs/analysis-run-repository.ts
+++ b/apps/kaede/src/services/analysis-runs/analysis-run-repository.ts
@@ -1,10 +1,20 @@
 import type { Insertable, Selectable } from 'kysely'
+import { sql } from 'kysely'
+import type { PaginationOptions } from '../../schemas/pagination.js'
 import type { AnalysisRuns, AnalysisRunTrajectories, JsonObject } from '../db/generated.js'
 import { db } from '../db/index.js'
 import type { DbExecutor } from '../executor.js'
 
 export type AnalysisRun = Selectable<AnalysisRuns>
 export type AnalysisRunTrajectory = Selectable<AnalysisRunTrajectories>
+export type AnalysisRunPageRow = AnalysisRun & { cursor_created_at: string }
+export type AnalysisRunTrajectoryState = AnalysisRunTrajectory & { deleted: boolean }
+
+export interface ListAnalysisRunsOptions extends PaginationOptions {
+  analysisType?: string
+  status?: string
+  floorId?: string
+}
 
 type NewAnalysisRun = Omit<Insertable<AnalysisRuns>, 'parameters'> & {
   parameters: JsonObject
@@ -46,6 +56,55 @@ export const findAnalysisRunById = async (
     .executeTakeFirst()
 }
 
+export const findOrganizationAnalysisRunById = async (
+  organizationId: string,
+  analysisRunId: string,
+  executor: DbExecutor = db
+): Promise<AnalysisRun | undefined> => {
+  return executor
+    .selectFrom('analysis_runs')
+    .selectAll()
+    .where('organization_id', '=', organizationId)
+    .where('id', '=', analysisRunId)
+    .executeTakeFirst()
+}
+
+export const listOrganizationAnalysisRuns = async (
+  organizationId: string,
+  options: ListAnalysisRunsOptions,
+  executor: DbExecutor = db
+): Promise<{ rows: AnalysisRunPageRow[]; totalCount: number }> => {
+  const scope = () => {
+    let query = executor.selectFrom('analysis_runs').where('organization_id', '=', organizationId)
+    if (options.analysisType) query = query.where('analysis_type', '=', options.analysisType)
+    if (options.status) query = query.where('status', '=', options.status)
+    if (options.floorId) query = query.where('floor_id', '=', options.floorId)
+    return query
+  }
+  let rowsQuery = scope()
+    .selectAll()
+    .select(
+      sql<string>`to_char(analysis_runs.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`.as(
+        'cursor_created_at'
+      )
+    )
+    .orderBy('created_at', 'desc')
+    .orderBy('id', 'desc')
+    .limit(options.limit + 1)
+  if (options.cursor) {
+    rowsQuery = rowsQuery.where(
+      sql<boolean>`(analysis_runs.created_at, analysis_runs.id) < (${options.cursor.createdAt}::timestamptz, ${options.cursor.id}::uuid)`
+    )
+  }
+  const [rows, count] = await Promise.all([
+    rowsQuery.execute(),
+    scope()
+      .select(({ fn }) => fn.countAll<string>().as('count'))
+      .executeTakeFirstOrThrow(),
+  ])
+  return { rows, totalCount: Number(count.count) }
+}
+
 export const listAnalysisRunTrajectories = async (
   analysisRunId: string,
   executor: DbExecutor = db
@@ -56,6 +115,26 @@ export const listAnalysisRunTrajectories = async (
     .where('analysis_run_id', '=', analysisRunId)
     .orderBy('seq', 'asc')
     .execute()
+}
+
+export const listAnalysisRunTrajectoryStates = async (
+  analysisRunId: string,
+  executor: DbExecutor = db
+): Promise<AnalysisRunTrajectoryState[]> => {
+  const rows = await executor
+    .selectFrom('analysis_run_trajectories')
+    .innerJoin('trajectories', 'trajectories.id', 'analysis_run_trajectories.trajectory_id')
+    .select([
+      'analysis_run_trajectories.analysis_run_id',
+      'analysis_run_trajectories.trajectory_id',
+      'analysis_run_trajectories.seq',
+      'trajectories.deleted_at',
+    ])
+    .where('analysis_run_id', '=', analysisRunId)
+    .orderBy('seq', 'asc')
+    .execute()
+
+  return rows.map(({ deleted_at, ...row }) => ({ ...row, deleted: deleted_at !== null }))
 }
 
 export const markAnalysisRunProcessing = async (

--- a/apps/kaede/src/services/analysis-runs/index.ts
+++ b/apps/kaede/src/services/analysis-runs/index.ts
@@ -1,12 +1,20 @@
 export {
   findAnalysisRunById,
+  findOrganizationAnalysisRunById,
   insertAnalysisRun,
   insertAnalysisRunTrajectories,
   listAnalysisRunTrajectories,
+  listAnalysisRunTrajectoryStates,
+  listOrganizationAnalysisRuns,
   markAnalysisRunCompleted,
   markAnalysisRunFailed,
   markAnalysisRunProcessing,
   markTimedOutAnalysisRunsFailed,
 } from './analysis-run-repository.js'
 export { expireTimedOutAnalysisRuns } from './timeout-service.js'
-export type { AnalysisRun, AnalysisRunTrajectory } from './analysis-run-repository.js'
+export type {
+  AnalysisRun,
+  AnalysisRunPageRow,
+  AnalysisRunTrajectory,
+  AnalysisRunTrajectoryState,
+} from './analysis-run-repository.js'

--- a/apps/kaede/src/services/storage/index.ts
+++ b/apps/kaede/src/services/storage/index.ts
@@ -2,6 +2,7 @@ export {
   deleteFloorMapObject,
   doesTrajectoryAnalyzedResultObjectExist,
   getTrajectoryAnalyzedResultObjectText,
+  getAnalysisHeatmapObjectText,
   listRecordingRawObjectKeys,
   putFloorMapObject,
 } from './object-store.js'

--- a/apps/kaede/src/services/storage/object-store.ts
+++ b/apps/kaede/src/services/storage/object-store.ts
@@ -7,6 +7,7 @@ import {
 } from '@aws-sdk/client-s3'
 import {
   buildRecordingRawObjectPrefix,
+  buildAnalysisHeatmapObjectKey,
   buildTrajectoryAnalyzedResultObjectKey,
   getFloorMapContentType,
 } from './presigned-url.js'
@@ -128,6 +129,31 @@ export const getTrajectoryAnalyzedResultObjectText = async (
       return undefined
     }
 
+    throw error
+  }
+}
+
+export const getAnalysisHeatmapObjectText = async (
+  organizationId: string,
+  analysisRunId: string
+): Promise<string | undefined> => {
+  const objectKey = buildAnalysisHeatmapObjectKey(organizationId, analysisRunId)
+  const { config, internalClient } = getS3Context()
+
+  try {
+    const response = await internalClient.send(
+      new GetObjectCommand({ Bucket: config.bucket, Key: objectKey })
+    )
+    return response.Body ? await response.Body.transformToString() : ''
+  } catch (error) {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'name' in error &&
+      (error.name === 'NotFound' || error.name === 'NoSuchKey')
+    ) {
+      return undefined
+    }
     throw error
   }
 }

--- a/apps/kaede/src/usecases/analysis-runs/get-analysis-runs.test.ts
+++ b/apps/kaede/src/usecases/analysis-runs/get-analysis-runs.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import { getAnalysisRunResult } from './get-analysis-runs.js'
+
+const mocks = vi.hoisted(() => ({
+  expire: vi.fn(),
+  findRun: vi.fn(),
+  listStates: vi.fn(),
+  getHeatmap: vi.fn(),
+  issueCsvUrl: vi.fn(),
+}))
+
+vi.mock('../../services/analysis-runs/index.js', () => ({
+  expireTimedOutAnalysisRuns: mocks.expire,
+  findOrganizationAnalysisRunById: mocks.findRun,
+  listAnalysisRunTrajectoryStates: mocks.listStates,
+  listOrganizationAnalysisRuns: vi.fn(),
+}))
+vi.mock('../../services/storage/index.js', () => ({
+  getAnalysisHeatmapObjectText: mocks.getHeatmap,
+  issueAnalysisTrajectoryCsvDownloadUrl: mocks.issueCsvUrl,
+}))
+
+const organizationId = '11111111-1111-4111-8111-111111111111'
+const runId = '22222222-2222-4222-8222-222222222222'
+const floorId = '33333333-3333-4333-8333-333333333333'
+const activeId = '44444444-4444-4444-8444-444444444444'
+const deletedId = '55555555-5555-4555-8555-555555555555'
+const actor: RequestActor = {
+  type: 'user',
+  user_id: '66666666-6666-4666-8666-666666666666',
+  email: 'manager@example.com',
+  global_role: 'none',
+  account_state: 'active',
+  memberships: [{ organization_id: organizationId, organization_name: 'Test', role: 'manager' }],
+}
+
+describe('getAnalysisRunResult', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.expire.mockResolvedValue(0)
+    mocks.findRun.mockResolvedValue({
+      id: runId,
+      organization_id: organizationId,
+      floor_id: floorId,
+      analysis_type: 'stay_heatmap',
+      status: 'completed',
+      definition_version: 'original-v1',
+      parameters: { speed_threshold_mps: 0.5, grid_size_m: 1 },
+      error_code: null,
+    })
+    mocks.listStates.mockResolvedValue([
+      { analysis_run_id: runId, trajectory_id: activeId, seq: 0, deleted: false },
+      { analysis_run_id: runId, trajectory_id: deletedId, seq: 1, deleted: true },
+    ])
+    mocks.getHeatmap.mockResolvedValue(
+      JSON.stringify({
+        schema_version: '1.0',
+        definition_version: 'original-v1',
+        parameters: { speed_threshold_mps: 0.5, grid_size_m: 1 },
+        floor_map: { width_px: 100, height_px: 200, scale_m_per_px: 0.01 },
+        grid: { size_m: 1, column_count: 1, row_count: 2 },
+        input_trajectory_count: 2,
+        trajectories: [
+          {
+            trajectory_id: activeId,
+            cells: [{ grid_column: 0, grid_row: 0, stay_cell_visit_count: 3 }],
+          },
+          {
+            trajectory_id: deletedId,
+            cells: [{ grid_column: 0, grid_row: 0, stay_cell_visit_count: 7 }],
+          },
+        ],
+      })
+    )
+    mocks.issueCsvUrl.mockResolvedValue({
+      downloadUrl: 'https://storage.test/stay.csv',
+      expiresAt: '2026-08-04T00:15:00.000Z',
+    })
+  })
+
+  it('削除済みtrajectoryを除外してcellとCSVを返す', async () => {
+    const result = await getAnalysisRunResult(actor, organizationId, runId)
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        trajectory_counts: { input: 2, included: 1, excluded_deleted: 1 },
+        grid: {
+          cells: [
+            {
+              grid_column: 0,
+              grid_row: 0,
+              total_stay_cell_visit_count: 3,
+              mean_stay_cell_visit_count: 3,
+            },
+          ],
+        },
+        trajectory_csvs: [{ trajectory_id: activeId }],
+      },
+    })
+    expect(mocks.issueCsvUrl).toHaveBeenCalledTimes(1)
+    expect(mocks.expire).toHaveBeenCalledOnce()
+  })
+
+  it('processingの結果取得を拒否する', async () => {
+    mocks.findRun.mockResolvedValue({ status: 'processing', error_code: null })
+
+    await expect(getAnalysisRunResult(actor, organizationId, runId)).resolves.toEqual({
+      ok: false,
+      error: { type: 'ANALYSIS_RESULT_NOT_READY', status: 'processing', errorCode: null },
+    })
+  })
+})

--- a/apps/kaede/src/usecases/analysis-runs/get-analysis-runs.ts
+++ b/apps/kaede/src/usecases/analysis-runs/get-analysis-runs.ts
@@ -1,0 +1,221 @@
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import {
+  stayHeatmapArtifactSchema,
+  stayHeatmapParametersSchema,
+} from '../../schemas/analysis-runs.js'
+import type { ListAnalysisRunsQuery } from '../../schemas/analysis-runs.js'
+import { buildPaginatedResult, decodePaginationCursor } from '../../schemas/pagination.js'
+import {
+  expireTimedOutAnalysisRuns,
+  findOrganizationAnalysisRunById,
+  listAnalysisRunTrajectoryStates,
+  listOrganizationAnalysisRuns,
+} from '../../services/analysis-runs/index.js'
+import {
+  getAnalysisHeatmapObjectText,
+  issueAnalysisTrajectoryCsvDownloadUrl,
+} from '../../services/storage/index.js'
+import type { AuthorizationError } from '../authorization.js'
+import { requireOrganizationManager } from '../authorization.js'
+
+type ReadError =
+  | AuthorizationError
+  | { type: 'PAGINATION_CURSOR_INVALID' }
+  | { type: 'ANALYSIS_RUN_NOT_FOUND' }
+  | { type: 'ANALYSIS_RESULT_NOT_READY'; status: string; errorCode: string | null }
+  | { type: 'ANALYSIS_RESULT_INVALID' }
+
+const errorMessage = (code: string) => {
+  const messages: Record<string, string> = {
+    INVALID_TRAJECTORY_CSV: 'Trajectory data is invalid.',
+    ANALYSIS_TIMEOUT: 'Analysis did not complete within the time limit.',
+  }
+  return messages[code] ?? 'Analysis processing failed.'
+}
+
+const serializeRun = async (run: Awaited<ReturnType<typeof findOrganizationAnalysisRunById>>) => {
+  if (!run) throw new Error('analysis run is required')
+  const trajectories = await listAnalysisRunTrajectoryStates(run.id)
+  const included = trajectories.filter((trajectory) => !trajectory.deleted).length
+  return {
+    analysis_run_id: run.id,
+    analysis_type: run.analysis_type,
+    status: run.status as 'accepted' | 'processing' | 'completed' | 'failed',
+    floor_id: run.floor_id,
+    parameters: stayHeatmapParametersSchema.parse(run.parameters),
+    definition_version: run.definition_version,
+    trajectory_counts: {
+      input: trajectories.length,
+      included,
+      excluded_deleted: trajectories.length - included,
+    },
+    error: run.error_code ? { code: run.error_code, message: errorMessage(run.error_code) } : null,
+    created_at: run.created_at.toISOString(),
+    updated_at: run.updated_at.toISOString(),
+    finished_at: run.finished_at?.toISOString() ?? null,
+    started_at: run.started_at?.toISOString() ?? null,
+    deadline_at: run.deadline_at.toISOString(),
+    trajectories: trajectories.map(({ trajectory_id, seq, deleted }) => ({
+      trajectory_id,
+      seq,
+      deleted,
+    })),
+  }
+}
+
+const authorize = (actor: RequestActor, organizationId: string) =>
+  requireOrganizationManager(actor, organizationId)
+
+export const listAnalysisRuns = async (
+  actor: RequestActor,
+  organizationId: string,
+  query: ListAnalysisRunsQuery
+) => {
+  const authorization = authorize(actor, organizationId)
+  if (!authorization.ok) return authorization
+  const cursor = query.cursor
+    ? decodePaginationCursor(query.cursor)
+    : { ok: true as const, value: null }
+  if (!cursor.ok) return cursor
+
+  await expireTimedOutAnalysisRuns()
+  const page = await listOrganizationAnalysisRuns(organizationId, {
+    limit: query.limit,
+    cursor: cursor.value,
+    analysisType: query.analysis_type,
+    status: query.status,
+    floorId: query.floor_id,
+  })
+  const paginated = buildPaginatedResult(page.rows, query.limit, page.totalCount)
+  const items = await Promise.all(paginated.items.map((run) => serializeRun(run)))
+  return {
+    ok: true as const,
+    value: {
+      analysis_runs: items.map(
+        ({ trajectories: _, started_at: __, deadline_at: ___, ...run }) => run
+      ),
+      pagination: { next_cursor: paginated.nextCursor, total_count: paginated.totalCount },
+    },
+  }
+}
+
+export const getAnalysisRun = async (
+  actor: RequestActor,
+  organizationId: string,
+  analysisRunId: string
+) => {
+  const authorization = authorize(actor, organizationId)
+  if (!authorization.ok) return authorization
+  await expireTimedOutAnalysisRuns()
+  const run = await findOrganizationAnalysisRunById(organizationId, analysisRunId)
+  if (!run) return { ok: false as const, error: { type: 'ANALYSIS_RUN_NOT_FOUND' as const } }
+  return { ok: true as const, value: await serializeRun(run) }
+}
+
+export const getAnalysisRunResult = async (
+  actor: RequestActor,
+  organizationId: string,
+  analysisRunId: string
+) => {
+  const authorization = authorize(actor, organizationId)
+  if (!authorization.ok) return authorization
+  await expireTimedOutAnalysisRuns()
+  const run = await findOrganizationAnalysisRunById(organizationId, analysisRunId)
+  if (!run) return { ok: false as const, error: { type: 'ANALYSIS_RUN_NOT_FOUND' as const } }
+  if (run.status !== 'completed') {
+    return {
+      ok: false as const,
+      error: {
+        type: 'ANALYSIS_RESULT_NOT_READY' as const,
+        status: run.status,
+        errorCode: run.error_code,
+      },
+    }
+  }
+
+  const [text, trajectories] = await Promise.all([
+    getAnalysisHeatmapObjectText(organizationId, analysisRunId),
+    listAnalysisRunTrajectoryStates(analysisRunId),
+  ])
+  let artifact: ReturnType<typeof stayHeatmapArtifactSchema.safeParse> | undefined
+  try {
+    artifact = text ? stayHeatmapArtifactSchema.safeParse(JSON.parse(text)) : undefined
+  } catch {
+    artifact = undefined
+  }
+  if (!artifact?.success) {
+    return { ok: false as const, error: { type: 'ANALYSIS_RESULT_INVALID' as const } }
+  }
+  const activeIds = new Set(
+    trajectories
+      .filter((trajectory) => !trajectory.deleted)
+      .map((trajectory) => trajectory.trajectory_id)
+  )
+  const totals = new Map<string, { grid_column: number; grid_row: number; total: number }>()
+  for (const trajectory of artifact.data.trajectories) {
+    if (!activeIds.has(trajectory.trajectory_id)) continue
+    for (const cell of trajectory.cells) {
+      const key = `${cell.grid_row}:${cell.grid_column}`
+      const current = totals.get(key)
+      totals.set(key, {
+        grid_column: cell.grid_column,
+        grid_row: cell.grid_row,
+        total: (current?.total ?? 0) + cell.stay_cell_visit_count,
+      })
+    }
+  }
+  const trajectoryCsvs = await Promise.all(
+    trajectories
+      .filter((trajectory) => !trajectory.deleted)
+      .map(async (trajectory) => {
+        const signed = await issueAnalysisTrajectoryCsvDownloadUrl(
+          organizationId,
+          analysisRunId,
+          trajectory.trajectory_id
+        )
+        return {
+          trajectory_id: trajectory.trajectory_id,
+          download_url: signed.downloadUrl,
+          expires_at: signed.expiresAt,
+        }
+      })
+  )
+  const included = activeIds.size
+  const cells = [...totals.values()]
+    .sort((a, b) => a.grid_row - b.grid_row || a.grid_column - b.grid_column)
+    .map(({ total, ...cell }) => ({
+      ...cell,
+      total_stay_cell_visit_count: total,
+      mean_stay_cell_visit_count: Math.round((total / included) * 1_000_000) / 1_000_000,
+    }))
+
+  return {
+    ok: true as const,
+    value: {
+      analysis_run_id: run.id,
+      analysis_type: 'stay_heatmap' as const,
+      status: 'completed' as const,
+      definition_version: run.definition_version,
+      floor: {
+        id: run.floor_id,
+        map_width_px: artifact.data.floor_map.width_px,
+        map_height_px: artifact.data.floor_map.height_px,
+        scale_m_per_px: artifact.data.floor_map.scale_m_per_px,
+      },
+      parameters: stayHeatmapParametersSchema.parse(run.parameters),
+      grid: {
+        column_count: artifact.data.grid.column_count,
+        row_count: artifact.data.grid.row_count,
+        cells: included === 0 ? [] : cells,
+      },
+      trajectory_counts: {
+        input: trajectories.length,
+        included,
+        excluded_deleted: trajectories.length - included,
+      },
+      trajectory_csvs: trajectoryCsvs,
+    },
+  }
+}
+
+export type AnalysisRunReadError = ReadError

--- a/apps/kaede/tests/services/analysis-runs/analysis-run-repository.test.ts
+++ b/apps/kaede/tests/services/analysis-runs/analysis-run-repository.test.ts
@@ -1,9 +1,12 @@
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 import {
   findAnalysisRunById,
+  findOrganizationAnalysisRunById,
   insertAnalysisRun,
   insertAnalysisRunTrajectories,
   listAnalysisRunTrajectories,
+  listAnalysisRunTrajectoryStates,
+  listOrganizationAnalysisRuns,
   markAnalysisRunCompleted,
   markAnalysisRunFailed,
   markAnalysisRunProcessing,
@@ -225,5 +228,54 @@ describe('analysis run repository', () => {
     })
     expect(activeFuture).toMatchObject({ status: 'accepted', finished_at: null })
     expect(terminalCompleted).toMatchObject({ status: 'completed' })
+  })
+
+  it('organization内のrunを絞り込み、trajectoryの削除状態を返す', async () => {
+    const { floor, organization, recording } = await createRecordingFixture(db)
+    const trajectory = await insertTrajectory(
+      {
+        recording_id: recording.id,
+        floor_id: floor.id,
+        organization_id: organization.id,
+        status: 'completed',
+        deleted_at: new Date('2026-08-04T01:00:00.000Z'),
+      },
+      db
+    )
+    const run = await insertAnalysisRun(
+      {
+        organization_id: organization.id,
+        floor_id: floor.id,
+        analysis_type: 'stay_heatmap',
+        parameters: {},
+        definition_version: 'original-v1',
+      },
+      db
+    )
+    await insertAnalysisRunTrajectories(
+      [{ analysis_run_id: run.id, trajectory_id: trajectory.id, seq: 0 }],
+      db
+    )
+
+    const page = await listOrganizationAnalysisRuns(
+      organization.id,
+      {
+        limit: 20,
+        cursor: null,
+        analysisType: 'stay_heatmap',
+        status: 'accepted',
+        floorId: floor.id,
+      },
+      db
+    )
+    const detail = await findOrganizationAnalysisRunById(organization.id, run.id, db)
+    const states = await listAnalysisRunTrajectoryStates(run.id, db)
+
+    expect(page.totalCount).toBe(1)
+    expect(page.rows[0]?.id).toBe(run.id)
+    expect(detail?.id).toBe(run.id)
+    expect(states).toEqual([
+      { analysis_run_id: run.id, trajectory_id: trajectory.id, seq: 0, deleted: true },
+    ])
   })
 })


### PR DESCRIPTION
## 関連Issue

- https://github.com/kajiLabTeam/okarin/issues/200

## 作業内容

- organization配下のanalysis run一覧・詳細・結果APIを追加
- cursor paginationとanalysis type・status・floor filterを追加
- 各取得前に期限超過runをfailedへ更新
- 入力trajectoryの順序と論理削除状態を返却
- 削除済みtrajectoryを除外してcell合計・平均を再集計
- 有効trajectoryだけに15分のCSV download URLを発行
- floor・grid metadataを返却
- 非completedまたは不正artifactの結果取得を`409`にする

## 検証

- `mise exec -- pnpm typecheck`
- `mise exec -- pnpm lint`
- unit test: 73 files / 412 tests passed
- DB test: 23 files / 202 tests passed

route専用テストは10ファイル制限のため含めず、OpenAPI routeを型検査、集計をusecase test、repositoryをDB testで検証しています。
