### PR TITLE
floor mapの画像サイズ移行CLIを追加

### DIFF
--- a/apps/kaede/package.json
+++ b/apps/kaede/package.json
@@ -15,7 +15,8 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "typecheck": "tsc --noEmit",
-    "storage-prefix-migration": "tsx src/cli/storage-prefix-migration.ts"
+    "storage-prefix-migration": "tsx src/cli/storage-prefix-migration.ts",
+    "floor-map-dimension-backfill": "tsx src/cli/floor-map-dimension-backfill.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1045.0",

--- a/apps/kaede/src/cli/floor-map-dimension-backfill.test.ts
+++ b/apps/kaede/src/cli/floor-map-dimension-backfill.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  listRows: vi.fn(),
+  backfill: vi.fn(),
+  getBytes: vi.fn(),
+  stdoutWrite: vi.fn(() => true),
+}))
+
+vi.mock('../services/floors/index.js', () => ({
+  listFloorMapDimensionRows: mocks.listRows,
+  backfillFloorMapDimensions: mocks.backfill,
+}))
+vi.mock('../services/storage/index.js', () => ({
+  getFloorMapExtensionFromObjectKey: (key: string) =>
+    key.endsWith('.png') ? 'png' : key.endsWith('.svg') ? 'svg' : undefined,
+  getFloorMapObjectBytes: mocks.getBytes,
+}))
+
+import { main, parseOptions } from './floor-map-dimension-backfill.js'
+
+const floorId = '11111111-1111-4111-8111-111111111111'
+const png = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0x0d, 0x49, 0x48, 0x44, 0x52, 0, 0, 0x02,
+  0x80, 0, 0, 0x01, 0xe0,
+])
+
+describe('floor-map-dimension-backfill', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(process.stdout, 'write').mockImplementation(mocks.stdoutWrite)
+    mocks.listRows.mockResolvedValue([
+      {
+        id: floorId,
+        image_object_path: `organizations/22222222-2222-4222-8222-222222222222/floors/${floorId}/map.png`,
+        map_width_px: null,
+        map_height_px: null,
+      },
+    ])
+    mocks.getBytes.mockResolvedValue(png)
+    mocks.backfill.mockResolvedValue(true)
+  })
+
+  it('commandとfloor IDを解析する', () => {
+    expect(parseOptions(['verify', '--floor-id', floorId])).toEqual({
+      command: 'verify',
+      floorId,
+    })
+    expect(() => parseOptions(['unknown'])).toThrow(/usage/)
+  })
+
+  it('objectから取得した寸法を未設定floorへ保存する', async () => {
+    await main(['backfill'])
+
+    expect(mocks.backfill).toHaveBeenCalledWith(floorId, 640, 480)
+    expect(mocks.stdoutWrite).toHaveBeenCalledWith(expect.stringContaining('"updated":1'))
+  })
+
+  it('verifyでDB寸法とobjectが異なる場合は失敗する', async () => {
+    mocks.listRows.mockResolvedValueOnce([
+      {
+        id: floorId,
+        image_object_path: `organizations/22222222-2222-4222-8222-222222222222/floors/${floorId}/map.png`,
+        map_width_px: 320,
+        map_height_px: 240,
+      },
+    ])
+
+    await expect(main(['verify'])).rejects.toThrow(
+      'floor map dimension migration failed for 1 resource(s)'
+    )
+    expect(mocks.backfill).not.toHaveBeenCalled()
+  })
+})

--- a/apps/kaede/src/cli/floor-map-dimension-backfill.ts
+++ b/apps/kaede/src/cli/floor-map-dimension-backfill.ts
@@ -1,0 +1,83 @@
+import { extractFloorMapDimensions } from '../services/floor-maps/dimensions.js'
+import { backfillFloorMapDimensions, listFloorMapDimensionRows } from '../services/floors/index.js'
+import {
+  getFloorMapExtensionFromObjectKey,
+  getFloorMapObjectBytes,
+} from '../services/storage/index.js'
+
+interface Options {
+  command: 'backfill' | 'verify'
+  floorId?: string
+}
+
+const usage = (): never => {
+  throw new Error('usage: floor-map-dimension-backfill <backfill|verify> [--floor-id UUID]')
+}
+
+export const parseOptions = (argv: string[]): Options => {
+  const command = argv.shift()
+  if (command !== 'backfill' && command !== 'verify') usage()
+  const options: Options = { command: command as Options['command'] }
+  while (argv.length > 0) {
+    const flag = argv.shift()
+    if (flag === '--floor-id') options.floorId = argv.shift() ?? usage()
+    else usage()
+  }
+  return options
+}
+
+export const main = async (argv = process.argv.slice(2)) => {
+  const options = parseOptions([...argv])
+  const rows = await listFloorMapDimensionRows(options.floorId)
+  if (options.floorId && rows.length === 0) throw new Error('floor does not exist')
+  let failed = 0
+  let updated = 0
+  let verified = 0
+
+  for (const row of rows) {
+    try {
+      const extension = getFloorMapExtensionFromObjectKey(row.image_object_path)
+      if (!extension) throw new Error('unsupported floor map extension')
+      const bytes = await getFloorMapObjectBytes(row.image_object_path)
+      if (!bytes) throw new Error('floor map object does not exist')
+      const dimensions = extractFloorMapDimensions(bytes, extension)
+      if (!dimensions) throw new Error('floor map dimensions are invalid')
+
+      if (row.map_width_px === null && row.map_height_px === null) {
+        if (options.command === 'verify') throw new Error('floor map dimensions are not stored')
+        const changed = await backfillFloorMapDimensions(
+          row.id,
+          dimensions.width,
+          dimensions.height
+        )
+        if (!changed) throw new Error('floor map dimensions were updated concurrently')
+        updated += 1
+        process.stdout.write(
+          `${JSON.stringify({ floor_id: row.id, status: 'updated', ...dimensions })}\n`
+        )
+      } else if (row.map_width_px !== dimensions.width || row.map_height_px !== dimensions.height) {
+        throw new Error('stored dimensions do not match floor map object')
+      } else {
+        verified += 1
+        process.stdout.write(
+          `${JSON.stringify({ floor_id: row.id, status: 'verified', ...dimensions })}\n`
+        )
+      }
+    } catch (error) {
+      failed += 1
+      process.stdout.write(
+        `${JSON.stringify({ floor_id: row.id, status: 'failed', message: error instanceof Error ? error.message : String(error) })}\n`
+      )
+    }
+  }
+
+  process.stdout.write(`${JSON.stringify({ resources: rows.length, updated, verified, failed })}\n`)
+  if (failed > 0) throw new Error(`floor map dimension migration failed for ${failed} resource(s)`)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error: unknown) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+    process.exitCode = 1
+  })
+}

--- a/apps/kaede/src/services/floor-maps/dimensions.ts
+++ b/apps/kaede/src/services/floor-maps/dimensions.ts
@@ -1,0 +1,59 @@
+import type { FloorMapImageExtension } from '../storage/presigned-url.js'
+
+export const floorMapMaxSidePx = 20_000
+export const floorMapMaxPixels = 100_000_000
+
+export interface FloorMapDimensions {
+  width: number
+  height: number
+}
+
+const pngMagicNumber = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+
+const areValidDimensions = ({ width, height }: FloorMapDimensions) =>
+  Number.isInteger(width) &&
+  Number.isInteger(height) &&
+  width > 0 &&
+  height > 0 &&
+  width <= floorMapMaxSidePx &&
+  height <= floorMapMaxSidePx &&
+  width * height <= floorMapMaxPixels
+
+const extractPngDimensions = (bytes: Uint8Array): FloorMapDimensions | undefined => {
+  if (
+    bytes.byteLength < 24 ||
+    !pngMagicNumber.every((value, index) => bytes[index] === value) ||
+    new TextDecoder('ascii').decode(bytes.slice(12, 16)) !== 'IHDR'
+  ) {
+    return undefined
+  }
+
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  const dimensions = { width: view.getUint32(16), height: view.getUint32(20) }
+  return areValidDimensions(dimensions) ? dimensions : undefined
+}
+
+const extractSvgDimensions = (bytes: Uint8Array): FloorMapDimensions | undefined => {
+  const text = new TextDecoder('utf-8', { fatal: false }).decode(bytes)
+  const svgTag = /<\s*svg\b[^>]*>/i.exec(text)?.[0]
+  if (
+    !svgTag ||
+    /<\s*script(?:\s|>)/i.test(text) ||
+    /<\s*foreignObject(?:\s|>)/i.test(text) ||
+    /\son[a-z]+\s*=/i.test(text)
+  ) {
+    return undefined
+  }
+
+  const viewBox = /\bviewBox\s*=\s*["']\s*0\s+0\s+(\d+)\s+(\d+)\s*["']/i.exec(svgTag)
+  if (!viewBox) return undefined
+
+  const dimensions = { width: Number(viewBox[1]), height: Number(viewBox[2]) }
+  return areValidDimensions(dimensions) ? dimensions : undefined
+}
+
+export const extractFloorMapDimensions = (
+  bytes: Uint8Array,
+  extension: FloorMapImageExtension
+): FloorMapDimensions | undefined =>
+  extension === 'png' ? extractPngDimensions(bytes) : extractSvgDimensions(bytes)

--- a/apps/kaede/src/services/floors/floor-repository.ts
+++ b/apps/kaede/src/services/floors/floor-repository.ts
@@ -26,6 +26,13 @@ export interface FloorRow {
   updated_at: Date
 }
 
+export interface FloorMapDimensionRow {
+  id: string
+  image_object_path: string
+  map_width_px: number | null
+  map_height_px: number | null
+}
+
 const floorRowsQuery = () =>
   db
     .selectFrom('floors')
@@ -103,4 +110,33 @@ export const findFloorById = async (
     .select(['id', 'organization_id', 'scale', 'map_width_px', 'map_height_px'])
     .where('id', '=', floorId)
     .executeTakeFirst()
+}
+
+export const listFloorMapDimensionRows = async (
+  floorId?: string,
+  executor: DbExecutor = db
+): Promise<FloorMapDimensionRow[]> => {
+  let query = executor
+    .selectFrom('floors')
+    .select(['id', 'image_object_path', 'map_width_px', 'map_height_px'])
+    .orderBy('id', 'asc')
+  if (floorId) query = query.where('id', '=', floorId)
+  return query.execute()
+}
+
+export const backfillFloorMapDimensions = async (
+  floorId: string,
+  width: number,
+  height: number,
+  executor: DbExecutor = db
+): Promise<boolean> => {
+  const updated = await executor
+    .updateTable('floors')
+    .set({ map_width_px: width, map_height_px: height, updated_at: new Date() })
+    .where('id', '=', floorId)
+    .where('map_width_px', 'is', null)
+    .where('map_height_px', 'is', null)
+    .returning('id')
+    .executeTakeFirst()
+  return updated !== undefined
 }

--- a/apps/kaede/src/services/floors/index.ts
+++ b/apps/kaede/src/services/floors/index.ts
@@ -1,1 +1,8 @@
-export { findFloorById, findFloorDetailById, insertFloor, listFloors } from './floor-repository.js'
+export {
+  backfillFloorMapDimensions,
+  findFloorById,
+  findFloorDetailById,
+  insertFloor,
+  listFloorMapDimensionRows,
+  listFloors,
+} from './floor-repository.js'

--- a/apps/kaede/src/services/storage/index.ts
+++ b/apps/kaede/src/services/storage/index.ts
@@ -4,6 +4,7 @@ export {
   doesTrajectoryAnalyzedResultObjectExist,
   getTrajectoryAnalyzedResultObjectText,
   getAnalysisHeatmapObjectText,
+  getFloorMapObjectBytes,
   listRecordingRawObjectKeys,
   putFloorMapObject,
 } from './object-store.js'

--- a/apps/kaede/src/services/storage/object-store.ts
+++ b/apps/kaede/src/services/storage/object-store.ts
@@ -43,6 +43,28 @@ export const deleteFloorMapObject = async (objectKey: string) => {
   )
 }
 
+export const getFloorMapObjectBytes = async (
+  objectKey: string
+): Promise<Uint8Array | undefined> => {
+  const { config, internalClient } = getS3Context()
+  try {
+    const response = await internalClient.send(
+      new GetObjectCommand({ Bucket: config.bucket, Key: objectKey })
+    )
+    return response.Body ? await response.Body.transformToByteArray() : new Uint8Array()
+  } catch (error) {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'name' in error &&
+      (error.name === 'NotFound' || error.name === 'NoSuchKey')
+    ) {
+      return undefined
+    }
+    throw error
+  }
+}
+
 export const listRecordingRawObjectKeys = async (organizationId: string, recordingId: string) => {
   const { config, internalClient } = getS3Context()
   const prefix = buildRecordingRawObjectPrefix(organizationId, recordingId)

--- a/apps/kaede/src/usecases/floors/create-floor.ts
+++ b/apps/kaede/src/usecases/floors/create-floor.ts
@@ -3,6 +3,12 @@ import { randomUUID } from 'node:crypto'
 import type { RequestActor } from '../../middleware/request-actor-context.js'
 import type { CreateFloorRequest, FloorResponse } from '../../schemas/floors.js'
 import { findBuildingById } from '../../services/buildings/index.js'
+import {
+  extractFloorMapDimensions,
+  floorMapMaxPixels,
+  floorMapMaxSidePx,
+} from '../../services/floor-maps/dimensions.js'
+import type { FloorMapDimensions } from '../../services/floor-maps/dimensions.js'
 import { insertFloor } from '../../services/floors/index.js'
 import {
   buildFloorMapObjectKey,
@@ -16,8 +22,7 @@ import type { AuthorizationError } from '../authorization.js'
 import { requireDashboardWriteAccess } from '../authorization.js'
 
 export const floorMapImageMaxBytes = 10 * 1024 * 1024
-export const floorMapMaxSidePx = 20_000
-export const floorMapMaxPixels = 100_000_000
+export { floorMapMaxPixels, floorMapMaxSidePx }
 
 export interface FloorMapImageUpload {
   bytes: Uint8Array
@@ -54,56 +59,6 @@ export type CreateFloorResult =
       error: AuthorizationError
     }
 
-const pngMagicNumber = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
-
-const hasPngMagicNumber = (bytes: Uint8Array) => {
-  return pngMagicNumber.every((value, index) => bytes[index] === value)
-}
-
-interface FloorMapDimensions {
-  width: number
-  height: number
-}
-
-const areValidDimensions = ({ width, height }: FloorMapDimensions) =>
-  Number.isInteger(width) &&
-  Number.isInteger(height) &&
-  width > 0 &&
-  height > 0 &&
-  width <= floorMapMaxSidePx &&
-  height <= floorMapMaxSidePx &&
-  width * height <= floorMapMaxPixels
-
-const extractPngDimensions = (bytes: Uint8Array): FloorMapDimensions | undefined => {
-  if (!hasPngMagicNumber(bytes) || bytes.byteLength < 24) return undefined
-
-  const chunkType = new TextDecoder('ascii').decode(bytes.slice(12, 16))
-  if (chunkType !== 'IHDR') return undefined
-
-  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
-  const dimensions = { width: view.getUint32(16), height: view.getUint32(20) }
-  return areValidDimensions(dimensions) ? dimensions : undefined
-}
-
-const extractSvgDimensions = (bytes: Uint8Array): FloorMapDimensions | undefined => {
-  const text = new TextDecoder('utf-8', { fatal: false }).decode(bytes)
-
-  const svgTag = /<\s*svg\b[^>]*>/i.exec(text)?.[0]
-  if (!svgTag) return undefined
-
-  if (/<\s*script(?:\s|>)/i.test(text) || /<\s*foreignObject(?:\s|>)/i.test(text)) {
-    return undefined
-  }
-
-  if (/\son[a-z]+\s*=/i.test(text)) return undefined
-
-  const viewBox = /\bviewBox\s*=\s*["']\s*0\s+0\s+(\d+)\s+(\d+)\s*["']/i.exec(svgTag)
-  if (!viewBox) return undefined
-
-  const dimensions = { width: Number(viewBox[1]), height: Number(viewBox[2]) }
-  return areValidDimensions(dimensions) ? dimensions : undefined
-}
-
 const validateFloorMapImage = (
   upload: FloorMapImageUpload
 ):
@@ -130,13 +85,13 @@ const validateFloorMapImage = (
   }
 
   if (upload.contentType === 'image/png') {
-    const dimensions = extractPngDimensions(upload.bytes)
+    const dimensions = extractFloorMapDimensions(upload.bytes, 'png')
     return dimensions
       ? { ok: true, extension: 'png', dimensions }
       : { ok: false, error: { type: 'FLOOR_MAP_IMAGE_INVALID' } }
   }
 
-  const dimensions = extractSvgDimensions(upload.bytes)
+  const dimensions = extractFloorMapDimensions(upload.bytes, 'svg')
   return dimensions
     ? { ok: true, extension: 'svg', dimensions }
     : { ok: false, error: { type: 'FLOOR_MAP_IMAGE_INVALID' } }

--- a/storage/README.md
+++ b/storage/README.md
@@ -67,3 +67,31 @@ make up ENV=local
 - `8333` は S3 API のため、ブラウザで直接開くと `Access Denied` になる
 - `8888` は Filer UI 用ポート
 - `9333` は SeaweedFS の管理情報確認用ポート
+
+## 既存floor mapの画像寸法を移行する
+
+`floors.map_width_px`と`map_height_px`が未設定の環境では、Kaedeコンテナ内で次を実行する。
+`backfill`はobject storage上のPNG IHDRまたはSVG viewBoxから寸法を取得し、未設定行だけを更新する。
+
+```sh
+node dist/cli/floor-map-dimension-backfill.js backfill
+node dist/cli/floor-map-dimension-backfill.js verify
+```
+
+開発環境ではmise経由で実行できる。
+
+```sh
+mise exec -- pnpm floor-map-dimension-backfill -- backfill
+mise exec -- pnpm floor-map-dimension-backfill -- verify
+```
+
+特定floorだけを再実行する場合は`--floor-id`を付ける。
+
+```sh
+node dist/cli/floor-map-dimension-backfill.js backfill --floor-id <UUID>
+```
+
+各floorの結果と最後の集計がJSON Linesで標準出力へ出る。`failed`が1件以上ある場合は終了コード1に
+なるため、objectの存在、拡張子、PNGのIHDRまたはSVGの`viewBox="0 0 width height"`、DBに保存済みの
+寸法との不一致を確認する。`backfill`は保存済み寸法を上書きせず、再実行できる。移行後に`verify`を
+実行し、最後の集計で`failed: 0`であることを確認する。


### PR DESCRIPTION
## 概要

既存のfloor map objectから画像寸法を取得し、`floors.map_width_px`と`map_height_px`を埋める移行CLIを追加します。

- PNGのIHDRまたはSVGのviewBoxから寸法を取得
- 未設定のfloorだけを更新する`backfill`を追加
- DB値とobjectの寸法を比較する`verify`を追加
- `--floor-id`による個別再実行に対応
- 新規floor作成と移行CLIで寸法抽出処理を共通化
- 実行手順と失敗時の確認事項をstorage READMEへ追記

PoC向けのため、NOT NULL化、manifest、並列実行、負荷制御は含めていません。

## 検証

- `mise exec -- pnpm lint`
- `mise exec -- pnpm typecheck`
- `mise exec -- pnpm test`（76 files / 423 tests）
- `mise exec -- pnpm test:db`（23 files / 202 tests）

## 関連Issue

- https://github.com/kajiLabTeam/okarin/issues/200