### PR TITLE
滞在ヒートマップ分析のKaede・Nozomi基盤を追加

### DIFF
--- a/apps/kaede/package.json
+++ b/apps/kaede/package.json
@@ -15,7 +15,8 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "typecheck": "tsc --noEmit",
-    "storage-prefix-migration": "tsx src/cli/storage-prefix-migration.ts"
+    "storage-prefix-migration": "tsx src/cli/storage-prefix-migration.ts",
+    "floor-map-dimension-backfill": "tsx src/cli/floor-map-dimension-backfill.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1045.0",

--- a/apps/kaede/src/cli/floor-map-dimension-backfill.test.ts
+++ b/apps/kaede/src/cli/floor-map-dimension-backfill.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  listRows: vi.fn(),
+  backfill: vi.fn(),
+  getBytes: vi.fn(),
+  stdoutWrite: vi.fn(() => true),
+}))
+
+vi.mock('../services/floors/index.js', () => ({
+  listFloorMapDimensionRows: mocks.listRows,
+  backfillFloorMapDimensions: mocks.backfill,
+}))
+vi.mock('../services/storage/index.js', () => ({
+  getFloorMapExtensionFromObjectKey: (key: string) =>
+    key.endsWith('.png') ? 'png' : key.endsWith('.svg') ? 'svg' : undefined,
+  getFloorMapObjectBytes: mocks.getBytes,
+}))
+
+import { main, parseOptions } from './floor-map-dimension-backfill.js'
+
+const floorId = '11111111-1111-4111-8111-111111111111'
+const png = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0x0d, 0x49, 0x48, 0x44, 0x52, 0, 0, 0x02,
+  0x80, 0, 0, 0x01, 0xe0,
+])
+
+describe('floor-map-dimension-backfill', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(process.stdout, 'write').mockImplementation(mocks.stdoutWrite)
+    mocks.listRows.mockResolvedValue([
+      {
+        id: floorId,
+        image_object_path: `organizations/22222222-2222-4222-8222-222222222222/floors/${floorId}/map.png`,
+        map_width_px: null,
+        map_height_px: null,
+      },
+    ])
+    mocks.getBytes.mockResolvedValue(png)
+    mocks.backfill.mockResolvedValue(true)
+  })
+
+  it('commandとfloor IDを解析する', () => {
+    expect(parseOptions(['verify', '--floor-id', floorId])).toEqual({
+      command: 'verify',
+      floorId,
+    })
+    expect(() => parseOptions(['unknown'])).toThrow(/usage/)
+  })
+
+  it('objectから取得した寸法を未設定floorへ保存する', async () => {
+    await main(['backfill'])
+
+    expect(mocks.backfill).toHaveBeenCalledWith(floorId, 640, 480)
+    expect(mocks.stdoutWrite).toHaveBeenCalledWith(expect.stringContaining('"updated":1'))
+  })
+
+  it('verifyでDB寸法とobjectが異なる場合は失敗する', async () => {
+    mocks.listRows.mockResolvedValueOnce([
+      {
+        id: floorId,
+        image_object_path: `organizations/22222222-2222-4222-8222-222222222222/floors/${floorId}/map.png`,
+        map_width_px: 320,
+        map_height_px: 240,
+      },
+    ])
+
+    await expect(main(['verify'])).rejects.toThrow(
+      'floor map dimension migration failed for 1 resource(s)'
+    )
+    expect(mocks.backfill).not.toHaveBeenCalled()
+  })
+})

--- a/apps/kaede/src/cli/floor-map-dimension-backfill.ts
+++ b/apps/kaede/src/cli/floor-map-dimension-backfill.ts
@@ -1,0 +1,83 @@
+import { extractFloorMapDimensions } from '../services/floor-maps/dimensions.js'
+import { backfillFloorMapDimensions, listFloorMapDimensionRows } from '../services/floors/index.js'
+import {
+  getFloorMapExtensionFromObjectKey,
+  getFloorMapObjectBytes,
+} from '../services/storage/index.js'
+
+interface Options {
+  command: 'backfill' | 'verify'
+  floorId?: string
+}
+
+const usage = (): never => {
+  throw new Error('usage: floor-map-dimension-backfill <backfill|verify> [--floor-id UUID]')
+}
+
+export const parseOptions = (argv: string[]): Options => {
+  const command = argv.shift()
+  if (command !== 'backfill' && command !== 'verify') usage()
+  const options: Options = { command: command as Options['command'] }
+  while (argv.length > 0) {
+    const flag = argv.shift()
+    if (flag === '--floor-id') options.floorId = argv.shift() ?? usage()
+    else usage()
+  }
+  return options
+}
+
+export const main = async (argv = process.argv.slice(2)) => {
+  const options = parseOptions([...argv])
+  const rows = await listFloorMapDimensionRows(options.floorId)
+  if (options.floorId && rows.length === 0) throw new Error('floor does not exist')
+  let failed = 0
+  let updated = 0
+  let verified = 0
+
+  for (const row of rows) {
+    try {
+      const extension = getFloorMapExtensionFromObjectKey(row.image_object_path)
+      if (!extension) throw new Error('unsupported floor map extension')
+      const bytes = await getFloorMapObjectBytes(row.image_object_path)
+      if (!bytes) throw new Error('floor map object does not exist')
+      const dimensions = extractFloorMapDimensions(bytes, extension)
+      if (!dimensions) throw new Error('floor map dimensions are invalid')
+
+      if (row.map_width_px === null && row.map_height_px === null) {
+        if (options.command === 'verify') throw new Error('floor map dimensions are not stored')
+        const changed = await backfillFloorMapDimensions(
+          row.id,
+          dimensions.width,
+          dimensions.height
+        )
+        if (!changed) throw new Error('floor map dimensions were updated concurrently')
+        updated += 1
+        process.stdout.write(
+          `${JSON.stringify({ floor_id: row.id, status: 'updated', ...dimensions })}\n`
+        )
+      } else if (row.map_width_px !== dimensions.width || row.map_height_px !== dimensions.height) {
+        throw new Error('stored dimensions do not match floor map object')
+      } else {
+        verified += 1
+        process.stdout.write(
+          `${JSON.stringify({ floor_id: row.id, status: 'verified', ...dimensions })}\n`
+        )
+      }
+    } catch (error) {
+      failed += 1
+      process.stdout.write(
+        `${JSON.stringify({ floor_id: row.id, status: 'failed', message: error instanceof Error ? error.message : String(error) })}\n`
+      )
+    }
+  }
+
+  process.stdout.write(`${JSON.stringify({ resources: rows.length, updated, verified, failed })}\n`)
+  if (failed > 0) throw new Error(`floor map dimension migration failed for ${failed} resource(s)`)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error: unknown) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+    process.exitCode = 1
+  })
+}

--- a/apps/kaede/src/index.ts
+++ b/apps/kaede/src/index.ts
@@ -2,8 +2,10 @@ import '../instrument.mjs'
 import { serve } from '@hono/node-server'
 import { validateRuntimeConfig } from './config/runtime.js'
 import { createApp } from './server.js'
+import { expireTimedOutAnalysisRuns } from './services/analysis-runs/index.js'
 
 const runtimeConfig = validateRuntimeConfig()
+await expireTimedOutAnalysisRuns()
 const app = createApp()
 const port = runtimeConfig.app.port
 const host = runtimeConfig.app.host

--- a/apps/kaede/src/routes/analysis-runs/callback.test.ts
+++ b/apps/kaede/src/routes/analysis-runs/callback.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRouteTestApp } from '../create-route-test-app.js'
+import { registerAnalysisCallbackRoute } from './callback.js'
+
+const { receiveCallbackMock } = vi.hoisted(() => ({ receiveCallbackMock: vi.fn() }))
+
+vi.mock('../../usecases/analysis-runs/receive-callback.js', () => ({
+  receiveAnalysisCallback: receiveCallbackMock,
+}))
+
+const runId = '11111111-1111-4111-8111-111111111111'
+
+describe('POST /api/analysis-runs/callback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('completed callbackを受理する', async () => {
+    receiveCallbackMock.mockResolvedValue({
+      ok: true,
+      value: { analysis_run_id: runId, status: 'completed' },
+    })
+    const app = createRouteTestApp('/analysis-runs', registerAnalysisCallbackRoute)
+    const response = await app.request('/api/analysis-runs/callback', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        analysis_run_id: runId,
+        status: 'completed',
+        callback_token: 'token',
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ analysis_run_id: runId, status: 'completed' })
+  })
+
+  it('不正tokenは401を返す', async () => {
+    receiveCallbackMock.mockResolvedValue({
+      ok: false,
+      error: { type: 'CALLBACK_TOKEN_INVALID' },
+    })
+    const app = createRouteTestApp('/analysis-runs', registerAnalysisCallbackRoute)
+    const response = await app.request('/api/analysis-runs/callback', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        analysis_run_id: runId,
+        status: 'completed',
+        callback_token: 'invalid',
+      }),
+    })
+
+    expect(response.status).toBe(401)
+  })
+
+  it('未知fieldを含むpayloadは400を返す', async () => {
+    const app = createRouteTestApp('/analysis-runs', registerAnalysisCallbackRoute)
+    const response = await app.request('/api/analysis-runs/callback', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        analysis_run_id: runId,
+        status: 'completed',
+        callback_token: 'token',
+        unknown: true,
+      }),
+    })
+
+    expect(response.status).toBe(400)
+    expect(receiveCallbackMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/kaede/src/routes/analysis-runs/callback.ts
+++ b/apps/kaede/src/routes/analysis-runs/callback.ts
@@ -1,0 +1,50 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import {
+  analysisCallbackErrorResponseSchema,
+  analysisCallbackRequestSchema,
+  analysisCallbackResponseSchema,
+} from '../../schemas/analysis-runs.js'
+import { receiveAnalysisCallback } from '../../usecases/analysis-runs/receive-callback.js'
+
+export const registerAnalysisCallbackRoute = (app: OpenAPIHono) => {
+  const errorResponse = {
+    description: 'callback rejected',
+    content: { 'application/json': { schema: analysisCallbackErrorResponseSchema } },
+  } as const
+  const route = createRoute({
+    method: 'post',
+    path: '/callback',
+    tags: ['Analysis runs'],
+    request: {
+      body: { content: { 'application/json': { schema: analysisCallbackRequestSchema } } },
+    },
+    responses: {
+      200: {
+        description: 'callback accepted',
+        content: { 'application/json': { schema: analysisCallbackResponseSchema } },
+      },
+      400: errorResponse,
+      401: errorResponse,
+      404: errorResponse,
+      409: errorResponse,
+      500: errorResponse,
+    },
+  })
+
+  app.openapi(route, async (c) => {
+    const result = await receiveAnalysisCallback(c.req.valid('json'))
+    if (result.ok) return c.json(result.value, 200)
+
+    const responses = {
+      CALLBACK_TOKEN_INVALID: [401, 'callback token is invalid'],
+      CALLBACK_TOKEN_EXPIRED: [401, 'callback token has expired'],
+      ANALYSIS_RUN_NOT_FOUND: [404, 'analysis run not found'],
+      CALLBACK_ANALYSIS_RUN_MISMATCH: [409, 'analysis run ID does not match token'],
+      CALLBACK_ALREADY_FINALIZED: [409, 'analysis run is already finalized'],
+      CALLBACK_ARTIFACT_INVALID: [409, 'analysis artifact is invalid'],
+    } as const
+    const [status, message] = responses[result.error.type]
+    return c.json({ error_code: result.error.type, error_message: message }, status)
+  })
+}

--- a/apps/kaede/src/routes/analysis-runs/index.ts
+++ b/apps/kaede/src/routes/analysis-runs/index.ts
@@ -1,0 +1,6 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { registerAnalysisCallbackRoute } from './callback.js'
+
+export const analysisRunsRoutes = new OpenAPIHono()
+
+registerAnalysisCallbackRoute(analysisRunsRoutes)

--- a/apps/kaede/src/routes/index.ts
+++ b/apps/kaede/src/routes/index.ts
@@ -1,5 +1,6 @@
 import { OpenAPIHono } from '@hono/zod-openapi'
 import { actorRoutes } from './actor/index.js'
+import { analysisRunsRoutes } from './analysis-runs/index.js'
 import { authRoutes } from './auth/index.js'
 import { buildingsRoutes } from './buildings/index.js'
 import { floorsRoutes } from './floors/index.js'
@@ -15,6 +16,7 @@ export const registerApiRoutes = (app: OpenAPIHono) => {
   const api = new OpenAPIHono()
 
   api.route('/actor', actorRoutes)
+  api.route('/analysis-runs', analysisRunsRoutes)
   api.route('/auth', authRoutes)
   api.route('/buildings', buildingsRoutes)
   api.route('/floors', floorsRoutes)

--- a/apps/kaede/src/routes/organizations/analysis-runs.test.ts
+++ b/apps/kaede/src/routes/organizations/analysis-runs.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import { createRouteTestApp } from '../create-route-test-app.js'
+import { registerAnalysisRunRoutes } from './analysis-runs.js'
+
+const mocks = vi.hoisted(() => ({
+  list: vi.fn(),
+  get: vi.fn(),
+  getResult: vi.fn(),
+}))
+
+vi.mock('../../usecases/analysis-runs/get-analysis-runs.js', () => ({
+  listAnalysisRuns: mocks.list,
+  getAnalysisRun: mocks.get,
+  getAnalysisRunResult: mocks.getResult,
+}))
+
+const organizationId = '11111111-1111-4111-8111-111111111111'
+const analysisRunId = '22222222-2222-4222-8222-222222222222'
+const floorId = '33333333-3333-4333-8333-333333333333'
+const trajectoryId = '44444444-4444-4444-8444-444444444444'
+const actor: RequestActor = {
+  type: 'user',
+  user_id: '55555555-5555-4555-8555-555555555555',
+  email: 'manager@example.com',
+  global_role: 'none',
+  account_state: 'active',
+  memberships: [{ organization_id: organizationId, organization_name: 'Test', role: 'manager' }],
+}
+
+const createApp = () => createRouteTestApp('/organizations', registerAnalysisRunRoutes, { actor })
+
+const runSummary = {
+  analysis_run_id: analysisRunId,
+  analysis_type: 'stay_heatmap',
+  status: 'completed',
+  floor_id: floorId,
+  parameters: { speed_threshold_mps: 0.5, grid_size_m: 1 },
+  definition_version: 'original-v1',
+  trajectory_counts: { input: 1, included: 1, excluded_deleted: 0 },
+  error: null,
+  created_at: '2026-08-04T00:00:00.000Z',
+  updated_at: '2026-08-04T00:01:00.000Z',
+  finished_at: '2026-08-04T00:01:00.000Z',
+} as const
+
+describe('organization analysis run routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('一覧queryをusecaseへ渡してrun一覧を返す', async () => {
+    mocks.list.mockResolvedValue({
+      ok: true,
+      value: {
+        analysis_runs: [runSummary],
+        pagination: { next_cursor: null, total_count: 1 },
+      },
+    })
+    const app = createApp()
+    const response = await app.request(
+      `/api/organizations/${organizationId}/analysis-runs?limit=10&analysis_type=stay_heatmap&status=completed&floor_id=${floorId}`
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      analysis_runs: [runSummary],
+      pagination: { next_cursor: null, total_count: 1 },
+    })
+    expect(mocks.list).toHaveBeenCalledWith(actor, organizationId, {
+      limit: 10,
+      analysis_type: 'stay_heatmap',
+      status: 'completed',
+      floor_id: floorId,
+    })
+  })
+
+  it('不正な一覧queryを400で拒否する', async () => {
+    const response = await createApp().request(
+      `/api/organizations/${organizationId}/analysis-runs?limit=0`
+    )
+
+    expect(response.status).toBe(400)
+    expect(mocks.list).not.toHaveBeenCalled()
+  })
+
+  it('run詳細とtrajectoryの削除状態を返す', async () => {
+    mocks.get.mockResolvedValue({
+      ok: true,
+      value: {
+        ...runSummary,
+        trajectories: [{ trajectory_id: trajectoryId, seq: 0, deleted: false }],
+        started_at: '2026-08-04T00:00:00.000Z',
+        deadline_at: '2026-08-04T01:00:00.000Z',
+      },
+    })
+    const response = await createApp().request(
+      `/api/organizations/${organizationId}/analysis-runs/${analysisRunId}`
+    )
+
+    expect(response.status).toBe(200)
+    expect(mocks.get).toHaveBeenCalledWith(actor, organizationId, analysisRunId)
+    await expect(response.json()).resolves.toMatchObject({
+      analysis_run_id: analysisRunId,
+      trajectories: [{ trajectory_id: trajectoryId, seq: 0, deleted: false }],
+    })
+  })
+
+  it('存在しないrun詳細を404で返す', async () => {
+    mocks.get.mockResolvedValue({ ok: false, error: { type: 'ANALYSIS_RUN_NOT_FOUND' } })
+    const response = await createApp().request(
+      `/api/organizations/${organizationId}/analysis-runs/${analysisRunId}`
+    )
+
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toEqual({
+      error_code: 'ANALYSIS_RUN_NOT_FOUND',
+      error_message: 'analysis run not found',
+    })
+  })
+
+  it('completed runのヒートマップ結果を返す', async () => {
+    mocks.getResult.mockResolvedValue({
+      ok: true,
+      value: {
+        analysis_run_id: analysisRunId,
+        analysis_type: 'stay_heatmap',
+        status: 'completed',
+        definition_version: 'original-v1',
+        floor: { id: floorId, map_width_px: 100, map_height_px: 200, scale_m_per_px: 0.01 },
+        parameters: { speed_threshold_mps: 0.5, grid_size_m: 1 },
+        grid: {
+          column_count: 1,
+          row_count: 2,
+          cells: [
+            {
+              grid_column: 0,
+              grid_row: 1,
+              total_stay_cell_visit_count: 2,
+              mean_stay_cell_visit_count: 2,
+            },
+          ],
+        },
+        trajectory_counts: { input: 1, included: 1, excluded_deleted: 0 },
+        trajectory_csvs: [
+          {
+            trajectory_id: trajectoryId,
+            download_url: 'https://storage.test/stay.csv',
+            expires_at: '2026-08-04T00:15:00.000Z',
+          },
+        ],
+      },
+    })
+    const response = await createApp().request(
+      `/api/organizations/${organizationId}/analysis-runs/${analysisRunId}/result`
+    )
+
+    expect(response.status).toBe(200)
+    expect(mocks.getResult).toHaveBeenCalledWith(actor, organizationId, analysisRunId)
+    await expect(response.json()).resolves.toMatchObject({
+      analysis_run_id: analysisRunId,
+      grid: { cells: [{ total_stay_cell_visit_count: 2 }] },
+      trajectory_csvs: [{ trajectory_id: trajectoryId }],
+    })
+  })
+
+  it('failed runの結果取得を409で返す', async () => {
+    mocks.getResult.mockResolvedValue({
+      ok: false,
+      error: {
+        type: 'ANALYSIS_RESULT_NOT_READY',
+        status: 'failed',
+        errorCode: 'ANALYSIS_TIMEOUT',
+      },
+    })
+    const response = await createApp().request(
+      `/api/organizations/${organizationId}/analysis-runs/${analysisRunId}/result`
+    )
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({
+      error_code: 'ANALYSIS_TIMEOUT',
+      error_message: 'analysis result is not available (failed)',
+    })
+  })
+})

--- a/apps/kaede/src/routes/organizations/analysis-runs.ts
+++ b/apps/kaede/src/routes/organizations/analysis-runs.ts
@@ -1,0 +1,150 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { requireRequestActor } from '../../middleware/request-actor-context.js'
+import type { RequestActorContext } from '../../middleware/request-actor-context.js'
+import {
+  analysisRunDetailResponseSchema,
+  analysisRunListResponseSchema,
+  analysisRunParamsSchema,
+  analysisRunResultResponseSchema,
+  listAnalysisRunsQuerySchema,
+} from '../../schemas/analysis-runs.js'
+import { errorResponseSchema } from '../../schemas/common.js'
+import { organizationIdParamsSchema } from '../../schemas/organizations.js'
+import {
+  getAnalysisRun,
+  getAnalysisRunResult,
+  listAnalysisRuns,
+} from '../../usecases/analysis-runs/get-analysis-runs.js'
+
+const errorResponse = {
+  description: 'analysis run request failed',
+  content: { 'application/json': { schema: errorResponseSchema } },
+} as const
+
+const toError = (error: {
+  type: string
+  status?: string
+  errorCode?: string | null
+}): { status: 400 | 403 | 404 | 409; body: { error_code: string; error_message: string } } => {
+  switch (error.type) {
+    case 'AUTH_DASHBOARD_FORBIDDEN':
+    case 'AUTH_ORGANIZATION_FORBIDDEN':
+      return { status: 403, body: { error_code: error.type, error_message: 'permission denied' } }
+    case 'ANALYSIS_RUN_NOT_FOUND':
+      return {
+        status: 404,
+        body: { error_code: error.type, error_message: 'analysis run not found' },
+      }
+    case 'ANALYSIS_RESULT_NOT_READY':
+      return {
+        status: 409,
+        body: {
+          error_code: error.errorCode ?? error.type,
+          error_message: `analysis result is not available (${error.status})`,
+        },
+      }
+    case 'ANALYSIS_RESULT_INVALID':
+      return {
+        status: 409,
+        body: { error_code: error.type, error_message: 'analysis result is invalid' },
+      }
+    default:
+      return { status: 400, body: { error_code: error.type, error_message: 'invalid request' } }
+  }
+}
+
+export const registerAnalysisRunRoutes = (app: OpenAPIHono) => {
+  const listRoute = createRoute({
+    method: 'get',
+    path: '/{organizationId}/analysis-runs',
+    tags: ['Organizations'],
+    request: { params: organizationIdParamsSchema, query: listAnalysisRunsQuerySchema },
+    responses: {
+      200: {
+        description: 'analysis runs',
+        content: { 'application/json': { schema: analysisRunListResponseSchema } },
+      },
+      400: errorResponse,
+      403: errorResponse,
+      404: errorResponse,
+      409: errorResponse,
+    },
+  })
+  app.openapi(listRoute, async (c) => {
+    const { organizationId } = c.req.valid('param')
+    const result = await listAnalysisRuns(
+      requireRequestActor(c as RequestActorContext),
+      organizationId,
+      c.req.valid('query')
+    )
+    if (result.ok) return c.json(result.value, 200)
+    const error = toError(result.error)
+    if (error.status === 403) return c.json(error.body, 403)
+    if (error.status === 404) return c.json(error.body, 404)
+    if (error.status === 409) return c.json(error.body, 409)
+    return c.json(error.body, 400)
+  })
+
+  const detailRoute = createRoute({
+    method: 'get',
+    path: '/{organizationId}/analysis-runs/{analysisRunId}',
+    tags: ['Organizations'],
+    request: { params: analysisRunParamsSchema },
+    responses: {
+      200: {
+        description: 'analysis run',
+        content: { 'application/json': { schema: analysisRunDetailResponseSchema } },
+      },
+      403: errorResponse,
+      404: errorResponse,
+      400: errorResponse,
+      409: errorResponse,
+    },
+  })
+  app.openapi(detailRoute, async (c) => {
+    const { organizationId, analysisRunId } = c.req.valid('param')
+    const result = await getAnalysisRun(
+      requireRequestActor(c as RequestActorContext),
+      organizationId,
+      analysisRunId
+    )
+    if (result.ok) return c.json(result.value, 200)
+    const error = toError(result.error)
+    if (error.status === 403) return c.json(error.body, 403)
+    if (error.status === 404) return c.json(error.body, 404)
+    if (error.status === 409) return c.json(error.body, 409)
+    return c.json(error.body, 400)
+  })
+
+  const resultRoute = createRoute({
+    method: 'get',
+    path: '/{organizationId}/analysis-runs/{analysisRunId}/result',
+    tags: ['Organizations'],
+    request: { params: analysisRunParamsSchema },
+    responses: {
+      200: {
+        description: 'analysis result',
+        content: { 'application/json': { schema: analysisRunResultResponseSchema } },
+      },
+      403: errorResponse,
+      404: errorResponse,
+      409: errorResponse,
+      400: errorResponse,
+    },
+  })
+  app.openapi(resultRoute, async (c) => {
+    const { organizationId, analysisRunId } = c.req.valid('param')
+    const result = await getAnalysisRunResult(
+      requireRequestActor(c as RequestActorContext),
+      organizationId,
+      analysisRunId
+    )
+    if (result.ok) return c.json(result.value, 200)
+    const error = toError(result.error)
+    if (error.status === 403) return c.json(error.body, 403)
+    if (error.status === 404) return c.json(error.body, 404)
+    if (error.status === 409) return c.json(error.body, 409)
+    return c.json(error.body, 400)
+  })
+}

--- a/apps/kaede/src/routes/organizations/create-stay-heatmap.ts
+++ b/apps/kaede/src/routes/organizations/create-stay-heatmap.ts
@@ -1,0 +1,72 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { requireRequestActor } from '../../middleware/request-actor-context.js'
+import type { RequestActorContext } from '../../middleware/request-actor-context.js'
+import {
+  createStayHeatmapErrorResponseSchema,
+  createStayHeatmapRequestSchema,
+  createStayHeatmapResponseSchema,
+} from '../../schemas/analysis-runs.js'
+import { organizationIdParamsSchema } from '../../schemas/organizations.js'
+import { createStayHeatmap } from '../../usecases/analysis-runs/create-stay-heatmap.js'
+
+export const registerCreateStayHeatmapRoute = (app: OpenAPIHono) => {
+  const errorResponse = {
+    description: 'analysis creation failed',
+    content: { 'application/json': { schema: createStayHeatmapErrorResponseSchema } },
+  } as const
+  const route = createRoute({
+    method: 'post',
+    path: '/{organizationId}/analyses/stay-heatmaps',
+    tags: ['Organizations'],
+    request: {
+      params: organizationIdParamsSchema,
+      body: { content: { 'application/json': { schema: createStayHeatmapRequestSchema } } },
+    },
+    responses: {
+      202: {
+        description: 'analysis accepted',
+        content: { 'application/json': { schema: createStayHeatmapResponseSchema } },
+      },
+      400: errorResponse,
+      403: errorResponse,
+      404: errorResponse,
+      409: errorResponse,
+      500: errorResponse,
+      502: errorResponse,
+    },
+  })
+
+  app.openapi(route, async (c) => {
+    const { organizationId } = c.req.valid('param')
+    const result = await createStayHeatmap(
+      requireRequestActor(c as RequestActorContext),
+      organizationId,
+      c.req.valid('json')
+    )
+    if (result.ok) return c.json(result.value, 202)
+
+    const runId = 'analysisRunId' in result.error ? result.error.analysisRunId : undefined
+    const responses = {
+      AUTH_DASHBOARD_FORBIDDEN: [403, 'dashboard write access is required'],
+      AUTH_ORGANIZATION_FORBIDDEN: [403, 'organization access is required'],
+      TRAJECTORY_NOT_FOUND: [404, 'trajectory not found'],
+      FLOOR_NOT_FOUND: [404, 'floor not found'],
+      TRAJECTORY_NOT_COMPLETED: [409, 'trajectory is not completed'],
+      TRAJECTORY_SCOPE_INVALID: [409, 'trajectory scope is invalid'],
+      TRAJECTORY_START_INVALID: [409, 'trajectory start is invalid'],
+      FLOOR_ANALYSIS_METADATA_INVALID: [409, 'floor analysis metadata is invalid'],
+      ANALYSIS_PREPARATION_FAILED: [500, 'failed to prepare analysis request'],
+      NOZOMI_REQUEST_FAILED: [502, 'failed to submit analysis request'],
+    } as const
+    const [status, message] = responses[result.error.type]
+    return c.json(
+      {
+        error_code: result.error.type,
+        error_message: message,
+        ...(runId ? { analysis_run_id: runId } : {}),
+      },
+      status
+    )
+  })
+}

--- a/apps/kaede/src/routes/organizations/index.ts
+++ b/apps/kaede/src/routes/organizations/index.ts
@@ -1,4 +1,5 @@
 import { OpenAPIHono } from '@hono/zod-openapi'
+import { registerAnalysisRunRoutes } from './analysis-runs.js'
 import { registerCreateOrganizationBuildingFloorRoute } from './create-organization-building-floor.js'
 import { registerCreateOrganizationBuildingRoute } from './create-organization-building.js'
 import { registerCreateOrganizationMembershipRoute } from './create-organization-membership.js'
@@ -34,3 +35,4 @@ registerCreateOrganizationUserRoute(organizationsRoutes)
 registerCreateOrganizationUserActivationLinkRoute(organizationsRoutes)
 registerCreateOrganizationMembershipRoute(organizationsRoutes)
 registerCreateStayHeatmapRoute(organizationsRoutes)
+registerAnalysisRunRoutes(organizationsRoutes)

--- a/apps/kaede/src/routes/organizations/index.ts
+++ b/apps/kaede/src/routes/organizations/index.ts
@@ -5,6 +5,7 @@ import { registerCreateOrganizationMembershipRoute } from './create-organization
 import { registerCreateOrganizationUserActivationLinkRoute } from './create-organization-user-activation-link.js'
 import { registerCreateOrganizationUserRoute } from './create-organization-user.js'
 import { registerCreateOrganizationRoute } from './create-organization.js'
+import { registerCreateStayHeatmapRoute } from './create-stay-heatmap.js'
 import { registerGetOrganizationUserRoute } from './get-organization-user.js'
 import { registerGetOrganizationRoute } from './get-organization.js'
 import { registerListOrganizationBuildingFloorsRoute } from './list-organization-building-floors.js'
@@ -32,3 +33,4 @@ registerGetOrganizationUserRoute(organizationsRoutes)
 registerCreateOrganizationUserRoute(organizationsRoutes)
 registerCreateOrganizationUserActivationLinkRoute(organizationsRoutes)
 registerCreateOrganizationMembershipRoute(organizationsRoutes)
+registerCreateStayHeatmapRoute(organizationsRoutes)

--- a/apps/kaede/src/schemas/analysis-runs.ts
+++ b/apps/kaede/src/schemas/analysis-runs.ts
@@ -1,0 +1,52 @@
+import { z } from '@hono/zod-openapi'
+import { uuidSchema } from './common.js'
+
+const parameterSchema = (minimum: number, maximum: number, defaultValue: number) =>
+  z
+    .number()
+    .finite()
+    .min(minimum)
+    .max(maximum)
+    .refine((value) => Number.isInteger(value * 1000), 'must have at most 3 decimal places')
+    .default(defaultValue)
+
+export const stayHeatmapParametersSchema = z
+  .object({
+    speed_threshold_mps: parameterSchema(0, 2, 0.5),
+    grid_size_m: parameterSchema(0.1, 10, 1),
+  })
+  .strict()
+  .openapi('StayHeatmapParameters')
+
+export const createStayHeatmapRequestSchema = z
+  .object({
+    trajectory_ids: z
+      .array(uuidSchema)
+      .min(1)
+      .max(100)
+      .refine((ids) => new Set(ids).size === ids.length, 'trajectory_ids must be unique'),
+    parameters: stayHeatmapParametersSchema.default({
+      speed_threshold_mps: 0.5,
+      grid_size_m: 1,
+    }),
+  })
+  .strict()
+  .openapi('CreateStayHeatmapRequest')
+
+export const createStayHeatmapResponseSchema = z
+  .object({
+    analysis_run_id: uuidSchema,
+    status: z.literal('processing'),
+  })
+  .openapi('CreateStayHeatmapResponse')
+
+export const createStayHeatmapErrorResponseSchema = z
+  .object({
+    error_code: z.string(),
+    error_message: z.string(),
+    analysis_run_id: uuidSchema.optional(),
+  })
+  .openapi('CreateStayHeatmapErrorResponse')
+
+export type CreateStayHeatmapRequest = z.infer<typeof createStayHeatmapRequestSchema>
+export type StayHeatmapParameters = z.infer<typeof stayHeatmapParametersSchema>

--- a/apps/kaede/src/schemas/analysis-runs.ts
+++ b/apps/kaede/src/schemas/analysis-runs.ts
@@ -1,19 +1,18 @@
 import { z } from '@hono/zod-openapi'
 import { uuidSchema } from './common.js'
 
-const parameterSchema = (minimum: number, maximum: number, defaultValue: number) =>
+const parameterSchema = (minimum: number, maximum: number) =>
   z
     .number()
     .finite()
     .min(minimum)
     .max(maximum)
     .refine((value) => Number.isInteger(value * 1000), 'must have at most 3 decimal places')
-    .default(defaultValue)
 
 export const stayHeatmapParametersSchema = z
   .object({
-    speed_threshold_mps: parameterSchema(0, 2, 0.5),
-    grid_size_m: parameterSchema(0.1, 10, 1),
+    speed_threshold_mps: parameterSchema(0, 2).default(0.5),
+    grid_size_m: parameterSchema(0.1, 10).default(1),
   })
   .strict()
   .openapi('StayHeatmapParameters')
@@ -48,5 +47,111 @@ export const createStayHeatmapErrorResponseSchema = z
   })
   .openapi('CreateStayHeatmapErrorResponse')
 
+const heatmapCellSchema = z
+  .object({
+    grid_column: z.number().int().min(0),
+    grid_row: z.number().int().min(0),
+    stay_cell_visit_count: z.number().int().positive(),
+  })
+  .strict()
+
+export const stayHeatmapArtifactSchema = z
+  .object({
+    schema_version: z.literal('1.0'),
+    definition_version: z.literal('original-v1'),
+    parameters: z
+      .object({
+        speed_threshold_mps: parameterSchema(0, 2),
+        grid_size_m: parameterSchema(0.1, 10),
+      })
+      .strict(),
+    floor_map: z
+      .object({
+        width_px: z.number().int().positive(),
+        height_px: z.number().int().positive(),
+        scale_m_per_px: z.number().positive().finite(),
+      })
+      .strict(),
+    grid: z
+      .object({
+        size_m: z.number().positive().finite(),
+        column_count: z.number().int().positive(),
+        row_count: z.number().int().positive(),
+      })
+      .strict(),
+    input_trajectory_count: z.number().int().positive(),
+    trajectories: z.array(
+      z
+        .object({
+          trajectory_id: uuidSchema,
+          cells: z.array(heatmapCellSchema),
+        })
+        .strict()
+        .superRefine((trajectory, ctx) => {
+          const cells = trajectory.cells.map((cell) => `${cell.grid_row}:${cell.grid_column}`)
+          if (new Set(cells).size !== cells.length) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'cells must be unique' })
+          }
+        })
+    ),
+  })
+  .strict()
+  .superRefine((artifact, ctx) => {
+    const ids = artifact.trajectories.map((trajectory) => trajectory.trajectory_id)
+    if (artifact.input_trajectory_count !== artifact.trajectories.length) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'trajectory count does not match' })
+    }
+    if (new Set(ids).size !== ids.length) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'trajectory IDs must be unique' })
+    }
+    for (const trajectory of artifact.trajectories) {
+      for (const cell of trajectory.cells) {
+        if (
+          cell.grid_column >= artifact.grid.column_count ||
+          cell.grid_row >= artifact.grid.row_count
+        ) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'cell must be inside the grid' })
+        }
+      }
+    }
+  })
+  .openapi('StayHeatmapArtifact')
+
+export const analysisCallbackRequestSchema = z
+  .discriminatedUnion('status', [
+    z
+      .object({
+        analysis_run_id: uuidSchema,
+        status: z.literal('completed'),
+        callback_token: z.string().min(1),
+      })
+      .strict(),
+    z
+      .object({
+        analysis_run_id: uuidSchema,
+        status: z.literal('failed'),
+        callback_token: z.string().min(1),
+        error_code: z.string().min(1).max(100),
+        error_message: z.string().min(1).max(500),
+      })
+      .strict(),
+  ])
+  .openapi('AnalysisCallbackRequest')
+
+export const analysisCallbackResponseSchema = z
+  .object({
+    analysis_run_id: uuidSchema,
+    status: z.enum(['completed', 'failed']),
+  })
+  .openapi('AnalysisCallbackResponse')
+
+export const analysisCallbackErrorResponseSchema = z
+  .object({
+    error_code: z.string(),
+    error_message: z.string(),
+  })
+  .openapi('AnalysisCallbackErrorResponse')
+
 export type CreateStayHeatmapRequest = z.infer<typeof createStayHeatmapRequestSchema>
 export type StayHeatmapParameters = z.infer<typeof stayHeatmapParametersSchema>
+export type AnalysisCallbackRequest = z.infer<typeof analysisCallbackRequestSchema>

--- a/apps/kaede/src/schemas/analysis-runs.ts
+++ b/apps/kaede/src/schemas/analysis-runs.ts
@@ -1,5 +1,6 @@
 import { z } from '@hono/zod-openapi'
 import { uuidSchema } from './common.js'
+import { paginationMetadataSchema, paginationQuerySchema } from './pagination.js'
 
 const parameterSchema = (minimum: number, maximum: number, defaultValue: number) =>
   z
@@ -50,3 +51,116 @@ export const createStayHeatmapErrorResponseSchema = z
 
 export type CreateStayHeatmapRequest = z.infer<typeof createStayHeatmapRequestSchema>
 export type StayHeatmapParameters = z.infer<typeof stayHeatmapParametersSchema>
+
+const analysisRunStatusSchema = z.enum(['accepted', 'processing', 'completed', 'failed'])
+const trajectoryCountsSchema = z.object({
+  input: z.number().int().nonnegative(),
+  included: z.number().int().nonnegative(),
+  excluded_deleted: z.number().int().nonnegative(),
+})
+const analysisRunErrorSchema = z.object({ code: z.string(), message: z.string() }).nullable()
+const nullableDateTimeSchema = z.string().datetime().nullable()
+
+export const analysisRunParamsSchema = z.object({
+  organizationId: uuidSchema,
+  analysisRunId: uuidSchema,
+})
+
+export const listAnalysisRunsQuerySchema = paginationQuerySchema
+  .extend({
+    analysis_type: z.string().min(1).optional(),
+    status: analysisRunStatusSchema.optional(),
+    floor_id: uuidSchema.optional(),
+  })
+  .strict()
+
+const analysisRunSummarySchema = z.object({
+  analysis_run_id: uuidSchema,
+  analysis_type: z.string(),
+  status: analysisRunStatusSchema,
+  floor_id: uuidSchema,
+  parameters: stayHeatmapParametersSchema,
+  definition_version: z.string(),
+  trajectory_counts: trajectoryCountsSchema,
+  error: analysisRunErrorSchema,
+  created_at: z.string().datetime(),
+  updated_at: z.string().datetime(),
+  finished_at: nullableDateTimeSchema,
+})
+
+export const analysisRunListResponseSchema = z.object({
+  analysis_runs: z.array(analysisRunSummarySchema),
+  pagination: paginationMetadataSchema,
+})
+
+export const analysisRunDetailResponseSchema = analysisRunSummarySchema.extend({
+  trajectories: z.array(
+    z.object({
+      trajectory_id: uuidSchema,
+      seq: z.number().int().nonnegative(),
+      deleted: z.boolean(),
+    })
+  ),
+  started_at: nullableDateTimeSchema,
+  deadline_at: z.string().datetime(),
+})
+
+const heatmapCellSchema = z.object({
+  grid_column: z.number().int().nonnegative(),
+  grid_row: z.number().int().nonnegative(),
+  stay_cell_visit_count: z.number().int().positive(),
+})
+
+export const stayHeatmapArtifactSchema = z
+  .object({
+    schema_version: z.literal('1.0'),
+    definition_version: z.string(),
+    parameters: stayHeatmapParametersSchema,
+    floor_map: z.object({
+      width_px: z.number().int().positive(),
+      height_px: z.number().int().positive(),
+      scale_m_per_px: z.number().positive(),
+    }),
+    grid: z.object({
+      size_m: z.number().positive(),
+      column_count: z.number().int().positive(),
+      row_count: z.number().int().positive(),
+    }),
+    input_trajectory_count: z.number().int().nonnegative(),
+    trajectories: z.array(
+      z.object({ trajectory_id: uuidSchema, cells: z.array(heatmapCellSchema) })
+    ),
+  })
+  .strict()
+
+export const analysisRunResultResponseSchema = z.object({
+  analysis_run_id: uuidSchema,
+  analysis_type: z.literal('stay_heatmap'),
+  status: z.literal('completed'),
+  definition_version: z.string(),
+  floor: z.object({
+    id: uuidSchema,
+    map_width_px: z.number().int().positive(),
+    map_height_px: z.number().int().positive(),
+    scale_m_per_px: z.number().positive(),
+  }),
+  parameters: stayHeatmapParametersSchema,
+  grid: z.object({
+    column_count: z.number().int().positive(),
+    row_count: z.number().int().positive(),
+    cells: z.array(
+      z.object({
+        grid_column: z.number().int().nonnegative(),
+        grid_row: z.number().int().nonnegative(),
+        total_stay_cell_visit_count: z.number().int().positive(),
+        mean_stay_cell_visit_count: z.number().nonnegative(),
+      })
+    ),
+  }),
+  trajectory_counts: trajectoryCountsSchema,
+  trajectory_csvs: z.array(
+    z.object({ trajectory_id: uuidSchema, download_url: z.string().url(), expires_at: z.string() })
+  ),
+})
+
+export type ListAnalysisRunsQuery = z.infer<typeof listAnalysisRunsQuerySchema>

--- a/apps/kaede/src/schemas/floors.ts
+++ b/apps/kaede/src/schemas/floors.ts
@@ -25,6 +25,12 @@ export const floorSchema = z
     scale: z.number().nullable().openapi({
       description: '縮尺。未設定の場合は null',
     }),
+    map_width_px: z.number().int().positive().nullable().optional().openapi({
+      description: 'floor map画像の幅（px）。移行前の画像は null',
+    }),
+    map_height_px: z.number().int().positive().nullable().optional().openapi({
+      description: 'floor map画像の高さ（px）。移行前の画像は null',
+    }),
     map_image: z
       .object({
         download_url: z.string().url().openapi({

--- a/apps/kaede/src/services/analysis-runs/analysis-run-repository.ts
+++ b/apps/kaede/src/services/analysis-runs/analysis-run-repository.ts
@@ -105,3 +105,23 @@ export const markAnalysisRunFailed = async (
     .returningAll()
     .executeTakeFirst()
 }
+
+export const markTimedOutAnalysisRunsFailed = async (
+  now: Date = new Date(),
+  executor: DbExecutor = db
+): Promise<number> => {
+  const runs = await executor
+    .updateTable('analysis_runs')
+    .set({
+      status: 'failed',
+      error_code: 'ANALYSIS_TIMEOUT',
+      finished_at: now,
+      updated_at: now,
+    })
+    .where('status', 'in', ['accepted', 'processing'])
+    .where('deadline_at', '<=', now)
+    .returning('id')
+    .execute()
+
+  return runs.length
+}

--- a/apps/kaede/src/services/analysis-runs/analysis-run-repository.ts
+++ b/apps/kaede/src/services/analysis-runs/analysis-run-repository.ts
@@ -1,0 +1,107 @@
+import type { Insertable, Selectable } from 'kysely'
+import type { AnalysisRuns, AnalysisRunTrajectories, JsonObject } from '../db/generated.js'
+import { db } from '../db/index.js'
+import type { DbExecutor } from '../executor.js'
+
+export type AnalysisRun = Selectable<AnalysisRuns>
+export type AnalysisRunTrajectory = Selectable<AnalysisRunTrajectories>
+
+type NewAnalysisRun = Omit<Insertable<AnalysisRuns>, 'parameters'> & {
+  parameters: JsonObject
+}
+type NewAnalysisRunTrajectory = Insertable<AnalysisRunTrajectories>
+
+export const insertAnalysisRun = async (
+  run: NewAnalysisRun,
+  executor: DbExecutor = db
+): Promise<AnalysisRun> => {
+  return executor
+    .insertInto('analysis_runs')
+    .values({ ...run, parameters: JSON.stringify(run.parameters) })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+}
+
+export const insertAnalysisRunTrajectories = async (
+  trajectories: NewAnalysisRunTrajectory[],
+  executor: DbExecutor = db
+): Promise<AnalysisRunTrajectory[]> => {
+  if (trajectories.length === 0) return []
+
+  return executor
+    .insertInto('analysis_run_trajectories')
+    .values(trajectories)
+    .returningAll()
+    .execute()
+}
+
+export const findAnalysisRunById = async (
+  analysisRunId: string,
+  executor: DbExecutor = db
+): Promise<AnalysisRun | undefined> => {
+  return executor
+    .selectFrom('analysis_runs')
+    .selectAll()
+    .where('id', '=', analysisRunId)
+    .executeTakeFirst()
+}
+
+export const listAnalysisRunTrajectories = async (
+  analysisRunId: string,
+  executor: DbExecutor = db
+): Promise<AnalysisRunTrajectory[]> => {
+  return executor
+    .selectFrom('analysis_run_trajectories')
+    .selectAll()
+    .where('analysis_run_id', '=', analysisRunId)
+    .orderBy('seq', 'asc')
+    .execute()
+}
+
+export const markAnalysisRunProcessing = async (
+  analysisRunId: string,
+  startedAt: Date = new Date(),
+  executor: DbExecutor = db
+): Promise<AnalysisRun | undefined> => {
+  return executor
+    .updateTable('analysis_runs')
+    .set({ status: 'processing', started_at: startedAt, updated_at: startedAt })
+    .where('id', '=', analysisRunId)
+    .where('status', '=', 'accepted')
+    .returningAll()
+    .executeTakeFirst()
+}
+
+export const markAnalysisRunCompleted = async (
+  analysisRunId: string,
+  finishedAt: Date = new Date(),
+  executor: DbExecutor = db
+): Promise<AnalysisRun | undefined> => {
+  return executor
+    .updateTable('analysis_runs')
+    .set({ status: 'completed', finished_at: finishedAt, updated_at: finishedAt })
+    .where('id', '=', analysisRunId)
+    .where('status', '=', 'processing')
+    .returningAll()
+    .executeTakeFirst()
+}
+
+export const markAnalysisRunFailed = async (
+  analysisRunId: string,
+  errorCode: string,
+  finishedAt: Date = new Date(),
+  executor: DbExecutor = db
+): Promise<AnalysisRun | undefined> => {
+  return executor
+    .updateTable('analysis_runs')
+    .set({
+      status: 'failed',
+      error_code: errorCode,
+      finished_at: finishedAt,
+      updated_at: finishedAt,
+    })
+    .where('id', '=', analysisRunId)
+    .where('status', 'in', ['accepted', 'processing'])
+    .returningAll()
+    .executeTakeFirst()
+}

--- a/apps/kaede/src/services/analysis-runs/analysis-run-repository.ts
+++ b/apps/kaede/src/services/analysis-runs/analysis-run-repository.ts
@@ -1,10 +1,20 @@
 import type { Insertable, Selectable } from 'kysely'
+import { sql } from 'kysely'
+import type { PaginationOptions } from '../../schemas/pagination.js'
 import type { AnalysisRuns, AnalysisRunTrajectories, JsonObject } from '../db/generated.js'
 import { db } from '../db/index.js'
 import type { DbExecutor } from '../executor.js'
 
 export type AnalysisRun = Selectable<AnalysisRuns>
 export type AnalysisRunTrajectory = Selectable<AnalysisRunTrajectories>
+export type AnalysisRunPageRow = AnalysisRun & { cursor_created_at: string }
+export type AnalysisRunTrajectoryState = AnalysisRunTrajectory & { deleted: boolean }
+
+export interface ListAnalysisRunsOptions extends PaginationOptions {
+  analysisType?: string
+  status?: string
+  floorId?: string
+}
 
 type NewAnalysisRun = Omit<Insertable<AnalysisRuns>, 'parameters'> & {
   parameters: JsonObject
@@ -46,6 +56,55 @@ export const findAnalysisRunById = async (
     .executeTakeFirst()
 }
 
+export const findOrganizationAnalysisRunById = async (
+  organizationId: string,
+  analysisRunId: string,
+  executor: DbExecutor = db
+): Promise<AnalysisRun | undefined> => {
+  return executor
+    .selectFrom('analysis_runs')
+    .selectAll()
+    .where('organization_id', '=', organizationId)
+    .where('id', '=', analysisRunId)
+    .executeTakeFirst()
+}
+
+export const listOrganizationAnalysisRuns = async (
+  organizationId: string,
+  options: ListAnalysisRunsOptions,
+  executor: DbExecutor = db
+): Promise<{ rows: AnalysisRunPageRow[]; totalCount: number }> => {
+  const scope = () => {
+    let query = executor.selectFrom('analysis_runs').where('organization_id', '=', organizationId)
+    if (options.analysisType) query = query.where('analysis_type', '=', options.analysisType)
+    if (options.status) query = query.where('status', '=', options.status)
+    if (options.floorId) query = query.where('floor_id', '=', options.floorId)
+    return query
+  }
+  let rowsQuery = scope()
+    .selectAll()
+    .select(
+      sql<string>`to_char(analysis_runs.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`.as(
+        'cursor_created_at'
+      )
+    )
+    .orderBy('created_at', 'desc')
+    .orderBy('id', 'desc')
+    .limit(options.limit + 1)
+  if (options.cursor) {
+    rowsQuery = rowsQuery.where(
+      sql<boolean>`(analysis_runs.created_at, analysis_runs.id) < (${options.cursor.createdAt}::timestamptz, ${options.cursor.id}::uuid)`
+    )
+  }
+  const [rows, count] = await Promise.all([
+    rowsQuery.execute(),
+    scope()
+      .select(({ fn }) => fn.countAll<string>().as('count'))
+      .executeTakeFirstOrThrow(),
+  ])
+  return { rows, totalCount: Number(count.count) }
+}
+
 export const listAnalysisRunTrajectories = async (
   analysisRunId: string,
   executor: DbExecutor = db
@@ -56,6 +115,26 @@ export const listAnalysisRunTrajectories = async (
     .where('analysis_run_id', '=', analysisRunId)
     .orderBy('seq', 'asc')
     .execute()
+}
+
+export const listAnalysisRunTrajectoryStates = async (
+  analysisRunId: string,
+  executor: DbExecutor = db
+): Promise<AnalysisRunTrajectoryState[]> => {
+  const rows = await executor
+    .selectFrom('analysis_run_trajectories')
+    .innerJoin('trajectories', 'trajectories.id', 'analysis_run_trajectories.trajectory_id')
+    .select([
+      'analysis_run_trajectories.analysis_run_id',
+      'analysis_run_trajectories.trajectory_id',
+      'analysis_run_trajectories.seq',
+      'trajectories.deleted_at',
+    ])
+    .where('analysis_run_id', '=', analysisRunId)
+    .orderBy('seq', 'asc')
+    .execute()
+
+  return rows.map(({ deleted_at, ...row }) => ({ ...row, deleted: deleted_at !== null }))
 }
 
 export const markAnalysisRunProcessing = async (

--- a/apps/kaede/src/services/analysis-runs/index.ts
+++ b/apps/kaede/src/services/analysis-runs/index.ts
@@ -6,5 +6,7 @@ export {
   markAnalysisRunCompleted,
   markAnalysisRunFailed,
   markAnalysisRunProcessing,
+  markTimedOutAnalysisRunsFailed,
 } from './analysis-run-repository.js'
+export { expireTimedOutAnalysisRuns } from './timeout-service.js'
 export type { AnalysisRun, AnalysisRunTrajectory } from './analysis-run-repository.js'

--- a/apps/kaede/src/services/analysis-runs/index.ts
+++ b/apps/kaede/src/services/analysis-runs/index.ts
@@ -1,0 +1,10 @@
+export {
+  findAnalysisRunById,
+  insertAnalysisRun,
+  insertAnalysisRunTrajectories,
+  listAnalysisRunTrajectories,
+  markAnalysisRunCompleted,
+  markAnalysisRunFailed,
+  markAnalysisRunProcessing,
+} from './analysis-run-repository.js'
+export type { AnalysisRun, AnalysisRunTrajectory } from './analysis-run-repository.js'

--- a/apps/kaede/src/services/analysis-runs/index.ts
+++ b/apps/kaede/src/services/analysis-runs/index.ts
@@ -1,12 +1,20 @@
 export {
   findAnalysisRunById,
+  findOrganizationAnalysisRunById,
   insertAnalysisRun,
   insertAnalysisRunTrajectories,
   listAnalysisRunTrajectories,
+  listAnalysisRunTrajectoryStates,
+  listOrganizationAnalysisRuns,
   markAnalysisRunCompleted,
   markAnalysisRunFailed,
   markAnalysisRunProcessing,
   markTimedOutAnalysisRunsFailed,
 } from './analysis-run-repository.js'
 export { expireTimedOutAnalysisRuns } from './timeout-service.js'
-export type { AnalysisRun, AnalysisRunTrajectory } from './analysis-run-repository.js'
+export type {
+  AnalysisRun,
+  AnalysisRunPageRow,
+  AnalysisRunTrajectory,
+  AnalysisRunTrajectoryState,
+} from './analysis-run-repository.js'

--- a/apps/kaede/src/services/analysis-runs/timeout-service.ts
+++ b/apps/kaede/src/services/analysis-runs/timeout-service.ts
@@ -1,0 +1,11 @@
+import { markTimedOutAnalysisRunsFailed } from './analysis-run-repository.js'
+
+export const expireTimedOutAnalysisRuns = async (now: Date = new Date()): Promise<number> => {
+  const expiredCount = await markTimedOutAnalysisRunsFailed(now)
+
+  if (expiredCount > 0) {
+    console.info(`Marked ${expiredCount} analysis run(s) as timed out`)
+  }
+
+  return expiredCount
+}

--- a/apps/kaede/src/services/db/generated.ts
+++ b/apps/kaede/src/services/db/generated.ts
@@ -52,6 +52,8 @@ export interface Floors {
   id: Generated<string>
   image_object_path: string
   level: number
+  map_height_px: number | null
+  map_width_px: number | null
   name: string
   organization_id: string
   scale: number | null

--- a/apps/kaede/src/services/db/generated.ts
+++ b/apps/kaede/src/services/db/generated.ts
@@ -36,6 +36,28 @@ export interface AuthIdentities {
   user_id: string
 }
 
+export interface AnalysisRuns {
+  analysis_type: string
+  created_at: Generated<Timestamp>
+  deadline_at: Generated<Timestamp>
+  definition_version: string
+  error_code: string | null
+  finished_at: Timestamp | null
+  floor_id: string
+  id: Generated<string>
+  organization_id: string
+  parameters: Json
+  started_at: Timestamp | null
+  status: Generated<string>
+  updated_at: Generated<Timestamp>
+}
+
+export interface AnalysisRunTrajectories {
+  analysis_run_id: string
+  seq: number
+  trajectory_id: string
+}
+
 export interface Buildings {
   created_at: Generated<Timestamp>
   id: Generated<string>
@@ -192,6 +214,8 @@ export interface Users {
 }
 
 export interface DB {
+  analysis_run_trajectories: AnalysisRunTrajectories
+  analysis_runs: AnalysisRuns
   auth_identities: AuthIdentities
   buildings: Buildings
   floors: Floors

--- a/apps/kaede/src/services/floor-maps/dimensions.ts
+++ b/apps/kaede/src/services/floor-maps/dimensions.ts
@@ -1,0 +1,59 @@
+import type { FloorMapImageExtension } from '../storage/presigned-url.js'
+
+export const floorMapMaxSidePx = 20_000
+export const floorMapMaxPixels = 100_000_000
+
+export interface FloorMapDimensions {
+  width: number
+  height: number
+}
+
+const pngMagicNumber = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+
+const areValidDimensions = ({ width, height }: FloorMapDimensions) =>
+  Number.isInteger(width) &&
+  Number.isInteger(height) &&
+  width > 0 &&
+  height > 0 &&
+  width <= floorMapMaxSidePx &&
+  height <= floorMapMaxSidePx &&
+  width * height <= floorMapMaxPixels
+
+const extractPngDimensions = (bytes: Uint8Array): FloorMapDimensions | undefined => {
+  if (
+    bytes.byteLength < 24 ||
+    !pngMagicNumber.every((value, index) => bytes[index] === value) ||
+    new TextDecoder('ascii').decode(bytes.slice(12, 16)) !== 'IHDR'
+  ) {
+    return undefined
+  }
+
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  const dimensions = { width: view.getUint32(16), height: view.getUint32(20) }
+  return areValidDimensions(dimensions) ? dimensions : undefined
+}
+
+const extractSvgDimensions = (bytes: Uint8Array): FloorMapDimensions | undefined => {
+  const text = new TextDecoder('utf-8', { fatal: false }).decode(bytes)
+  const svgTag = /<\s*svg\b[^>]*>/i.exec(text)?.[0]
+  if (
+    !svgTag ||
+    /<\s*script(?:\s|>)/i.test(text) ||
+    /<\s*foreignObject(?:\s|>)/i.test(text) ||
+    /\son[a-z]+\s*=/i.test(text)
+  ) {
+    return undefined
+  }
+
+  const viewBox = /\bviewBox\s*=\s*["']\s*0\s+0\s+(\d+)\s+(\d+)\s*["']/i.exec(svgTag)
+  if (!viewBox) return undefined
+
+  const dimensions = { width: Number(viewBox[1]), height: Number(viewBox[2]) }
+  return areValidDimensions(dimensions) ? dimensions : undefined
+}
+
+export const extractFloorMapDimensions = (
+  bytes: Uint8Array,
+  extension: FloorMapImageExtension
+): FloorMapDimensions | undefined =>
+  extension === 'png' ? extractPngDimensions(bytes) : extractSvgDimensions(bytes)

--- a/apps/kaede/src/services/floors/floor-repository.ts
+++ b/apps/kaede/src/services/floors/floor-repository.ts
@@ -19,6 +19,8 @@ export interface FloorRow {
   level: number
   name: string
   image_object_path: string
+  map_width_px: number | null
+  map_height_px: number | null
   scale: number | null
   created_at: Date
   updated_at: Date
@@ -36,6 +38,8 @@ const floorRowsQuery = () =>
       'floors.level',
       'floors.name',
       'floors.image_object_path',
+      'floors.map_width_px',
+      'floors.map_height_px',
       'floors.scale',
       'floors.created_at',
       'floors.updated_at',

--- a/apps/kaede/src/services/floors/floor-repository.ts
+++ b/apps/kaede/src/services/floors/floor-repository.ts
@@ -26,6 +26,13 @@ export interface FloorRow {
   updated_at: Date
 }
 
+export interface FloorMapDimensionRow {
+  id: string
+  image_object_path: string
+  map_width_px: number | null
+  map_height_px: number | null
+}
+
 const floorRowsQuery = () =>
   db
     .selectFrom('floors')
@@ -103,4 +110,33 @@ export const findFloorById = async (
     .select(['id', 'organization_id', 'scale', 'map_width_px', 'map_height_px'])
     .where('id', '=', floorId)
     .executeTakeFirst()
+}
+
+export const listFloorMapDimensionRows = async (
+  floorId?: string,
+  executor: DbExecutor = db
+): Promise<FloorMapDimensionRow[]> => {
+  let query = executor
+    .selectFrom('floors')
+    .select(['id', 'image_object_path', 'map_width_px', 'map_height_px'])
+    .orderBy('id', 'asc')
+  if (floorId) query = query.where('id', '=', floorId)
+  return query.execute()
+}
+
+export const backfillFloorMapDimensions = async (
+  floorId: string,
+  width: number,
+  height: number,
+  executor: DbExecutor = db
+): Promise<boolean> => {
+  const updated = await executor
+    .updateTable('floors')
+    .set({ map_width_px: width, map_height_px: height, updated_at: new Date() })
+    .where('id', '=', floorId)
+    .where('map_width_px', 'is', null)
+    .where('map_height_px', 'is', null)
+    .returning('id')
+    .executeTakeFirst()
+  return updated !== undefined
 }

--- a/apps/kaede/src/services/floors/floor-repository.ts
+++ b/apps/kaede/src/services/floors/floor-repository.ts
@@ -95,10 +95,12 @@ export const insertFloor = async (
 export const findFloorById = async (
   floorId: string,
   executor: DbExecutor = db
-): Promise<Pick<Floor, 'id' | 'organization_id' | 'scale'> | undefined> => {
+): Promise<
+  Pick<Floor, 'id' | 'organization_id' | 'scale' | 'map_width_px' | 'map_height_px'> | undefined
+> => {
   return executor
     .selectFrom('floors')
-    .select(['id', 'organization_id', 'scale'])
+    .select(['id', 'organization_id', 'scale', 'map_width_px', 'map_height_px'])
     .where('id', '=', floorId)
     .executeTakeFirst()
 }

--- a/apps/kaede/src/services/floors/index.ts
+++ b/apps/kaede/src/services/floors/index.ts
@@ -1,1 +1,8 @@
-export { findFloorById, findFloorDetailById, insertFloor, listFloors } from './floor-repository.js'
+export {
+  backfillFloorMapDimensions,
+  findFloorById,
+  findFloorDetailById,
+  insertFloor,
+  listFloorMapDimensionRows,
+  listFloors,
+} from './floor-repository.js'

--- a/apps/kaede/src/services/nozomi/analyze-client.ts
+++ b/apps/kaede/src/services/nozomi/analyze-client.ts
@@ -6,6 +6,11 @@ const analyzeAcceptedResponseSchema = z.object({
   status: z.literal('accepted'),
 })
 
+const stayHeatmapAcceptedResponseSchema = z.object({
+  analysis_run_id: z.string().uuid(),
+  status: z.literal('accepted'),
+})
+
 export interface AnalyzeConstraint {
   seq: number
   point_type: 'start' | 'waypoint' | 'goal'
@@ -60,4 +65,47 @@ export const submitAnalyzeRequest = async (payload: AnalyzeRequestPayload) => {
 
   const raw = await response.json()
   return analyzeAcceptedResponseSchema.parse(raw)
+}
+
+export interface StayHeatmapAnalyzeRequestPayload {
+  analysis_run_id: string
+  analysis_type: 'stay_heatmap'
+  definition_version: 'original-v1'
+  parameters: {
+    speed_threshold_mps: number
+    grid_size_m: number
+  }
+  floor: {
+    floor_id: string
+    map_width_px: number
+    map_height_px: number
+    scale_m_per_px: number
+  }
+  trajectories: {
+    trajectory_id: string
+    seq: number
+    start: { x_px: number; y_px: number }
+    source: { download_url: string }
+    output: { upload_url: string }
+  }[]
+  heatmap_output: { upload_url: string }
+  callback: { url: string; token: string }
+}
+
+export const submitStayHeatmapAnalyzeRequest = async (
+  payload: StayHeatmapAnalyzeRequestPayload
+) => {
+  const config = getNozomiRuntimeConfig()
+  const response = await fetch(`${config.internalEndpoint}/stay-heatmaps/analyze`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(config.requestTimeoutMs),
+  })
+
+  if (!response.ok) {
+    throw new Error(`nozomi stay heatmap request failed with status ${response.status}`)
+  }
+
+  return stayHeatmapAcceptedResponseSchema.parse(await response.json())
 }

--- a/apps/kaede/src/services/nozomi/index.ts
+++ b/apps/kaede/src/services/nozomi/index.ts
@@ -1,3 +1,3 @@
-export { submitAnalyzeRequest } from './analyze-client.js'
-export type { AnalyzeRequestPayload } from './analyze-client.js'
+export { submitAnalyzeRequest, submitStayHeatmapAnalyzeRequest } from './analyze-client.js'
+export type { AnalyzeRequestPayload, StayHeatmapAnalyzeRequestPayload } from './analyze-client.js'
 export { pingNozomi } from './ping-client.js'

--- a/apps/kaede/src/services/storage/index.ts
+++ b/apps/kaede/src/services/storage/index.ts
@@ -4,6 +4,7 @@ export {
   doesTrajectoryAnalyzedResultObjectExist,
   getTrajectoryAnalyzedResultObjectText,
   getAnalysisHeatmapObjectText,
+  getFloorMapObjectBytes,
   listRecordingRawObjectKeys,
   putFloorMapObject,
 } from './object-store.js'

--- a/apps/kaede/src/services/storage/index.ts
+++ b/apps/kaede/src/services/storage/index.ts
@@ -7,6 +7,8 @@ export {
 } from './object-store.js'
 export {
   buildFloorMapObjectKey,
+  buildAnalysisHeatmapObjectKey,
+  buildAnalysisTrajectoryCsvObjectKey,
   buildTrajectoryAnalyzedResultObjectKey,
   buildRecordingRawObjectPrefix,
   buildRecordingRawObjectKey,
@@ -14,10 +16,14 @@ export {
   getFloorMapContentType,
   getFloorMapExtensionFromObjectKey,
   issueInternalRecordingRawDownloadUrls,
+  issueInternalAnalysisHeatmapUploadUrl,
+  issueInternalAnalysisTrajectoryDownloadUrl,
+  issueInternalAnalysisTrajectoryUploadUrl,
   issueInternalTrajectoryResultUploadUrl,
   issueRecordingRawDownloadUrls,
   issueRecordingUploadUrls,
   issueTrajectoryResultDownloadUrl,
+  issueAnalysisTrajectoryCsvDownloadUrl,
 } from './presigned-url.js'
 export { resetS3ClientForTests } from './s3-client.js'
 export type {

--- a/apps/kaede/src/services/storage/index.ts
+++ b/apps/kaede/src/services/storage/index.ts
@@ -1,7 +1,9 @@
 export {
   deleteFloorMapObject,
+  doesAnalysisTrajectoryCsvObjectExist,
   doesTrajectoryAnalyzedResultObjectExist,
   getTrajectoryAnalyzedResultObjectText,
+  getAnalysisHeatmapObjectText,
   listRecordingRawObjectKeys,
   putFloorMapObject,
 } from './object-store.js'

--- a/apps/kaede/src/services/storage/index.ts
+++ b/apps/kaede/src/services/storage/index.ts
@@ -2,6 +2,7 @@ export {
   deleteFloorMapObject,
   doesTrajectoryAnalyzedResultObjectExist,
   getTrajectoryAnalyzedResultObjectText,
+  getAnalysisHeatmapObjectText,
   listRecordingRawObjectKeys,
   putFloorMapObject,
 } from './object-store.js'

--- a/apps/kaede/src/services/storage/object-store.ts
+++ b/apps/kaede/src/services/storage/object-store.ts
@@ -43,6 +43,28 @@ export const deleteFloorMapObject = async (objectKey: string) => {
   )
 }
 
+export const getFloorMapObjectBytes = async (
+  objectKey: string
+): Promise<Uint8Array | undefined> => {
+  const { config, internalClient } = getS3Context()
+  try {
+    const response = await internalClient.send(
+      new GetObjectCommand({ Bucket: config.bucket, Key: objectKey })
+    )
+    return response.Body ? await response.Body.transformToByteArray() : new Uint8Array()
+  } catch (error) {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'name' in error &&
+      (error.name === 'NotFound' || error.name === 'NoSuchKey')
+    ) {
+      return undefined
+    }
+    throw error
+  }
+}
+
 export const listRecordingRawObjectKeys = async (organizationId: string, recordingId: string) => {
   const { config, internalClient } = getS3Context()
   const prefix = buildRecordingRawObjectPrefix(organizationId, recordingId)

--- a/apps/kaede/src/services/storage/object-store.ts
+++ b/apps/kaede/src/services/storage/object-store.ts
@@ -7,6 +7,7 @@ import {
 } from '@aws-sdk/client-s3'
 import {
   buildRecordingRawObjectPrefix,
+  buildAnalysisHeatmapObjectKey,
   buildTrajectoryAnalyzedResultObjectKey,
   getFloorMapContentType,
 } from './presigned-url.js'
@@ -128,6 +129,31 @@ export const getTrajectoryAnalyzedResultObjectText = async (
       return undefined
     }
 
+    throw error
+  }
+}
+
+export const getAnalysisHeatmapObjectText = async (
+  organizationId: string,
+  analysisRunId: string
+): Promise<string | undefined> => {
+  const objectKey = buildAnalysisHeatmapObjectKey(organizationId, analysisRunId)
+  const { config, internalClient } = getS3Context()
+
+  try {
+    const response = await internalClient.send(
+      new GetObjectCommand({ Bucket: config.bucket, Key: objectKey })
+    )
+    return response.Body ? await response.Body.transformToString() : ''
+  } catch (error) {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'name' in error &&
+      (error.name === 'NotFound' || error.name === 'NoSuchKey')
+    ) {
+      return undefined
+    }
     throw error
   }
 }

--- a/apps/kaede/src/services/storage/object-store.ts
+++ b/apps/kaede/src/services/storage/object-store.ts
@@ -6,6 +6,8 @@ import {
   PutObjectCommand,
 } from '@aws-sdk/client-s3'
 import {
+  buildAnalysisHeatmapObjectKey,
+  buildAnalysisTrajectoryCsvObjectKey,
   buildRecordingRawObjectPrefix,
   buildTrajectoryAnalyzedResultObjectKey,
   getFloorMapContentType,
@@ -128,6 +130,55 @@ export const getTrajectoryAnalyzedResultObjectText = async (
       return undefined
     }
 
+    throw error
+  }
+}
+
+const doesObjectExist = async (objectKey: string) => {
+  const { config, internalClient } = getS3Context()
+  try {
+    await internalClient.send(new HeadObjectCommand({ Bucket: config.bucket, Key: objectKey }))
+    return true
+  } catch (error) {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'name' in error &&
+      (error.name === 'NotFound' || error.name === 'NoSuchKey')
+    ) {
+      return false
+    }
+    throw error
+  }
+}
+
+export const doesAnalysisTrajectoryCsvObjectExist = (
+  organizationId: string,
+  analysisRunId: string,
+  trajectoryId: string
+) =>
+  doesObjectExist(buildAnalysisTrajectoryCsvObjectKey(organizationId, analysisRunId, trajectoryId))
+
+export const getAnalysisHeatmapObjectText = async (
+  organizationId: string,
+  analysisRunId: string
+): Promise<string | undefined> => {
+  const objectKey = buildAnalysisHeatmapObjectKey(organizationId, analysisRunId)
+  const { config, internalClient } = getS3Context()
+  try {
+    const response = await internalClient.send(
+      new GetObjectCommand({ Bucket: config.bucket, Key: objectKey })
+    )
+    return response.Body ? await response.Body.transformToString() : ''
+  } catch (error) {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'name' in error &&
+      (error.name === 'NotFound' || error.name === 'NoSuchKey')
+    ) {
+      return undefined
+    }
     throw error
   }
 }

--- a/apps/kaede/src/services/storage/presigned-url.test.ts
+++ b/apps/kaede/src/services/storage/presigned-url.test.ts
@@ -1,12 +1,18 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { StorageRuntimeConfig } from '../../config/runtime.js'
 import {
+  buildAnalysisHeatmapObjectKey,
+  buildAnalysisTrajectoryCsvObjectKey,
   buildFloorMapObjectKey,
   buildRecordingRawObjectKey,
   buildTrajectoryAnalyzedResultObjectKey,
   getFloorMapContentType,
   getFloorMapExtensionFromObjectKey,
   issueFloorMapDownloadUrl,
+  issueAnalysisTrajectoryCsvDownloadUrl,
+  issueInternalAnalysisHeatmapUploadUrl,
+  issueInternalAnalysisTrajectoryDownloadUrl,
+  issueInternalAnalysisTrajectoryUploadUrl,
   issueRecordingRawDownloadUrls,
   issueRecordingUploadUrls,
   issueTrajectoryResultDownloadUrl,
@@ -28,6 +34,87 @@ afterEach(() => {
 })
 
 describe('storage presigned url service', () => {
+  const analysisOrganizationId = '22222222-2222-4222-8222-222222222222'
+  const analysisRunId = '33333333-3333-4333-8333-333333333333'
+  const analysisTrajectoryId = '44444444-4444-4444-8444-444444444444'
+
+  const mockStorageConfig = () => {
+    getStorageRuntimeConfigMock.mockReturnValue({
+      accessKeyId: 'kaede-test',
+      secretAccessKey: 'kaede-secret',
+      internalEndpoint: 'http://seaweedfs:8333',
+      publicEndpoint: 'http://127.0.0.1:8333',
+      region: 'us-east-1',
+      bucket: 'okarin-local',
+      floorMapDownloadUrlTtlSeconds: 3600,
+      recordingRawDownloadUrlTtlSeconds: 900,
+      recordingUploadUrlTtlSeconds: 900,
+      trajectoryRawDownloadUrlTtlSeconds: 86400,
+      trajectoryResultDownloadUrlTtlSeconds: 900,
+      trajectoryResultUploadUrlTtlSeconds: 86400,
+    })
+  }
+
+  it('analysis artifact key をrun単位の保存規約どおりに組み立てる', () => {
+    expect(
+      buildAnalysisTrajectoryCsvObjectKey(
+        analysisOrganizationId,
+        analysisRunId,
+        analysisTrajectoryId
+      )
+    ).toBe(
+      `organizations/${analysisOrganizationId}/analysis-runs/${analysisRunId}/artifacts/trajectories/${analysisTrajectoryId}/stay.csv`
+    )
+    expect(buildAnalysisHeatmapObjectKey(analysisOrganizationId, analysisRunId)).toBe(
+      `organizations/${analysisOrganizationId}/analysis-runs/${analysisRunId}/artifacts/stay-heatmap.json`
+    )
+  })
+
+  it('Nozomi用analysis URLを既存の24時間設定で生成できる', async () => {
+    mockStorageConfig()
+    const now = new Date('2026-08-04T00:00:00.000Z')
+
+    const [source, trajectoryOutput, heatmapOutput] = await Promise.all([
+      issueInternalAnalysisTrajectoryDownloadUrl(analysisOrganizationId, analysisTrajectoryId, now),
+      issueInternalAnalysisTrajectoryUploadUrl(
+        analysisOrganizationId,
+        analysisRunId,
+        analysisTrajectoryId,
+        now
+      ),
+      issueInternalAnalysisHeatmapUploadUrl(analysisOrganizationId, analysisRunId, now),
+    ])
+
+    expect(source.expiresAt).toBe('2026-08-05T00:00:00.000Z')
+    expect(trajectoryOutput.expiresAt).toBe('2026-08-05T00:00:00.000Z')
+    expect(heatmapOutput.expiresAt).toBe('2026-08-05T00:00:00.000Z')
+    expect(new URL(source.downloadUrl).origin).toBe('http://seaweedfs:8333')
+    expect(new URL(source.downloadUrl).searchParams.get('X-Amz-Expires')).toBe('86400')
+    expect(new URL(trajectoryOutput.uploadUrl).pathname).toBe(
+      `/okarin-local/${trajectoryOutput.objectKey}`
+    )
+    expect(new URL(heatmapOutput.uploadUrl).pathname).toBe(
+      `/okarin-local/${heatmapOutput.objectKey}`
+    )
+  })
+
+  it('公開用analysis CSV URLを15分設定で生成できる', async () => {
+    mockStorageConfig()
+    const now = new Date('2026-08-04T00:00:00.000Z')
+
+    const result = await issueAnalysisTrajectoryCsvDownloadUrl(
+      analysisOrganizationId,
+      analysisRunId,
+      analysisTrajectoryId,
+      now
+    )
+
+    expect(result.expiresAt).toBe('2026-08-04T00:15:00.000Z')
+    expect(new URL(result.downloadUrl).origin).toBe('http://127.0.0.1:8333')
+    expect(new URL(result.downloadUrl).searchParams.get('X-Amz-Expires')).toBe('900')
+    expect(new URL(result.downloadUrl).pathname).toBe(`/okarin-local/${result.objectKey}`)
+  })
+
   it('recording raw object key を保存規約どおりに組み立てる', () => {
     expect(
       buildRecordingRawObjectKey(

--- a/apps/kaede/src/services/storage/presigned-url.ts
+++ b/apps/kaede/src/services/storage/presigned-url.ts
@@ -91,6 +91,18 @@ export const buildTrajectoryAnalyzedResultObjectKey = (
   return `organizations/${validateObjectKeyUuid(organizationId, 'organizationId')}/trajectories/${validateObjectKeyUuid(trajectoryId, 'trajectoryId')}/analyzed/result.csv`
 }
 
+export const buildAnalysisTrajectoryCsvObjectKey = (
+  organizationId: string,
+  analysisRunId: string,
+  trajectoryId: string
+) => {
+  return `organizations/${validateObjectKeyUuid(organizationId, 'organizationId')}/analysis-runs/${validateObjectKeyUuid(analysisRunId, 'analysisRunId')}/artifacts/trajectories/${validateObjectKeyUuid(trajectoryId, 'trajectoryId')}/stay.csv`
+}
+
+export const buildAnalysisHeatmapObjectKey = (organizationId: string, analysisRunId: string) => {
+  return `organizations/${validateObjectKeyUuid(organizationId, 'organizationId')}/analysis-runs/${validateObjectKeyUuid(analysisRunId, 'analysisRunId')}/artifacts/stay-heatmap.json`
+}
+
 export const issueRecordingUploadUrls = async (
   organizationId: string,
   recordingId: string,
@@ -272,6 +284,96 @@ export const issueTrajectoryResultDownloadUrl = async (
       Bucket: config.bucket,
       Key: objectKey,
     }),
+    { expiresIn: config.trajectoryResultDownloadUrlTtlSeconds }
+  )
+
+  return {
+    downloadUrl,
+    expiresAt: new Date(
+      now.getTime() + config.trajectoryResultDownloadUrlTtlSeconds * 1000
+    ).toISOString(),
+    objectKey,
+  }
+}
+
+export const issueInternalAnalysisTrajectoryDownloadUrl = async (
+  organizationId: string,
+  trajectoryId: string,
+  now: Date = new Date()
+) => {
+  const { config, internalClient } = getS3Context()
+  const objectKey = buildTrajectoryAnalyzedResultObjectKey(organizationId, trajectoryId)
+  const downloadUrl = await getSignedUrl(
+    internalClient,
+    new GetObjectCommand({ Bucket: config.bucket, Key: objectKey }),
+    { expiresIn: config.trajectoryRawDownloadUrlTtlSeconds }
+  )
+
+  return {
+    downloadUrl,
+    expiresAt: new Date(
+      now.getTime() + config.trajectoryRawDownloadUrlTtlSeconds * 1000
+    ).toISOString(),
+    objectKey,
+  }
+}
+
+export const issueInternalAnalysisTrajectoryUploadUrl = async (
+  organizationId: string,
+  analysisRunId: string,
+  trajectoryId: string,
+  now: Date = new Date()
+) => {
+  const { config, internalClient } = getS3Context()
+  const objectKey = buildAnalysisTrajectoryCsvObjectKey(organizationId, analysisRunId, trajectoryId)
+  const uploadUrl = await getSignedUrl(
+    internalClient,
+    new PutObjectCommand({ Bucket: config.bucket, Key: objectKey }),
+    { expiresIn: config.trajectoryResultUploadUrlTtlSeconds }
+  )
+
+  return {
+    expiresAt: new Date(
+      now.getTime() + config.trajectoryResultUploadUrlTtlSeconds * 1000
+    ).toISOString(),
+    objectKey,
+    uploadUrl,
+  }
+}
+
+export const issueInternalAnalysisHeatmapUploadUrl = async (
+  organizationId: string,
+  analysisRunId: string,
+  now: Date = new Date()
+) => {
+  const { config, internalClient } = getS3Context()
+  const objectKey = buildAnalysisHeatmapObjectKey(organizationId, analysisRunId)
+  const uploadUrl = await getSignedUrl(
+    internalClient,
+    new PutObjectCommand({ Bucket: config.bucket, Key: objectKey }),
+    { expiresIn: config.trajectoryResultUploadUrlTtlSeconds }
+  )
+
+  return {
+    expiresAt: new Date(
+      now.getTime() + config.trajectoryResultUploadUrlTtlSeconds * 1000
+    ).toISOString(),
+    objectKey,
+    uploadUrl,
+  }
+}
+
+export const issueAnalysisTrajectoryCsvDownloadUrl = async (
+  organizationId: string,
+  analysisRunId: string,
+  trajectoryId: string,
+  now: Date = new Date()
+) => {
+  const { config, presignClient } = getS3Context()
+  const objectKey = buildAnalysisTrajectoryCsvObjectKey(organizationId, analysisRunId, trajectoryId)
+  const downloadUrl = await getSignedUrl(
+    presignClient,
+    new GetObjectCommand({ Bucket: config.bucket, Key: objectKey }),
     { expiresIn: config.trajectoryResultDownloadUrlTtlSeconds }
   )
 

--- a/apps/kaede/src/services/trajectories/callback-token.ts
+++ b/apps/kaede/src/services/trajectories/callback-token.ts
@@ -37,6 +37,20 @@ export type VerifyCallbackTokenResult =
       error: 'CALLBACK_TOKEN_INVALID' | 'CALLBACK_TOKEN_EXPIRED'
     }
 
+export type VerifyAnalysisCallbackTokenResult =
+  | {
+      ok: true
+      value: {
+        analysisRunId: string
+        analysisType: 'stay_heatmap'
+        exp: number
+      }
+    }
+  | {
+      ok: false
+      error: 'CALLBACK_TOKEN_INVALID' | 'CALLBACK_TOKEN_EXPIRED'
+    }
+
 export const generateCallbackToken = (trajectoryId: string, now: Date = new Date()): string => {
   const callbackConfig = getCallbackRuntimeConfig()
   const exp = Math.floor(now.getTime() / 1000) + callbackConfig.tokenTtlSeconds
@@ -123,6 +137,59 @@ export const verifyCallbackToken = (
     value: {
       trajectoryId: parsedPayload.trajectory_id,
       exp: parsedPayload.exp,
+    },
+  }
+}
+
+export const verifyAnalysisCallbackToken = (
+  token: string,
+  now: Date = new Date()
+): VerifyAnalysisCallbackTokenResult => {
+  const callbackConfig = getCallbackRuntimeConfig()
+  const [payload, signature, ...rest] = token.split('.')
+  if (!payload || !signature || rest.length > 0) {
+    return { ok: false, error: 'CALLBACK_TOKEN_INVALID' }
+  }
+
+  const expectedSignature = createHmac('sha256', callbackConfig.tokenSecret)
+    .update(payload)
+    .digest('base64url')
+  if (
+    signature.length !== expectedSignature.length ||
+    !timingSafeEqual(Buffer.from(signature), Buffer.from(expectedSignature))
+  ) {
+    return { ok: false, error: 'CALLBACK_TOKEN_INVALID' }
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(base64UrlDecode(payload)) as unknown
+  } catch {
+    return { ok: false, error: 'CALLBACK_TOKEN_INVALID' }
+  }
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    !('analysis_run_id' in parsed) ||
+    !('analysis_type' in parsed) ||
+    !('exp' in parsed) ||
+    typeof parsed.analysis_run_id !== 'string' ||
+    parsed.analysis_type !== 'stay_heatmap' ||
+    typeof parsed.exp !== 'number' ||
+    !Number.isFinite(parsed.exp)
+  ) {
+    return { ok: false, error: 'CALLBACK_TOKEN_INVALID' }
+  }
+  if (parsed.exp <= Math.floor(now.getTime() / 1000)) {
+    return { ok: false, error: 'CALLBACK_TOKEN_EXPIRED' }
+  }
+
+  return {
+    ok: true,
+    value: {
+      analysisRunId: parsed.analysis_run_id,
+      analysisType: parsed.analysis_type,
+      exp: parsed.exp,
     },
   }
 }

--- a/apps/kaede/src/services/trajectories/callback-token.ts
+++ b/apps/kaede/src/services/trajectories/callback-token.ts
@@ -9,6 +9,21 @@ interface CallbackTokenPayload {
   exp: number
 }
 
+interface AnalysisCallbackTokenPayload {
+  analysis_run_id: string
+  analysis_type: 'stay_heatmap'
+  exp: number
+}
+
+const signCallbackPayload = (payload: CallbackTokenPayload | AnalysisCallbackTokenPayload) => {
+  const encodedPayload = base64UrlEncode(JSON.stringify(payload))
+  const signature = createHmac('sha256', getCallbackRuntimeConfig().tokenSecret)
+    .update(encodedPayload)
+    .digest('base64url')
+
+  return `${encodedPayload}.${signature}`
+}
+
 export type VerifyCallbackTokenResult =
   | {
       ok: true
@@ -25,18 +40,20 @@ export type VerifyCallbackTokenResult =
 export const generateCallbackToken = (trajectoryId: string, now: Date = new Date()): string => {
   const callbackConfig = getCallbackRuntimeConfig()
   const exp = Math.floor(now.getTime() / 1000) + callbackConfig.tokenTtlSeconds
-  const payload = base64UrlEncode(
-    JSON.stringify({
-      trajectory_id: trajectoryId,
-      exp,
-    })
-  )
+  return signCallbackPayload({ trajectory_id: trajectoryId, exp })
+}
 
-  const signature = createHmac('sha256', callbackConfig.tokenSecret)
-    .update(payload)
-    .digest('base64url')
-
-  return `${payload}.${signature}`
+export const generateAnalysisCallbackToken = (
+  analysisRunId: string,
+  now: Date = new Date()
+): string => {
+  const callbackConfig = getCallbackRuntimeConfig()
+  const exp = Math.floor(now.getTime() / 1000) + callbackConfig.tokenTtlSeconds
+  return signCallbackPayload({
+    analysis_run_id: analysisRunId,
+    analysis_type: 'stay_heatmap',
+    exp,
+  })
 }
 
 export const verifyCallbackToken = (

--- a/apps/kaede/src/usecases/analysis-runs/create-stay-heatmap.test.ts
+++ b/apps/kaede/src/usecases/analysis-runs/create-stay-heatmap.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import { createStayHeatmap } from './create-stay-heatmap.js'
+
+const mocks = vi.hoisted(() => ({
+  findTrajectoryById: vi.fn(),
+  findFloorById: vi.fn(),
+  insertAnalysisRun: vi.fn(),
+  insertInputs: vi.fn(),
+  markProcessing: vi.fn(),
+  markFailed: vi.fn(),
+  sourceUrl: vi.fn(),
+  outputUrl: vi.fn(),
+  heatmapUrl: vi.fn(),
+  callbackToken: vi.fn(),
+  submit: vi.fn(),
+  transaction: vi.fn(),
+}))
+
+vi.mock('../../services/db/index.js', () => ({
+  db: { transaction: () => ({ execute: mocks.transaction }) },
+}))
+vi.mock('../../services/analysis-runs/index.js', () => ({
+  insertAnalysisRun: mocks.insertAnalysisRun,
+  insertAnalysisRunTrajectories: mocks.insertInputs,
+  markAnalysisRunProcessing: mocks.markProcessing,
+  markAnalysisRunFailed: mocks.markFailed,
+}))
+vi.mock('../../services/trajectories/index.js', () => ({
+  findTrajectoryById: mocks.findTrajectoryById,
+}))
+vi.mock('../../services/trajectories/callback-token.js', () => ({
+  generateAnalysisCallbackToken: mocks.callbackToken,
+}))
+vi.mock('../../services/floors/index.js', () => ({ findFloorById: mocks.findFloorById }))
+vi.mock('../../services/nozomi/index.js', () => ({
+  submitStayHeatmapAnalyzeRequest: mocks.submit,
+}))
+vi.mock('../../services/storage/index.js', () => ({
+  issueInternalAnalysisTrajectoryDownloadUrl: mocks.sourceUrl,
+  issueInternalAnalysisTrajectoryUploadUrl: mocks.outputUrl,
+  issueInternalAnalysisHeatmapUploadUrl: mocks.heatmapUrl,
+}))
+vi.mock('../../config/runtime.js', () => ({
+  getCallbackRuntimeConfig: () => ({ baseUrl: 'https://kaede.test' }),
+}))
+
+const organizationId = '11111111-1111-4111-8111-111111111111'
+const floorId = '22222222-2222-4222-8222-222222222222'
+const trajectoryId = '33333333-3333-4333-8333-333333333333'
+const runId = '44444444-4444-4444-8444-444444444444'
+const actor: RequestActor = {
+  type: 'user',
+  user_id: '55555555-5555-4555-8555-555555555555',
+  email: 'manager@example.com',
+  global_role: 'none',
+  account_state: 'active',
+  memberships: [{ organization_id: organizationId, organization_name: 'Test', role: 'manager' }],
+}
+
+describe('createStayHeatmap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.findTrajectoryById.mockResolvedValue({
+      id: trajectoryId,
+      organization_id: organizationId,
+      floor_id: floorId,
+      status: 'completed',
+      constraints: [
+        { seq: 0, point_type: 'start', x: 10, y: 20 },
+        { seq: 1, point_type: 'goal', x: 30, y: 40 },
+      ],
+    })
+    mocks.findFloorById.mockResolvedValue({
+      id: floorId,
+      organization_id: organizationId,
+      scale: 0.01,
+      map_width_px: 100,
+      map_height_px: 200,
+    })
+    mocks.insertAnalysisRun.mockResolvedValue({ id: runId })
+    mocks.insertInputs.mockResolvedValue([])
+    mocks.markProcessing.mockResolvedValue({ id: runId })
+    mocks.markFailed.mockResolvedValue({ id: runId, status: 'failed' })
+    mocks.transaction.mockImplementation((callback) => callback({}))
+    mocks.sourceUrl.mockResolvedValue({ downloadUrl: 'https://storage.test/input.csv' })
+    mocks.outputUrl.mockResolvedValue({ uploadUrl: 'https://storage.test/stay.csv' })
+    mocks.heatmapUrl.mockResolvedValue({ uploadUrl: 'https://storage.test/heatmap.json' })
+    mocks.callbackToken.mockReturnValue('token')
+    mocks.submit.mockResolvedValue({ analysis_run_id: runId, status: 'accepted' })
+  })
+
+  it('runを作成してNozomiへ滞在ヒートマップ分析を依頼する', async () => {
+    const result = await createStayHeatmap(actor, organizationId, {
+      trajectory_ids: [trajectoryId],
+      parameters: { speed_threshold_mps: 0.5, grid_size_m: 1 },
+    })
+
+    expect(result).toEqual({ ok: true, value: { analysis_run_id: runId, status: 'processing' } })
+    expect(mocks.insertInputs).toHaveBeenCalledWith(
+      [{ analysis_run_id: runId, trajectory_id: trajectoryId, seq: 0 }],
+      {}
+    )
+    expect(mocks.submit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        analysis_run_id: runId,
+        floor: {
+          floor_id: floorId,
+          map_width_px: 100,
+          map_height_px: 200,
+          scale_m_per_px: 0.01,
+        },
+        trajectories: [
+          expect.objectContaining({
+            trajectory_id: trajectoryId,
+            seq: 0,
+            start: { x_px: 10, y_px: 20 },
+          }),
+        ],
+      })
+    )
+  })
+
+  it('開始点が画像外の場合はrunを作成しない', async () => {
+    mocks.findTrajectoryById.mockResolvedValueOnce({
+      id: trajectoryId,
+      organization_id: organizationId,
+      floor_id: floorId,
+      status: 'completed',
+      constraints: [{ seq: 0, point_type: 'start', x: 100, y: 20 }],
+    })
+
+    const result = await createStayHeatmap(actor, organizationId, {
+      trajectory_ids: [trajectoryId],
+      parameters: { speed_threshold_mps: 0.5, grid_size_m: 1 },
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      error: { type: 'TRAJECTORY_START_INVALID', trajectoryId },
+    })
+    expect(mocks.insertAnalysisRun).not.toHaveBeenCalled()
+  })
+
+  it('Nozomi依頼失敗時はrunをfailedにする', async () => {
+    mocks.submit.mockRejectedValueOnce(new Error('nozomi unavailable'))
+
+    const result = await createStayHeatmap(actor, organizationId, {
+      trajectory_ids: [trajectoryId],
+      parameters: { speed_threshold_mps: 0.5, grid_size_m: 1 },
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      error: { type: 'NOZOMI_REQUEST_FAILED', analysisRunId: runId },
+    })
+    expect(mocks.markFailed).toHaveBeenCalledWith(runId, 'NOZOMI_REQUEST_FAILED')
+  })
+
+  it('署名URLの準備失敗時はNozomiへ依頼せずrunをfailedにする', async () => {
+    mocks.sourceUrl.mockRejectedValueOnce(new Error('storage unavailable'))
+
+    const result = await createStayHeatmap(actor, organizationId, {
+      trajectory_ids: [trajectoryId],
+      parameters: { speed_threshold_mps: 0.5, grid_size_m: 1 },
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      error: { type: 'ANALYSIS_PREPARATION_FAILED', analysisRunId: runId },
+    })
+    expect(mocks.markFailed).toHaveBeenCalledWith(runId, 'ANALYSIS_PREPARATION_FAILED')
+    expect(mocks.submit).not.toHaveBeenCalled()
+  })
+})

--- a/apps/kaede/src/usecases/analysis-runs/create-stay-heatmap.ts
+++ b/apps/kaede/src/usecases/analysis-runs/create-stay-heatmap.ts
@@ -1,0 +1,200 @@
+import * as Sentry from '@sentry/node'
+import { getCallbackRuntimeConfig } from '../../config/runtime.js'
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import type { CreateStayHeatmapRequest } from '../../schemas/analysis-runs.js'
+import { trajectoryConstraintsSchema } from '../../schemas/trajectories.js'
+import {
+  insertAnalysisRun,
+  insertAnalysisRunTrajectories,
+  markAnalysisRunFailed,
+  markAnalysisRunProcessing,
+} from '../../services/analysis-runs/index.js'
+import { db } from '../../services/db/index.js'
+import { findFloorById } from '../../services/floors/index.js'
+import { submitStayHeatmapAnalyzeRequest } from '../../services/nozomi/index.js'
+import {
+  issueInternalAnalysisHeatmapUploadUrl,
+  issueInternalAnalysisTrajectoryDownloadUrl,
+  issueInternalAnalysisTrajectoryUploadUrl,
+} from '../../services/storage/index.js'
+import { generateAnalysisCallbackToken } from '../../services/trajectories/callback-token.js'
+import { findTrajectoryById } from '../../services/trajectories/index.js'
+import type { AuthorizationError } from '../authorization.js'
+import { requireOrganizationManager } from '../authorization.js'
+
+type ValidationError =
+  | { type: 'TRAJECTORY_NOT_FOUND'; trajectoryId: string }
+  | { type: 'TRAJECTORY_NOT_COMPLETED'; trajectoryId: string }
+  | { type: 'TRAJECTORY_SCOPE_INVALID'; trajectoryId: string }
+  | { type: 'TRAJECTORY_START_INVALID'; trajectoryId: string }
+  | { type: 'FLOOR_NOT_FOUND'; floorId: string }
+  | { type: 'FLOOR_ANALYSIS_METADATA_INVALID'; floorId: string }
+
+export type CreateStayHeatmapResult =
+  | { ok: true; value: { analysis_run_id: string; status: 'processing' } }
+  | { ok: false; error: AuthorizationError | ValidationError }
+  | {
+      ok: false
+      error: {
+        type: 'ANALYSIS_PREPARATION_FAILED' | 'NOZOMI_REQUEST_FAILED'
+        analysisRunId: string
+      }
+    }
+
+const callbackUrl = () => `${getCallbackRuntimeConfig().baseUrl}/api/analysis-runs/callback`
+
+export const createStayHeatmap = async (
+  actor: RequestActor,
+  organizationId: string,
+  payload: CreateStayHeatmapRequest
+): Promise<CreateStayHeatmapResult> => {
+  const authorization = requireOrganizationManager(actor, organizationId)
+  if (!authorization.ok) return authorization
+
+  const trajectories = await Promise.all(
+    payload.trajectory_ids.map((trajectoryId) => findTrajectoryById(trajectoryId))
+  )
+  const validatedTrajectories = []
+  for (const [index, trajectory] of trajectories.entries()) {
+    if (!trajectory) {
+      return {
+        ok: false,
+        error: { type: 'TRAJECTORY_NOT_FOUND', trajectoryId: payload.trajectory_ids[index] },
+      }
+    }
+    if (trajectory.status !== 'completed') {
+      return { ok: false, error: { type: 'TRAJECTORY_NOT_COMPLETED', trajectoryId: trajectory.id } }
+    }
+    validatedTrajectories.push(trajectory)
+  }
+
+  const first = validatedTrajectories[0]
+  for (const trajectory of validatedTrajectories) {
+    if (trajectory.organization_id !== organizationId || trajectory.floor_id !== first.floor_id) {
+      return { ok: false, error: { type: 'TRAJECTORY_SCOPE_INVALID', trajectoryId: trajectory.id } }
+    }
+  }
+
+  const floor = await findFloorById(first.floor_id)
+  if (floor?.organization_id !== organizationId) {
+    return { ok: false, error: { type: 'FLOOR_NOT_FOUND', floorId: first.floor_id } }
+  }
+  if (
+    floor.scale === null ||
+    floor.scale <= 0 ||
+    floor.map_width_px === null ||
+    floor.map_width_px <= 0 ||
+    floor.map_height_px === null ||
+    floor.map_height_px <= 0
+  ) {
+    return {
+      ok: false,
+      error: { type: 'FLOOR_ANALYSIS_METADATA_INVALID', floorId: floor.id },
+    }
+  }
+
+  const preparedTrajectories: {
+    trajectory: (typeof validatedTrajectories)[number]
+    seq: number
+    start: { x: number; y: number }
+  }[] = []
+  for (const [seq, trajectory] of validatedTrajectories.entries()) {
+    const constraints = trajectoryConstraintsSchema.safeParse(trajectory.constraints)
+    const start = constraints.success
+      ? constraints.data.find((constraint) => constraint.point_type === 'start')
+      : undefined
+    if (
+      !start ||
+      start.x < 0 ||
+      start.y < 0 ||
+      start.x >= floor.map_width_px ||
+      start.y >= floor.map_height_px
+    ) {
+      return { ok: false, error: { type: 'TRAJECTORY_START_INVALID', trajectoryId: trajectory.id } }
+    }
+    preparedTrajectories.push({ trajectory, seq, start })
+  }
+
+  const processing = await db.transaction().execute(async (transaction) => {
+    const run = await insertAnalysisRun(
+      {
+        organization_id: organizationId,
+        floor_id: floor.id,
+        analysis_type: 'stay_heatmap',
+        parameters: payload.parameters,
+        definition_version: 'original-v1',
+      },
+      transaction
+    )
+    await insertAnalysisRunTrajectories(
+      preparedTrajectories.map(({ trajectory, seq }) => ({
+        analysis_run_id: run.id,
+        trajectory_id: trajectory.id,
+        seq,
+      })),
+      transaction
+    )
+    const updated = await markAnalysisRunProcessing(run.id, new Date(), transaction)
+    if (!updated) throw new Error('failed to mark analysis run processing')
+    return updated
+  })
+
+  let request: Parameters<typeof submitStayHeatmapAnalyzeRequest>[0]
+  try {
+    const [trajectoryUrls, heatmapOutput, token] = await Promise.all([
+      Promise.all(
+        preparedTrajectories.map(async ({ trajectory, seq, start }) => {
+          const [source, output] = await Promise.all([
+            issueInternalAnalysisTrajectoryDownloadUrl(organizationId, trajectory.id),
+            issueInternalAnalysisTrajectoryUploadUrl(organizationId, processing.id, trajectory.id),
+          ])
+          return {
+            trajectory_id: trajectory.id,
+            seq,
+            start: { x_px: start.x, y_px: start.y },
+            source: { download_url: source.downloadUrl },
+            output: { upload_url: output.uploadUrl },
+          }
+        })
+      ),
+      issueInternalAnalysisHeatmapUploadUrl(organizationId, processing.id),
+      Promise.resolve(generateAnalysisCallbackToken(processing.id)),
+    ])
+    request = {
+      analysis_run_id: processing.id,
+      analysis_type: 'stay_heatmap',
+      definition_version: 'original-v1',
+      parameters: payload.parameters,
+      floor: {
+        floor_id: floor.id,
+        map_width_px: floor.map_width_px,
+        map_height_px: floor.map_height_px,
+        scale_m_per_px: floor.scale,
+      },
+      trajectories: trajectoryUrls,
+      heatmap_output: { upload_url: heatmapOutput.uploadUrl },
+      callback: { url: callbackUrl(), token },
+    }
+  } catch (error) {
+    Sentry.captureException(error)
+    await markAnalysisRunFailed(processing.id, 'ANALYSIS_PREPARATION_FAILED')
+    return {
+      ok: false,
+      error: { type: 'ANALYSIS_PREPARATION_FAILED', analysisRunId: processing.id },
+    }
+  }
+
+  try {
+    const accepted = await submitStayHeatmapAnalyzeRequest(request)
+    if (accepted.analysis_run_id !== processing.id) throw new Error('unexpected analysis run id')
+  } catch (error) {
+    Sentry.captureException(error)
+    await markAnalysisRunFailed(processing.id, 'NOZOMI_REQUEST_FAILED')
+    return {
+      ok: false,
+      error: { type: 'NOZOMI_REQUEST_FAILED', analysisRunId: processing.id },
+    }
+  }
+
+  return { ok: true, value: { analysis_run_id: processing.id, status: 'processing' } }
+}

--- a/apps/kaede/src/usecases/analysis-runs/get-analysis-runs.test.ts
+++ b/apps/kaede/src/usecases/analysis-runs/get-analysis-runs.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import { getAnalysisRunResult } from './get-analysis-runs.js'
+
+const mocks = vi.hoisted(() => ({
+  expire: vi.fn(),
+  findRun: vi.fn(),
+  listStates: vi.fn(),
+  getHeatmap: vi.fn(),
+  issueCsvUrl: vi.fn(),
+}))
+
+vi.mock('../../services/analysis-runs/index.js', () => ({
+  expireTimedOutAnalysisRuns: mocks.expire,
+  findOrganizationAnalysisRunById: mocks.findRun,
+  listAnalysisRunTrajectoryStates: mocks.listStates,
+  listOrganizationAnalysisRuns: vi.fn(),
+}))
+vi.mock('../../services/storage/index.js', () => ({
+  getAnalysisHeatmapObjectText: mocks.getHeatmap,
+  issueAnalysisTrajectoryCsvDownloadUrl: mocks.issueCsvUrl,
+}))
+
+const organizationId = '11111111-1111-4111-8111-111111111111'
+const runId = '22222222-2222-4222-8222-222222222222'
+const floorId = '33333333-3333-4333-8333-333333333333'
+const activeId = '44444444-4444-4444-8444-444444444444'
+const deletedId = '55555555-5555-4555-8555-555555555555'
+const actor: RequestActor = {
+  type: 'user',
+  user_id: '66666666-6666-4666-8666-666666666666',
+  email: 'manager@example.com',
+  global_role: 'none',
+  account_state: 'active',
+  memberships: [{ organization_id: organizationId, organization_name: 'Test', role: 'manager' }],
+}
+
+describe('getAnalysisRunResult', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.expire.mockResolvedValue(0)
+    mocks.findRun.mockResolvedValue({
+      id: runId,
+      organization_id: organizationId,
+      floor_id: floorId,
+      analysis_type: 'stay_heatmap',
+      status: 'completed',
+      definition_version: 'original-v1',
+      parameters: { speed_threshold_mps: 0.5, grid_size_m: 1 },
+      error_code: null,
+    })
+    mocks.listStates.mockResolvedValue([
+      { analysis_run_id: runId, trajectory_id: activeId, seq: 0, deleted: false },
+      { analysis_run_id: runId, trajectory_id: deletedId, seq: 1, deleted: true },
+    ])
+    mocks.getHeatmap.mockResolvedValue(
+      JSON.stringify({
+        schema_version: '1.0',
+        definition_version: 'original-v1',
+        parameters: { speed_threshold_mps: 0.5, grid_size_m: 1 },
+        floor_map: { width_px: 100, height_px: 200, scale_m_per_px: 0.01 },
+        grid: { size_m: 1, column_count: 1, row_count: 2 },
+        input_trajectory_count: 2,
+        trajectories: [
+          {
+            trajectory_id: activeId,
+            cells: [{ grid_column: 0, grid_row: 0, stay_cell_visit_count: 3 }],
+          },
+          {
+            trajectory_id: deletedId,
+            cells: [{ grid_column: 0, grid_row: 0, stay_cell_visit_count: 7 }],
+          },
+        ],
+      })
+    )
+    mocks.issueCsvUrl.mockResolvedValue({
+      downloadUrl: 'https://storage.test/stay.csv',
+      expiresAt: '2026-08-04T00:15:00.000Z',
+    })
+  })
+
+  it('削除済みtrajectoryを除外してcellとCSVを返す', async () => {
+    const result = await getAnalysisRunResult(actor, organizationId, runId)
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        trajectory_counts: { input: 2, included: 1, excluded_deleted: 1 },
+        grid: {
+          cells: [
+            {
+              grid_column: 0,
+              grid_row: 0,
+              total_stay_cell_visit_count: 3,
+              mean_stay_cell_visit_count: 3,
+            },
+          ],
+        },
+        trajectory_csvs: [{ trajectory_id: activeId }],
+      },
+    })
+    expect(mocks.issueCsvUrl).toHaveBeenCalledTimes(1)
+    expect(mocks.expire).toHaveBeenCalledOnce()
+  })
+
+  it('processingの結果取得を拒否する', async () => {
+    mocks.findRun.mockResolvedValue({ status: 'processing', error_code: null })
+
+    await expect(getAnalysisRunResult(actor, organizationId, runId)).resolves.toEqual({
+      ok: false,
+      error: { type: 'ANALYSIS_RESULT_NOT_READY', status: 'processing', errorCode: null },
+    })
+  })
+})

--- a/apps/kaede/src/usecases/analysis-runs/get-analysis-runs.ts
+++ b/apps/kaede/src/usecases/analysis-runs/get-analysis-runs.ts
@@ -1,0 +1,221 @@
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import {
+  stayHeatmapArtifactSchema,
+  stayHeatmapParametersSchema,
+} from '../../schemas/analysis-runs.js'
+import type { ListAnalysisRunsQuery } from '../../schemas/analysis-runs.js'
+import { buildPaginatedResult, decodePaginationCursor } from '../../schemas/pagination.js'
+import {
+  expireTimedOutAnalysisRuns,
+  findOrganizationAnalysisRunById,
+  listAnalysisRunTrajectoryStates,
+  listOrganizationAnalysisRuns,
+} from '../../services/analysis-runs/index.js'
+import {
+  getAnalysisHeatmapObjectText,
+  issueAnalysisTrajectoryCsvDownloadUrl,
+} from '../../services/storage/index.js'
+import type { AuthorizationError } from '../authorization.js'
+import { requireOrganizationManager } from '../authorization.js'
+
+type ReadError =
+  | AuthorizationError
+  | { type: 'PAGINATION_CURSOR_INVALID' }
+  | { type: 'ANALYSIS_RUN_NOT_FOUND' }
+  | { type: 'ANALYSIS_RESULT_NOT_READY'; status: string; errorCode: string | null }
+  | { type: 'ANALYSIS_RESULT_INVALID' }
+
+const errorMessage = (code: string) => {
+  const messages: Record<string, string> = {
+    INVALID_TRAJECTORY_CSV: 'Trajectory data is invalid.',
+    ANALYSIS_TIMEOUT: 'Analysis did not complete within the time limit.',
+  }
+  return messages[code] ?? 'Analysis processing failed.'
+}
+
+const serializeRun = async (run: Awaited<ReturnType<typeof findOrganizationAnalysisRunById>>) => {
+  if (!run) throw new Error('analysis run is required')
+  const trajectories = await listAnalysisRunTrajectoryStates(run.id)
+  const included = trajectories.filter((trajectory) => !trajectory.deleted).length
+  return {
+    analysis_run_id: run.id,
+    analysis_type: run.analysis_type,
+    status: run.status as 'accepted' | 'processing' | 'completed' | 'failed',
+    floor_id: run.floor_id,
+    parameters: stayHeatmapParametersSchema.parse(run.parameters),
+    definition_version: run.definition_version,
+    trajectory_counts: {
+      input: trajectories.length,
+      included,
+      excluded_deleted: trajectories.length - included,
+    },
+    error: run.error_code ? { code: run.error_code, message: errorMessage(run.error_code) } : null,
+    created_at: run.created_at.toISOString(),
+    updated_at: run.updated_at.toISOString(),
+    finished_at: run.finished_at?.toISOString() ?? null,
+    started_at: run.started_at?.toISOString() ?? null,
+    deadline_at: run.deadline_at.toISOString(),
+    trajectories: trajectories.map(({ trajectory_id, seq, deleted }) => ({
+      trajectory_id,
+      seq,
+      deleted,
+    })),
+  }
+}
+
+const authorize = (actor: RequestActor, organizationId: string) =>
+  requireOrganizationManager(actor, organizationId)
+
+export const listAnalysisRuns = async (
+  actor: RequestActor,
+  organizationId: string,
+  query: ListAnalysisRunsQuery
+) => {
+  const authorization = authorize(actor, organizationId)
+  if (!authorization.ok) return authorization
+  const cursor = query.cursor
+    ? decodePaginationCursor(query.cursor)
+    : { ok: true as const, value: null }
+  if (!cursor.ok) return cursor
+
+  await expireTimedOutAnalysisRuns()
+  const page = await listOrganizationAnalysisRuns(organizationId, {
+    limit: query.limit,
+    cursor: cursor.value,
+    analysisType: query.analysis_type,
+    status: query.status,
+    floorId: query.floor_id,
+  })
+  const paginated = buildPaginatedResult(page.rows, query.limit, page.totalCount)
+  const items = await Promise.all(paginated.items.map((run) => serializeRun(run)))
+  return {
+    ok: true as const,
+    value: {
+      analysis_runs: items.map(
+        ({ trajectories: _, started_at: __, deadline_at: ___, ...run }) => run
+      ),
+      pagination: { next_cursor: paginated.nextCursor, total_count: paginated.totalCount },
+    },
+  }
+}
+
+export const getAnalysisRun = async (
+  actor: RequestActor,
+  organizationId: string,
+  analysisRunId: string
+) => {
+  const authorization = authorize(actor, organizationId)
+  if (!authorization.ok) return authorization
+  await expireTimedOutAnalysisRuns()
+  const run = await findOrganizationAnalysisRunById(organizationId, analysisRunId)
+  if (!run) return { ok: false as const, error: { type: 'ANALYSIS_RUN_NOT_FOUND' as const } }
+  return { ok: true as const, value: await serializeRun(run) }
+}
+
+export const getAnalysisRunResult = async (
+  actor: RequestActor,
+  organizationId: string,
+  analysisRunId: string
+) => {
+  const authorization = authorize(actor, organizationId)
+  if (!authorization.ok) return authorization
+  await expireTimedOutAnalysisRuns()
+  const run = await findOrganizationAnalysisRunById(organizationId, analysisRunId)
+  if (!run) return { ok: false as const, error: { type: 'ANALYSIS_RUN_NOT_FOUND' as const } }
+  if (run.status !== 'completed') {
+    return {
+      ok: false as const,
+      error: {
+        type: 'ANALYSIS_RESULT_NOT_READY' as const,
+        status: run.status,
+        errorCode: run.error_code,
+      },
+    }
+  }
+
+  const [text, trajectories] = await Promise.all([
+    getAnalysisHeatmapObjectText(organizationId, analysisRunId),
+    listAnalysisRunTrajectoryStates(analysisRunId),
+  ])
+  let artifact: ReturnType<typeof stayHeatmapArtifactSchema.safeParse> | undefined
+  try {
+    artifact = text ? stayHeatmapArtifactSchema.safeParse(JSON.parse(text)) : undefined
+  } catch {
+    artifact = undefined
+  }
+  if (!artifact?.success) {
+    return { ok: false as const, error: { type: 'ANALYSIS_RESULT_INVALID' as const } }
+  }
+  const activeIds = new Set(
+    trajectories
+      .filter((trajectory) => !trajectory.deleted)
+      .map((trajectory) => trajectory.trajectory_id)
+  )
+  const totals = new Map<string, { grid_column: number; grid_row: number; total: number }>()
+  for (const trajectory of artifact.data.trajectories) {
+    if (!activeIds.has(trajectory.trajectory_id)) continue
+    for (const cell of trajectory.cells) {
+      const key = `${cell.grid_row}:${cell.grid_column}`
+      const current = totals.get(key)
+      totals.set(key, {
+        grid_column: cell.grid_column,
+        grid_row: cell.grid_row,
+        total: (current?.total ?? 0) + cell.stay_cell_visit_count,
+      })
+    }
+  }
+  const trajectoryCsvs = await Promise.all(
+    trajectories
+      .filter((trajectory) => !trajectory.deleted)
+      .map(async (trajectory) => {
+        const signed = await issueAnalysisTrajectoryCsvDownloadUrl(
+          organizationId,
+          analysisRunId,
+          trajectory.trajectory_id
+        )
+        return {
+          trajectory_id: trajectory.trajectory_id,
+          download_url: signed.downloadUrl,
+          expires_at: signed.expiresAt,
+        }
+      })
+  )
+  const included = activeIds.size
+  const cells = [...totals.values()]
+    .sort((a, b) => a.grid_row - b.grid_row || a.grid_column - b.grid_column)
+    .map(({ total, ...cell }) => ({
+      ...cell,
+      total_stay_cell_visit_count: total,
+      mean_stay_cell_visit_count: Math.round((total / included) * 1_000_000) / 1_000_000,
+    }))
+
+  return {
+    ok: true as const,
+    value: {
+      analysis_run_id: run.id,
+      analysis_type: 'stay_heatmap' as const,
+      status: 'completed' as const,
+      definition_version: run.definition_version,
+      floor: {
+        id: run.floor_id,
+        map_width_px: artifact.data.floor_map.width_px,
+        map_height_px: artifact.data.floor_map.height_px,
+        scale_m_per_px: artifact.data.floor_map.scale_m_per_px,
+      },
+      parameters: stayHeatmapParametersSchema.parse(run.parameters),
+      grid: {
+        column_count: artifact.data.grid.column_count,
+        row_count: artifact.data.grid.row_count,
+        cells: included === 0 ? [] : cells,
+      },
+      trajectory_counts: {
+        input: trajectories.length,
+        included,
+        excluded_deleted: trajectories.length - included,
+      },
+      trajectory_csvs: trajectoryCsvs,
+    },
+  }
+}
+
+export type AnalysisRunReadError = ReadError

--- a/apps/kaede/src/usecases/analysis-runs/receive-callback.test.ts
+++ b/apps/kaede/src/usecases/analysis-runs/receive-callback.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { receiveAnalysisCallback } from './receive-callback.js'
+
+const mocks = vi.hoisted(() => ({
+  verifyToken: vi.fn(),
+  findRun: vi.fn(),
+  listInputs: vi.fn(),
+  markCompleted: vi.fn(),
+  markFailed: vi.fn(),
+  getHeatmap: vi.fn(),
+  csvExists: vi.fn(),
+}))
+
+vi.mock('../../services/trajectories/callback-token.js', () => ({
+  verifyAnalysisCallbackToken: mocks.verifyToken,
+}))
+vi.mock('../../services/analysis-runs/index.js', () => ({
+  findAnalysisRunById: mocks.findRun,
+  listAnalysisRunTrajectories: mocks.listInputs,
+  markAnalysisRunCompleted: mocks.markCompleted,
+  markAnalysisRunFailed: mocks.markFailed,
+}))
+vi.mock('../../services/storage/index.js', () => ({
+  getAnalysisHeatmapObjectText: mocks.getHeatmap,
+  doesAnalysisTrajectoryCsvObjectExist: mocks.csvExists,
+}))
+
+const runId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const trajectoryId = '33333333-3333-4333-8333-333333333333'
+const now = new Date('2026-08-04T03:00:00.000Z')
+const artifact = {
+  schema_version: '1.0',
+  definition_version: 'original-v1',
+  parameters: { speed_threshold_mps: 0.5, grid_size_m: 1 },
+  floor_map: { width_px: 100, height_px: 200, scale_m_per_px: 0.01 },
+  grid: { size_m: 1, column_count: 1, row_count: 2 },
+  input_trajectory_count: 1,
+  trajectories: [{ trajectory_id: trajectoryId, cells: [] }],
+}
+
+describe('receiveAnalysisCallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyToken.mockReturnValue({
+      ok: true,
+      value: { analysisRunId: runId, analysisType: 'stay_heatmap', exp: 1 },
+    })
+    mocks.findRun.mockResolvedValue({
+      id: runId,
+      organization_id: organizationId,
+      analysis_type: 'stay_heatmap',
+      status: 'processing',
+      error_code: null,
+    })
+    mocks.listInputs.mockResolvedValue([
+      { analysis_run_id: runId, trajectory_id: trajectoryId, seq: 0 },
+    ])
+    mocks.getHeatmap.mockResolvedValue(JSON.stringify(artifact))
+    mocks.csvExists.mockResolvedValue(true)
+    mocks.markCompleted.mockResolvedValue({ id: runId, status: 'completed' })
+    mocks.markFailed.mockResolvedValue({ id: runId, status: 'failed' })
+  })
+
+  it('成果物を検証してrunをcompletedにする', async () => {
+    const result = await receiveAnalysisCallback(
+      { analysis_run_id: runId, status: 'completed', callback_token: 'token' },
+      now
+    )
+
+    expect(result).toEqual({ ok: true, value: { analysis_run_id: runId, status: 'completed' } })
+    expect(mocks.markCompleted).toHaveBeenCalledWith(runId, now)
+  })
+
+  it('成果物のtrajectory集合が異なる場合はrunをfailedにする', async () => {
+    mocks.getHeatmap.mockResolvedValueOnce(
+      JSON.stringify({ ...artifact, trajectories: [], input_trajectory_count: 1 })
+    )
+
+    const result = await receiveAnalysisCallback(
+      { analysis_run_id: runId, status: 'completed', callback_token: 'token' },
+      now
+    )
+
+    expect(result).toEqual({ ok: false, error: { type: 'CALLBACK_ARTIFACT_INVALID' } })
+    expect(mocks.markFailed).toHaveBeenCalledWith(runId, 'ARTIFACT_VALIDATION_FAILED', now)
+  })
+
+  it('未知の失敗codeを正規化してfailedにする', async () => {
+    const result = await receiveAnalysisCallback(
+      {
+        analysis_run_id: runId,
+        status: 'failed',
+        callback_token: 'token',
+        error_code: 'UNKNOWN',
+        error_message: 'detail',
+      },
+      now
+    )
+
+    expect(result).toEqual({ ok: true, value: { analysis_run_id: runId, status: 'failed' } })
+    expect(mocks.markFailed).toHaveBeenCalledWith(runId, 'ANALYSIS_PROCESSING_FAILED', now)
+  })
+
+  it('同じcompleted callbackの再送は成功する', async () => {
+    mocks.findRun.mockResolvedValueOnce({ id: runId, status: 'completed' })
+
+    const result = await receiveAnalysisCallback(
+      { analysis_run_id: runId, status: 'completed', callback_token: 'token' },
+      now
+    )
+
+    expect(result).toEqual({ ok: true, value: { analysis_run_id: runId, status: 'completed' } })
+    expect(mocks.getHeatmap).not.toHaveBeenCalled()
+  })
+
+  it('不正tokenは401相当のerrorにする', async () => {
+    mocks.verifyToken.mockReturnValueOnce({ ok: false, error: 'CALLBACK_TOKEN_INVALID' })
+
+    const result = await receiveAnalysisCallback(
+      { analysis_run_id: runId, status: 'completed', callback_token: 'invalid' },
+      now
+    )
+
+    expect(result).toEqual({ ok: false, error: { type: 'CALLBACK_TOKEN_INVALID' } })
+    expect(mocks.findRun).not.toHaveBeenCalled()
+  })
+})

--- a/apps/kaede/src/usecases/analysis-runs/receive-callback.ts
+++ b/apps/kaede/src/usecases/analysis-runs/receive-callback.ts
@@ -1,0 +1,108 @@
+import type { AnalysisCallbackRequest } from '../../schemas/analysis-runs.js'
+import { stayHeatmapArtifactSchema } from '../../schemas/analysis-runs.js'
+import {
+  findAnalysisRunById,
+  listAnalysisRunTrajectories,
+  markAnalysisRunCompleted,
+  markAnalysisRunFailed,
+} from '../../services/analysis-runs/index.js'
+import {
+  doesAnalysisTrajectoryCsvObjectExist,
+  getAnalysisHeatmapObjectText,
+} from '../../services/storage/index.js'
+import { verifyAnalysisCallbackToken } from '../../services/trajectories/callback-token.js'
+
+const nozomiErrorCodes = new Set([
+  'TRAJECTORY_DOWNLOAD_FAILED',
+  'INVALID_TRAJECTORY_CSV',
+  'ANALYSIS_PROCESSING_FAILED',
+  'ARTIFACT_UPLOAD_FAILED',
+])
+
+type CallbackError =
+  | { type: 'CALLBACK_TOKEN_INVALID' | 'CALLBACK_TOKEN_EXPIRED' }
+  | { type: 'ANALYSIS_RUN_NOT_FOUND' }
+  | { type: 'CALLBACK_ANALYSIS_RUN_MISMATCH' }
+  | { type: 'CALLBACK_ALREADY_FINALIZED' }
+  | { type: 'CALLBACK_ARTIFACT_INVALID' }
+
+export type ReceiveAnalysisCallbackResult =
+  | { ok: true; value: { analysis_run_id: string; status: 'completed' | 'failed' } }
+  | { ok: false; error: CallbackError }
+
+const normalizedErrorCode = (code: string) =>
+  nozomiErrorCodes.has(code) ? code : 'ANALYSIS_PROCESSING_FAILED'
+
+export const receiveAnalysisCallback = async (
+  payload: AnalysisCallbackRequest,
+  now: Date = new Date()
+): Promise<ReceiveAnalysisCallbackResult> => {
+  const verified = verifyAnalysisCallbackToken(payload.callback_token, now)
+  if (!verified.ok) return { ok: false, error: { type: verified.error } }
+  if (verified.value.analysisRunId !== payload.analysis_run_id) {
+    return { ok: false, error: { type: 'CALLBACK_ANALYSIS_RUN_MISMATCH' } }
+  }
+
+  const run = await findAnalysisRunById(payload.analysis_run_id)
+  if (!run) return { ok: false, error: { type: 'ANALYSIS_RUN_NOT_FOUND' } }
+
+  if (payload.status === 'failed') {
+    const errorCode = normalizedErrorCode(payload.error_code)
+    if (run.status === 'failed' && run.error_code === errorCode) {
+      return { ok: true, value: { analysis_run_id: run.id, status: 'failed' } }
+    }
+    if (run.status === 'completed' || run.status === 'failed') {
+      return { ok: false, error: { type: 'CALLBACK_ALREADY_FINALIZED' } }
+    }
+    const failed = await markAnalysisRunFailed(run.id, errorCode, now)
+    if (!failed) return { ok: false, error: { type: 'CALLBACK_ALREADY_FINALIZED' } }
+    return { ok: true, value: { analysis_run_id: failed.id, status: 'failed' } }
+  }
+
+  if (run.status === 'completed') {
+    return { ok: true, value: { analysis_run_id: run.id, status: 'completed' } }
+  }
+  if (run.status !== 'processing') {
+    return { ok: false, error: { type: 'CALLBACK_ALREADY_FINALIZED' } }
+  }
+
+  const inputs = await listAnalysisRunTrajectories(run.id)
+  const heatmapText = await getAnalysisHeatmapObjectText(run.organization_id, run.id)
+  let heatmap: unknown
+  try {
+    heatmap = heatmapText === undefined ? undefined : JSON.parse(heatmapText)
+  } catch {
+    heatmap = undefined
+  }
+  const parsed = stayHeatmapArtifactSchema.safeParse(heatmap)
+  const expectedIds = new Set(inputs.map((input) => input.trajectory_id))
+  const artifactIds = parsed.success
+    ? new Set(parsed.data.trajectories.map((trajectory) => trajectory.trajectory_id))
+    : new Set<string>()
+  const idsMatch =
+    parsed.success &&
+    expectedIds.size === artifactIds.size &&
+    [...expectedIds].every((id) => artifactIds.has(id))
+  const csvObjectsExist = idsMatch
+    ? await Promise.all(
+        inputs.map((input) =>
+          doesAnalysisTrajectoryCsvObjectExist(run.organization_id, run.id, input.trajectory_id)
+        )
+      )
+    : []
+
+  if (!idsMatch || csvObjectsExist.some((exists) => !exists)) {
+    await markAnalysisRunFailed(run.id, 'ARTIFACT_VALIDATION_FAILED', now)
+    return { ok: false, error: { type: 'CALLBACK_ARTIFACT_INVALID' } }
+  }
+
+  const completed = await markAnalysisRunCompleted(run.id, now)
+  if (completed) {
+    return { ok: true, value: { analysis_run_id: completed.id, status: 'completed' } }
+  }
+  const latest = await findAnalysisRunById(run.id)
+  if (latest?.status === 'completed') {
+    return { ok: true, value: { analysis_run_id: latest.id, status: 'completed' } }
+  }
+  return { ok: false, error: { type: 'CALLBACK_ALREADY_FINALIZED' } }
+}

--- a/apps/kaede/src/usecases/floors/create-floor.ts
+++ b/apps/kaede/src/usecases/floors/create-floor.ts
@@ -16,6 +16,8 @@ import type { AuthorizationError } from '../authorization.js'
 import { requireDashboardWriteAccess } from '../authorization.js'
 
 export const floorMapImageMaxBytes = 10 * 1024 * 1024
+export const floorMapMaxSidePx = 20_000
+export const floorMapMaxPixels = 100_000_000
 
 export interface FloorMapImageUpload {
   bytes: Uint8Array
@@ -58,18 +60,48 @@ const hasPngMagicNumber = (bytes: Uint8Array) => {
   return pngMagicNumber.every((value, index) => bytes[index] === value)
 }
 
-const isValidSvg = (bytes: Uint8Array) => {
+interface FloorMapDimensions {
+  width: number
+  height: number
+}
+
+const areValidDimensions = ({ width, height }: FloorMapDimensions) =>
+  Number.isInteger(width) &&
+  Number.isInteger(height) &&
+  width > 0 &&
+  height > 0 &&
+  width <= floorMapMaxSidePx &&
+  height <= floorMapMaxSidePx &&
+  width * height <= floorMapMaxPixels
+
+const extractPngDimensions = (bytes: Uint8Array): FloorMapDimensions | undefined => {
+  if (!hasPngMagicNumber(bytes) || bytes.byteLength < 24) return undefined
+
+  const chunkType = new TextDecoder('ascii').decode(bytes.slice(12, 16))
+  if (chunkType !== 'IHDR') return undefined
+
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  const dimensions = { width: view.getUint32(16), height: view.getUint32(20) }
+  return areValidDimensions(dimensions) ? dimensions : undefined
+}
+
+const extractSvgDimensions = (bytes: Uint8Array): FloorMapDimensions | undefined => {
   const text = new TextDecoder('utf-8', { fatal: false }).decode(bytes)
 
-  if (!/<\s*svg(?:\s|>)/i.test(text)) {
-    return false
-  }
+  const svgTag = /<\s*svg\b[^>]*>/i.exec(text)?.[0]
+  if (!svgTag) return undefined
 
   if (/<\s*script(?:\s|>)/i.test(text) || /<\s*foreignObject(?:\s|>)/i.test(text)) {
-    return false
+    return undefined
   }
 
-  return !/\son[a-z]+\s*=/i.test(text)
+  if (/\son[a-z]+\s*=/i.test(text)) return undefined
+
+  const viewBox = /\bviewBox\s*=\s*["']\s*0\s+0\s+(\d+)\s+(\d+)\s*["']/i.exec(svgTag)
+  if (!viewBox) return undefined
+
+  const dimensions = { width: Number(viewBox[1]), height: Number(viewBox[2]) }
+  return areValidDimensions(dimensions) ? dimensions : undefined
 }
 
 const validateFloorMapImage = (
@@ -78,6 +110,7 @@ const validateFloorMapImage = (
   | {
       ok: true
       extension: FloorMapImageExtension
+      dimensions: FloorMapDimensions
     }
   | {
       ok: false
@@ -97,13 +130,15 @@ const validateFloorMapImage = (
   }
 
   if (upload.contentType === 'image/png') {
-    return hasPngMagicNumber(upload.bytes)
-      ? { ok: true, extension: 'png' }
+    const dimensions = extractPngDimensions(upload.bytes)
+    return dimensions
+      ? { ok: true, extension: 'png', dimensions }
       : { ok: false, error: { type: 'FLOOR_MAP_IMAGE_INVALID' } }
   }
 
-  return isValidSvg(upload.bytes)
-    ? { ok: true, extension: 'svg' }
+  const dimensions = extractSvgDimensions(upload.bytes)
+  return dimensions
+    ? { ok: true, extension: 'svg', dimensions }
     : { ok: false, error: { type: 'FLOOR_MAP_IMAGE_INVALID' } }
 }
 
@@ -168,6 +203,8 @@ export const createFloor = async (
       level: payload.level,
       name: payload.name,
       image_object_path: imageObjectPath,
+      map_width_px: mapValidation.dimensions.width,
+      map_height_px: mapValidation.dimensions.height,
       scale: payload.scale ?? null,
     })
   } catch (error) {
@@ -196,6 +233,8 @@ export const createFloor = async (
       level: floor.level,
       name: floor.name,
       scale: floor.scale,
+      map_width_px: floor.map_width_px,
+      map_height_px: floor.map_height_px,
       map_image: {
         download_url: mapDownload.url,
         download_expires_at: mapDownload.expiresAt,

--- a/apps/kaede/src/usecases/floors/create-floor.ts
+++ b/apps/kaede/src/usecases/floors/create-floor.ts
@@ -3,6 +3,12 @@ import { randomUUID } from 'node:crypto'
 import type { RequestActor } from '../../middleware/request-actor-context.js'
 import type { CreateFloorRequest, FloorResponse } from '../../schemas/floors.js'
 import { findBuildingById } from '../../services/buildings/index.js'
+import {
+  extractFloorMapDimensions,
+  floorMapMaxPixels,
+  floorMapMaxSidePx,
+} from '../../services/floor-maps/dimensions.js'
+import type { FloorMapDimensions } from '../../services/floor-maps/dimensions.js'
 import { insertFloor } from '../../services/floors/index.js'
 import {
   buildFloorMapObjectKey,
@@ -16,8 +22,7 @@ import type { AuthorizationError } from '../authorization.js'
 import { requireDashboardWriteAccess } from '../authorization.js'
 
 export const floorMapImageMaxBytes = 10 * 1024 * 1024
-export const floorMapMaxSidePx = 20_000
-export const floorMapMaxPixels = 100_000_000
+export { floorMapMaxPixels, floorMapMaxSidePx }
 
 export interface FloorMapImageUpload {
   bytes: Uint8Array
@@ -54,56 +59,6 @@ export type CreateFloorResult =
       error: AuthorizationError
     }
 
-const pngMagicNumber = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
-
-const hasPngMagicNumber = (bytes: Uint8Array) => {
-  return pngMagicNumber.every((value, index) => bytes[index] === value)
-}
-
-interface FloorMapDimensions {
-  width: number
-  height: number
-}
-
-const areValidDimensions = ({ width, height }: FloorMapDimensions) =>
-  Number.isInteger(width) &&
-  Number.isInteger(height) &&
-  width > 0 &&
-  height > 0 &&
-  width <= floorMapMaxSidePx &&
-  height <= floorMapMaxSidePx &&
-  width * height <= floorMapMaxPixels
-
-const extractPngDimensions = (bytes: Uint8Array): FloorMapDimensions | undefined => {
-  if (!hasPngMagicNumber(bytes) || bytes.byteLength < 24) return undefined
-
-  const chunkType = new TextDecoder('ascii').decode(bytes.slice(12, 16))
-  if (chunkType !== 'IHDR') return undefined
-
-  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
-  const dimensions = { width: view.getUint32(16), height: view.getUint32(20) }
-  return areValidDimensions(dimensions) ? dimensions : undefined
-}
-
-const extractSvgDimensions = (bytes: Uint8Array): FloorMapDimensions | undefined => {
-  const text = new TextDecoder('utf-8', { fatal: false }).decode(bytes)
-
-  const svgTag = /<\s*svg\b[^>]*>/i.exec(text)?.[0]
-  if (!svgTag) return undefined
-
-  if (/<\s*script(?:\s|>)/i.test(text) || /<\s*foreignObject(?:\s|>)/i.test(text)) {
-    return undefined
-  }
-
-  if (/\son[a-z]+\s*=/i.test(text)) return undefined
-
-  const viewBox = /\bviewBox\s*=\s*["']\s*0\s+0\s+(\d+)\s+(\d+)\s*["']/i.exec(svgTag)
-  if (!viewBox) return undefined
-
-  const dimensions = { width: Number(viewBox[1]), height: Number(viewBox[2]) }
-  return areValidDimensions(dimensions) ? dimensions : undefined
-}
-
 const validateFloorMapImage = (
   upload: FloorMapImageUpload
 ):
@@ -130,13 +85,13 @@ const validateFloorMapImage = (
   }
 
   if (upload.contentType === 'image/png') {
-    const dimensions = extractPngDimensions(upload.bytes)
+    const dimensions = extractFloorMapDimensions(upload.bytes, 'png')
     return dimensions
       ? { ok: true, extension: 'png', dimensions }
       : { ok: false, error: { type: 'FLOOR_MAP_IMAGE_INVALID' } }
   }
 
-  const dimensions = extractSvgDimensions(upload.bytes)
+  const dimensions = extractFloorMapDimensions(upload.bytes, 'svg')
   return dimensions
     ? { ok: true, extension: 'svg', dimensions }
     : { ok: false, error: { type: 'FLOOR_MAP_IMAGE_INVALID' } }

--- a/apps/kaede/src/usecases/floors/floor-response.ts
+++ b/apps/kaede/src/usecases/floors/floor-response.ts
@@ -13,6 +13,8 @@ interface FloorResponseRow {
   level: number
   name: string
   image_object_path: string
+  map_width_px: number | null
+  map_height_px: number | null
   scale: number | null
   created_at: Date
   updated_at: Date
@@ -43,6 +45,8 @@ export const toFloorResponse = async (floor: FloorResponseRow): Promise<FloorRes
     level: floor.level,
     name: floor.name,
     scale: floor.scale,
+    map_width_px: floor.map_width_px,
+    map_height_px: floor.map_height_px,
     map_image: {
       download_url: downloadUrl.url,
       download_expires_at: downloadUrl.expiresAt,

--- a/apps/kaede/tests/services/analysis-runs/analysis-run-repository.test.ts
+++ b/apps/kaede/tests/services/analysis-runs/analysis-run-repository.test.ts
@@ -1,0 +1,176 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import {
+  findAnalysisRunById,
+  insertAnalysisRun,
+  insertAnalysisRunTrajectories,
+  listAnalysisRunTrajectories,
+  markAnalysisRunCompleted,
+  markAnalysisRunFailed,
+  markAnalysisRunProcessing,
+} from '../../../src/services/analysis-runs/index.js'
+import { createDb } from '../../../src/services/db/client.js'
+import { insertTrajectory } from '../../../src/services/trajectories/index.js'
+import { resetDatabase } from '../../db/helpers.js'
+import { createRecordingFixture } from '../../fixtures/recordings.js'
+
+const db = createDb()
+
+describe('analysis run repository', () => {
+  beforeEach(async () => {
+    await resetDatabase(db)
+  })
+
+  afterAll(async () => {
+    await db.destroy()
+  })
+
+  it('runと入力trajectoryを順序付きで保存できる', async () => {
+    const { floor, organization, recording } = await createRecordingFixture(db)
+    const trajectories = await Promise.all(
+      [0, 1].map(() =>
+        insertTrajectory(
+          {
+            recording_id: recording.id,
+            floor_id: floor.id,
+            organization_id: organization.id,
+            status: 'completed',
+          },
+          db
+        )
+      )
+    )
+    const run = await insertAnalysisRun(
+      {
+        organization_id: organization.id,
+        floor_id: floor.id,
+        analysis_type: 'stay_heatmap',
+        parameters: { speed_threshold_mps: 0.5, grid_size_m: 1 },
+        definition_version: 'original-v1',
+      },
+      db
+    )
+
+    await insertAnalysisRunTrajectories(
+      [
+        { analysis_run_id: run.id, trajectory_id: trajectories[1].id, seq: 1 },
+        { analysis_run_id: run.id, trajectory_id: trajectories[0].id, seq: 0 },
+      ],
+      db
+    )
+
+    const storedRun = await findAnalysisRunById(run.id, db)
+    const inputs = await listAnalysisRunTrajectories(run.id, db)
+
+    expect(storedRun).toMatchObject({
+      status: 'accepted',
+      parameters: { speed_threshold_mps: 0.5, grid_size_m: 1 },
+      error_code: null,
+      started_at: null,
+      finished_at: null,
+    })
+    expect(inputs.map(({ trajectory_id, seq }) => ({ trajectory_id, seq }))).toEqual([
+      { trajectory_id: trajectories[0].id, seq: 0 },
+      { trajectory_id: trajectories[1].id, seq: 1 },
+    ])
+  })
+
+  it('acceptedからprocessingを経てcompletedへ更新できる', async () => {
+    const { floor, organization } = await createRecordingFixture(db)
+    const run = await insertAnalysisRun(
+      {
+        organization_id: organization.id,
+        floor_id: floor.id,
+        analysis_type: 'stay_heatmap',
+        parameters: {},
+        definition_version: 'original-v1',
+      },
+      db
+    )
+    const startedAt = new Date('2026-08-04T01:00:00.000Z')
+    const finishedAt = new Date('2026-08-04T01:01:00.000Z')
+
+    const processing = await markAnalysisRunProcessing(run.id, startedAt, db)
+    const completed = await markAnalysisRunCompleted(run.id, finishedAt, db)
+    const failed = await markAnalysisRunFailed(run.id, 'ANALYSIS_PROCESSING_FAILED', finishedAt, db)
+
+    expect(processing).toMatchObject({ status: 'processing', started_at: startedAt })
+    expect(completed).toMatchObject({ status: 'completed', finished_at: finishedAt })
+    expect(failed).toBeUndefined()
+  })
+
+  it('acceptedからfailedへ更新し終端状態から遷移しない', async () => {
+    const { floor, organization } = await createRecordingFixture(db)
+    const run = await insertAnalysisRun(
+      {
+        organization_id: organization.id,
+        floor_id: floor.id,
+        analysis_type: 'stay_heatmap',
+        parameters: {},
+        definition_version: 'original-v1',
+      },
+      db
+    )
+    const finishedAt = new Date('2026-08-04T01:01:00.000Z')
+
+    const failed = await markAnalysisRunFailed(
+      run.id,
+      'ANALYSIS_PREPARATION_FAILED',
+      finishedAt,
+      db
+    )
+    const processing = await markAnalysisRunProcessing(run.id, finishedAt, db)
+
+    expect(failed).toMatchObject({
+      status: 'failed',
+      error_code: 'ANALYSIS_PREPARATION_FAILED',
+      started_at: null,
+      finished_at: finishedAt,
+    })
+    expect(processing).toBeUndefined()
+  })
+
+  it('同じrun内でtrajectoryとseqを重複できない', async () => {
+    const { floor, organization, recording } = await createRecordingFixture(db)
+    const [trajectory, anotherTrajectory] = await Promise.all(
+      [0, 1].map(() =>
+        insertTrajectory(
+          {
+            recording_id: recording.id,
+            floor_id: floor.id,
+            organization_id: organization.id,
+            status: 'completed',
+          },
+          db
+        )
+      )
+    )
+    const run = await insertAnalysisRun(
+      {
+        organization_id: organization.id,
+        floor_id: floor.id,
+        analysis_type: 'stay_heatmap',
+        parameters: {},
+        definition_version: 'original-v1',
+      },
+      db
+    )
+
+    await insertAnalysisRunTrajectories(
+      [{ analysis_run_id: run.id, trajectory_id: trajectory.id, seq: 0 }],
+      db
+    )
+
+    await expect(
+      insertAnalysisRunTrajectories(
+        [{ analysis_run_id: run.id, trajectory_id: trajectory.id, seq: 1 }],
+        db
+      )
+    ).rejects.toMatchObject({ code: '23505' })
+    await expect(
+      insertAnalysisRunTrajectories(
+        [{ analysis_run_id: run.id, trajectory_id: anotherTrajectory.id, seq: 0 }],
+        db
+      )
+    ).rejects.toMatchObject({ code: '23505' })
+  })
+})

--- a/apps/kaede/tests/services/analysis-runs/analysis-run-repository.test.ts
+++ b/apps/kaede/tests/services/analysis-runs/analysis-run-repository.test.ts
@@ -1,9 +1,12 @@
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 import {
   findAnalysisRunById,
+  findOrganizationAnalysisRunById,
   insertAnalysisRun,
   insertAnalysisRunTrajectories,
   listAnalysisRunTrajectories,
+  listAnalysisRunTrajectoryStates,
+  listOrganizationAnalysisRuns,
   markAnalysisRunCompleted,
   markAnalysisRunFailed,
   markAnalysisRunProcessing,
@@ -225,5 +228,54 @@ describe('analysis run repository', () => {
     })
     expect(activeFuture).toMatchObject({ status: 'accepted', finished_at: null })
     expect(terminalCompleted).toMatchObject({ status: 'completed' })
+  })
+
+  it('organization内のrunを絞り込み、trajectoryの削除状態を返す', async () => {
+    const { floor, organization, recording } = await createRecordingFixture(db)
+    const trajectory = await insertTrajectory(
+      {
+        recording_id: recording.id,
+        floor_id: floor.id,
+        organization_id: organization.id,
+        status: 'completed',
+        deleted_at: new Date('2026-08-04T01:00:00.000Z'),
+      },
+      db
+    )
+    const run = await insertAnalysisRun(
+      {
+        organization_id: organization.id,
+        floor_id: floor.id,
+        analysis_type: 'stay_heatmap',
+        parameters: {},
+        definition_version: 'original-v1',
+      },
+      db
+    )
+    await insertAnalysisRunTrajectories(
+      [{ analysis_run_id: run.id, trajectory_id: trajectory.id, seq: 0 }],
+      db
+    )
+
+    const page = await listOrganizationAnalysisRuns(
+      organization.id,
+      {
+        limit: 20,
+        cursor: null,
+        analysisType: 'stay_heatmap',
+        status: 'accepted',
+        floorId: floor.id,
+      },
+      db
+    )
+    const detail = await findOrganizationAnalysisRunById(organization.id, run.id, db)
+    const states = await listAnalysisRunTrajectoryStates(run.id, db)
+
+    expect(page.totalCount).toBe(1)
+    expect(page.rows[0]?.id).toBe(run.id)
+    expect(detail?.id).toBe(run.id)
+    expect(states).toEqual([
+      { analysis_run_id: run.id, trajectory_id: trajectory.id, seq: 0, deleted: true },
+    ])
   })
 })

--- a/apps/kaede/tests/services/analysis-runs/analysis-run-repository.test.ts
+++ b/apps/kaede/tests/services/analysis-runs/analysis-run-repository.test.ts
@@ -7,6 +7,7 @@ import {
   markAnalysisRunCompleted,
   markAnalysisRunFailed,
   markAnalysisRunProcessing,
+  markTimedOutAnalysisRunsFailed,
 } from '../../../src/services/analysis-runs/index.js'
 import { createDb } from '../../../src/services/db/client.js'
 import { insertTrajectory } from '../../../src/services/trajectories/index.js'
@@ -172,5 +173,57 @@ describe('analysis run repository', () => {
         db
       )
     ).rejects.toMatchObject({ code: '23505' })
+  })
+
+  it('期限超過したacceptedとprocessingだけをfailedへ更新する', async () => {
+    const { floor, organization } = await createRecordingFixture(db)
+    const deadlineAt = new Date('2026-08-04T01:00:00.000Z')
+    const futureDeadlineAt = new Date('2026-08-04T03:00:00.000Z')
+    const now = new Date('2026-08-04T02:00:00.000Z')
+    const createRun = (deadline_at: Date) =>
+      insertAnalysisRun(
+        {
+          organization_id: organization.id,
+          floor_id: floor.id,
+          analysis_type: 'stay_heatmap',
+          parameters: {},
+          definition_version: 'original-v1',
+          deadline_at,
+        },
+        db
+      )
+    const [accepted, processing, future, completed] = await Promise.all([
+      createRun(deadlineAt),
+      createRun(deadlineAt),
+      createRun(futureDeadlineAt),
+      createRun(deadlineAt),
+    ])
+    await markAnalysisRunProcessing(processing.id, new Date('2026-08-04T00:30:00.000Z'), db)
+    await markAnalysisRunProcessing(completed.id, new Date('2026-08-04T00:30:00.000Z'), db)
+    await markAnalysisRunCompleted(completed.id, new Date('2026-08-04T00:45:00.000Z'), db)
+
+    const expiredCount = await markTimedOutAnalysisRunsFailed(now, db)
+    const [expiredAccepted, expiredProcessing, activeFuture, terminalCompleted] = await Promise.all(
+      [
+        findAnalysisRunById(accepted.id, db),
+        findAnalysisRunById(processing.id, db),
+        findAnalysisRunById(future.id, db),
+        findAnalysisRunById(completed.id, db),
+      ]
+    )
+
+    expect(expiredCount).toBe(2)
+    expect(expiredAccepted).toMatchObject({
+      status: 'failed',
+      error_code: 'ANALYSIS_TIMEOUT',
+      finished_at: now,
+    })
+    expect(expiredProcessing).toMatchObject({
+      status: 'failed',
+      error_code: 'ANALYSIS_TIMEOUT',
+      finished_at: now,
+    })
+    expect(activeFuture).toMatchObject({ status: 'accepted', finished_at: null })
+    expect(terminalCompleted).toMatchObject({ status: 'completed' })
   })
 })

--- a/apps/kaede/tests/services/floors/create-floor.test.ts
+++ b/apps/kaede/tests/services/floors/create-floor.test.ts
@@ -24,8 +24,13 @@ vi.mock('../../../src/services/storage/index.js', async (importOriginal) => {
 })
 
 const db = createDb()
-const validSvg = new TextEncoder().encode('<svg xmlns="http://www.w3.org/2000/svg"></svg>')
-const validPng = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+const validSvg = new TextEncoder().encode(
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 720"></svg>'
+)
+const validPng = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x02, 0x80, 0x00, 0x00, 0x01, 0xe0,
+])
 
 const serviceClientActor: RequestActor = {
   type: 'service_client',
@@ -125,6 +130,8 @@ describe('createFloor', () => {
       level: 2,
       name: '2F',
       scale: 25,
+      map_width_px: 1280,
+      map_height_px: 720,
     })
     expect(result.value.map_image.download_expires_at).toEqual(expect.any(String))
     const mapDownloadUrl = new URL(result.value.map_image.download_url)
@@ -154,6 +161,8 @@ describe('createFloor', () => {
       name: '2F',
       scale: 25,
       image_object_path: `organizations/${organization.id}/floors/${result.value.floor_id}/map.svg`,
+      map_width_px: 1280,
+      map_height_px: 720,
     })
   })
 
@@ -369,6 +378,33 @@ describe('createFloor', () => {
     })
     expect(putFloorMapObjectMock).not.toHaveBeenCalled()
     await expect(db.selectFrom('floors').select('id').execute()).resolves.toEqual([])
+  })
+
+  it('viewBox がない SVG は floor を作成しない', async () => {
+    const organization = await db
+      .insertInto('organizations')
+      .values({ name: 'Invalid SVG Dimensions Organization' })
+      .returning(['id'])
+      .executeTakeFirstOrThrow()
+    const building = await db
+      .insertInto('buildings')
+      .values({ organization_id: organization.id, name: 'Invalid SVG Dimensions Building' })
+      .returning(['id'])
+      .executeTakeFirstOrThrow()
+
+    const result = await createFloor(
+      adminActor,
+      organization.id,
+      building.id,
+      { level: 1, name: '1F' },
+      {
+        bytes: new TextEncoder().encode('<svg xmlns="http://www.w3.org/2000/svg"></svg>'),
+        contentType: 'image/svg+xml',
+      }
+    )
+
+    expect(result).toEqual({ ok: false, error: { type: 'FLOOR_MAP_IMAGE_INVALID' } })
+    expect(putFloorMapObjectMock).not.toHaveBeenCalled()
   })
 
   it('10MB を超える floor map image は floor を作成しない', async () => {

--- a/apps/kaede/tests/storage/presigned-upload.test.ts
+++ b/apps/kaede/tests/storage/presigned-upload.test.ts
@@ -1,5 +1,8 @@
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 import {
+  issueAnalysisTrajectoryCsvDownloadUrl,
+  issueInternalAnalysisHeatmapUploadUrl,
+  issueInternalAnalysisTrajectoryUploadUrl,
   putFloorMapObject,
   issueRecordingUploadUrls,
   resetS3ClientForTests,
@@ -80,5 +83,36 @@ describe('presigned upload integration', () => {
     await putFloorMapObject(objectKey, 'svg', new TextEncoder().encode(svg))
 
     await expect(readObjectText(s3, objectKey)).resolves.toBe(svg)
+  }, 30000)
+
+  it('analysis artifact を署名URLで保存してCSVを公開取得できる', async () => {
+    const organizationId = '77777777-7777-4777-8777-777777777777'
+    const analysisRunId = '66666666-6666-4666-8666-666666666666'
+    const trajectoryId = '55555555-5555-4555-8555-555555555555'
+    const csv = 'timestamp,x,y,speed_mps,is_stay\n0,1,2,,false\n'
+    const heatmap = '{"schema_version":"1","trajectories":[]}\n'
+
+    const [csvOutput, heatmapOutput] = await Promise.all([
+      issueInternalAnalysisTrajectoryUploadUrl(organizationId, analysisRunId, trajectoryId),
+      issueInternalAnalysisHeatmapUploadUrl(organizationId, analysisRunId),
+    ])
+
+    const [csvUploadResponse, heatmapUploadResponse] = await Promise.all([
+      fetch(csvOutput.uploadUrl, { method: 'PUT', body: csv }),
+      fetch(heatmapOutput.uploadUrl, { method: 'PUT', body: heatmap }),
+    ])
+    expect(csvUploadResponse.ok).toBe(true)
+    expect(heatmapUploadResponse.ok).toBe(true)
+
+    const csvDownload = await issueAnalysisTrajectoryCsvDownloadUrl(
+      organizationId,
+      analysisRunId,
+      trajectoryId
+    )
+    const csvDownloadResponse = await fetch(csvDownload.downloadUrl)
+
+    expect(csvDownloadResponse.ok).toBe(true)
+    await expect(csvDownloadResponse.text()).resolves.toBe(csv)
+    await expect(readObjectText(s3, heatmapOutput.objectKey)).resolves.toBe(heatmap)
   }, 30000)
 })

--- a/apps/nozomi/pyproject.toml
+++ b/apps/nozomi/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
     "fastapi[standard]>=0.135.1",
+    "pandas>=3.0.1",
     "pydantic>=2.12.5",
     "rikka",
     "sentry-sdk>=2.54.0",
@@ -32,7 +33,7 @@ dev = [
 ]
 
 [tool.uv.sources]
-rikka = { git = "https://github.com/kajiLabTeam/rikka.git" }
+rikka = { git = "https://github.com/kajiLabTeam/rikka.git", rev = "ebbf7978f8c12829bb891c149cbf1985ab846529" }
 
 [tool.ruff]
 line-length = 88

--- a/apps/nozomi/src/analysis/stay_heatmap.py
+++ b/apps/nozomi/src/analysis/stay_heatmap.py
@@ -1,0 +1,213 @@
+import importlib
+import json
+import math
+from io import BytesIO
+from typing import Any, Protocol, cast
+from urllib.request import Request as UrlRequest
+from urllib.request import urlopen
+
+import pandas as pd
+
+from src.schemas.analysis import StayHeatmapAnalyzeRequest, StayHeatmapTrajectory
+
+HTTP_TIMEOUT_SECONDS = 120
+ERROR_MESSAGES = {
+    "TRAJECTORY_DOWNLOAD_FAILED": "trajectory download failed",
+    "INVALID_TRAJECTORY_CSV": "input validation failed",
+    "ANALYSIS_PROCESSING_FAILED": "analysis processing failed",
+    "ARTIFACT_UPLOAD_FAILED": "artifact upload failed",
+}
+
+
+class InvalidTrajectoryCsvError(ValueError):
+    pass
+
+
+class StayHeatmapAnalyzer(Protocol):
+    def enrich_and_aggregate(
+        self,
+        dataframe: pd.DataFrame,
+        request: StayHeatmapAnalyzeRequest,
+        trajectory: StayHeatmapTrajectory,
+    ) -> tuple[pd.DataFrame, list[dict[str, int]]]: ...
+
+
+class RikkaStayHeatmapAnalyzer:
+    """Rikkaの滞在分析公開APIをNozomiから隔離するadapter。"""
+
+    def enrich_and_aggregate(
+        self,
+        dataframe: pd.DataFrame,
+        request: StayHeatmapAnalyzeRequest,
+        trajectory: StayHeatmapTrajectory,
+    ) -> tuple[pd.DataFrame, list[dict[str, int]]]:
+        try:
+            module = importlib.import_module("rikka.stay_analysis")
+        except ImportError as error:
+            raise RuntimeError("rikka stay analysis API is not installed") from error
+
+        enriched = module.enrich_trajectory(
+            dataframe,
+            speed_threshold_mps=request.parameters.speed_threshold_mps,
+        )
+        cells = module.aggregate_trajectory_grid(
+            enriched,
+            map_width_px=request.floor.map_width_px,
+            map_height_px=request.floor.map_height_px,
+            floor_scale=request.floor.scale_m_per_px,
+            grid_size_m=request.parameters.grid_size_m,
+            start_x_px=trajectory.start.x_px,
+            start_y_px=trajectory.start.y_px,
+        )
+        return enriched, cells
+
+
+def get_stay_heatmap_analyzer() -> StayHeatmapAnalyzer:
+    return RikkaStayHeatmapAnalyzer()
+
+
+class StayHeatmapRunner:
+    def __init__(self, analyzer: StayHeatmapAnalyzer) -> None:
+        self.analyzer = analyzer
+
+    def run(self, request: StayHeatmapAnalyzeRequest) -> None:
+        try:
+            trajectories: list[dict[str, Any]] = []
+            for trajectory in request.trajectories:
+                dataframe = self._download_csv(trajectory)
+                enriched, cells = self._analyze(dataframe, request, trajectory)
+                self._upload(
+                    trajectory.output.upload_url,
+                    self._serialize_csv(enriched),
+                    "text/csv; charset=utf-8",
+                )
+                trajectories.append(
+                    {"trajectory_id": str(trajectory.trajectory_id), "cells": cells}
+                )
+
+            self._upload(
+                request.heatmap_output.upload_url,
+                self._serialize_heatmap(request, trajectories),
+                "application/json",
+            )
+            self._callback(request, {"status": "completed"})
+        except Exception as error:
+            code = self._error_code(error)
+            self._callback(
+                request,
+                {
+                    "status": "failed",
+                    "error_code": code,
+                    "error_message": ERROR_MESSAGES[code],
+                },
+            )
+
+    def _download_csv(self, trajectory: StayHeatmapTrajectory) -> pd.DataFrame:
+        try:
+            with urlopen(
+                str(trajectory.source.download_url), timeout=HTTP_TIMEOUT_SECONDS
+            ) as response:
+                if response.status >= 400:
+                    raise RuntimeError(f"download failed with status {response.status}")
+                return pd.read_csv(BytesIO(response.read()))
+        except (ValueError, pd.errors.ParserError) as error:
+            raise InvalidTrajectoryCsvError("input CSV is invalid") from error
+        except Exception as error:
+            raise ConnectionError("trajectory download failed") from error
+
+    def _analyze(
+        self,
+        dataframe: pd.DataFrame,
+        request: StayHeatmapAnalyzeRequest,
+        trajectory: StayHeatmapTrajectory,
+    ) -> tuple[pd.DataFrame, list[dict[str, int]]]:
+        try:
+            return self.analyzer.enrich_and_aggregate(dataframe, request, trajectory)
+        except ValueError as error:
+            raise InvalidTrajectoryCsvError("input CSV validation failed") from error
+
+    def _serialize_csv(self, dataframe: pd.DataFrame) -> bytes:
+        output = dataframe.copy()
+        output["speed_mps"] = output["speed_mps"].map(
+            lambda value: "" if pd.isna(value) else f"{float(value):.6f}"
+        )
+        output["is_stay"] = output["is_stay"].map(
+            lambda value: "true" if bool(value) else "false"
+        )
+        csv_text = cast(str, output.to_csv(index=False, lineterminator="\n"))
+        return csv_text.encode("utf-8")
+
+    def _serialize_heatmap(
+        self,
+        request: StayHeatmapAnalyzeRequest,
+        trajectories: list[dict[str, Any]],
+    ) -> bytes:
+        floor = request.floor
+        grid_size = request.parameters.grid_size_m
+        artifact = {
+            "schema_version": "1.0",
+            "definition_version": request.definition_version,
+            "parameters": request.parameters.model_dump(),
+            "floor_map": {
+                "width_px": floor.map_width_px,
+                "height_px": floor.map_height_px,
+                "scale_m_per_px": floor.scale_m_per_px,
+            },
+            "grid": {
+                "size_m": grid_size,
+                "column_count": math.ceil(
+                    floor.map_width_px * floor.scale_m_per_px / grid_size
+                ),
+                "row_count": math.ceil(
+                    floor.map_height_px * floor.scale_m_per_px / grid_size
+                ),
+            },
+            "input_trajectory_count": len(trajectories),
+            "trajectories": trajectories,
+        }
+        return json.dumps(artifact, ensure_ascii=False, separators=(",", ":")).encode()
+
+    def _upload(self, url: object, body: bytes, content_type: str) -> None:
+        try:
+            upload = UrlRequest(
+                str(url),
+                data=body,
+                headers={"content-type": content_type},
+                method="PUT",
+            )
+            with urlopen(upload, timeout=HTTP_TIMEOUT_SECONDS) as response:
+                if response.status >= 400:
+                    raise RuntimeError(f"upload failed with status {response.status}")
+        except Exception as error:
+            raise OSError("artifact upload failed") from error
+
+    def _callback(
+        self, request: StayHeatmapAnalyzeRequest, result: dict[str, object]
+    ) -> None:
+        payload = {
+            "analysis_run_id": str(request.analysis_run_id),
+            **result,
+            "callback_token": request.callback.token,
+        }
+        callback = UrlRequest(
+            str(request.callback.url),
+            data=json.dumps(payload).encode(),
+            headers={"content-type": "application/json"},
+            method="POST",
+        )
+        with urlopen(callback, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            if response.status >= 400:
+                raise RuntimeError(f"callback failed with status {response.status}")
+
+    def _error_code(self, error: Exception) -> str:
+        if isinstance(error, ConnectionError):
+            return "TRAJECTORY_DOWNLOAD_FAILED"
+        if isinstance(error, InvalidTrajectoryCsvError):
+            return "INVALID_TRAJECTORY_CSV"
+        if isinstance(error, OSError):
+            return "ARTIFACT_UPLOAD_FAILED"
+        return "ANALYSIS_PROCESSING_FAILED"
+
+
+def get_stay_heatmap_runner() -> StayHeatmapRunner:
+    return StayHeatmapRunner(get_stay_heatmap_analyzer())

--- a/apps/nozomi/src/routes/analysis.py
+++ b/apps/nozomi/src/routes/analysis.py
@@ -1,7 +1,13 @@
 from fastapi import APIRouter, BackgroundTasks, status
 
-from src.schemas.analysis import AnalyzeAcceptedResponse, AnalyzeRequest
+from src.schemas.analysis import (
+    AnalyzeAcceptedResponse,
+    AnalyzeRequest,
+    StayHeatmapAcceptedResponse,
+    StayHeatmapAnalyzeRequest,
+)
 from src.usecases.submit_analysis import submit_analysis
+from src.usecases.submit_stay_heatmap import submit_stay_heatmap
 
 analysis_router = APIRouter()
 
@@ -21,3 +27,16 @@ def analyze(
     payload: AnalyzeRequest, background_tasks: BackgroundTasks
 ) -> AnalyzeAcceptedResponse:
     return submit_analysis(payload, background_tasks)
+
+
+@analysis_router.post(
+    "/stay-heatmaps/analyze",
+    response_model=StayHeatmapAcceptedResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="滞在ヒートマップ解析依頼を受け付ける",
+    tags=["analysis"],
+)
+def analyze_stay_heatmap(
+    payload: StayHeatmapAnalyzeRequest, background_tasks: BackgroundTasks
+) -> StayHeatmapAcceptedResponse:
+    return submit_stay_heatmap(payload, background_tasks)

--- a/apps/nozomi/src/schemas/analysis.py
+++ b/apps/nozomi/src/schemas/analysis.py
@@ -166,3 +166,88 @@ class AnalyzeRequest(BaseModel):
 class AnalyzeAcceptedResponse(BaseModel):
     trajectory_id: UUID = Field(description="受理した trajectory の ID")
     status: Literal["accepted"] = Field(description="解析要求を受理した状態")
+
+
+class StayHeatmapParameters(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    speed_threshold_mps: float = Field(ge=0, le=2)
+    grid_size_m: float = Field(ge=0.1, le=10)
+
+
+class StayHeatmapFloor(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    floor_id: UUID
+    map_width_px: int = Field(gt=0)
+    map_height_px: int = Field(gt=0)
+    scale_m_per_px: float = Field(gt=0)
+
+
+class StayHeatmapStart(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    x_px: float
+    y_px: float
+
+
+class StayHeatmapSource(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    download_url: HttpUrl
+
+
+class StayHeatmapOutput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    upload_url: HttpUrl
+
+
+class StayHeatmapTrajectory(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    trajectory_id: UUID
+    seq: int = Field(ge=0)
+    start: StayHeatmapStart
+    source: StayHeatmapSource
+    output: StayHeatmapOutput
+
+
+class StayHeatmapCallback(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    url: HttpUrl
+    token: str = Field(min_length=1)
+
+
+class StayHeatmapAnalyzeRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    analysis_run_id: UUID
+    analysis_type: Literal["stay_heatmap"]
+    definition_version: Literal["original-v1"]
+    parameters: StayHeatmapParameters
+    floor: StayHeatmapFloor
+    trajectories: list[StayHeatmapTrajectory] = Field(min_length=1, max_length=100)
+    heatmap_output: StayHeatmapOutput
+    callback: StayHeatmapCallback
+
+    @model_validator(mode="after")
+    def validate_trajectories(self) -> StayHeatmapAnalyzeRequest:
+        seqs = [trajectory.seq for trajectory in self.trajectories]
+        if seqs != list(range(len(seqs))):
+            raise ValueError("trajectories must be ordered by seq with no gaps")
+        ids = [trajectory.trajectory_id for trajectory in self.trajectories]
+        if len(ids) != len(set(ids)):
+            raise ValueError("trajectory_id must be unique")
+        for trajectory in self.trajectories:
+            if not 0 <= trajectory.start.x_px < self.floor.map_width_px:
+                raise ValueError("start x_px must be inside the floor map")
+            if not 0 <= trajectory.start.y_px < self.floor.map_height_px:
+                raise ValueError("start y_px must be inside the floor map")
+        return self
+
+
+class StayHeatmapAcceptedResponse(BaseModel):
+    analysis_run_id: UUID
+    status: Literal["accepted"]

--- a/apps/nozomi/src/usecases/submit_stay_heatmap.py
+++ b/apps/nozomi/src/usecases/submit_stay_heatmap.py
@@ -1,0 +1,17 @@
+from fastapi import BackgroundTasks
+
+from src.analysis.stay_heatmap import get_stay_heatmap_runner
+from src.schemas.analysis import (
+    StayHeatmapAcceptedResponse,
+    StayHeatmapAnalyzeRequest,
+)
+
+
+def submit_stay_heatmap(
+    payload: StayHeatmapAnalyzeRequest, background_tasks: BackgroundTasks
+) -> StayHeatmapAcceptedResponse:
+    background_tasks.add_task(get_stay_heatmap_runner().run, payload)
+    return StayHeatmapAcceptedResponse(
+        analysis_run_id=payload.analysis_run_id,
+        status="accepted",
+    )

--- a/apps/nozomi/tests/test_stay_heatmap.py
+++ b/apps/nozomi/tests/test_stay_heatmap.py
@@ -2,10 +2,12 @@ import asyncio
 import json
 from typing import Any
 
+import pandas as pd
+import pytest
 from fastapi import BackgroundTasks
 from fastapi.testclient import TestClient
 
-from src.analysis.stay_heatmap import StayHeatmapRunner
+from src.analysis.stay_heatmap import RikkaStayHeatmapAnalyzer, StayHeatmapRunner
 from src.schemas.analysis import StayHeatmapAnalyzeRequest
 from src.server import app
 from src.usecases.submit_stay_heatmap import submit_stay_heatmap
@@ -114,6 +116,31 @@ def test_submit_registers_background_runner(monkeypatch: Any) -> None:
 
     assert response.status == "accepted"
     assert calls == [request]
+
+
+def test_rikka_adapter_enriches_and_aggregates_real_implementation() -> None:
+    request = StayHeatmapAnalyzeRequest.model_validate(valid_payload())
+    trajectory = request.trajectories[0]
+    dataframe = pd.DataFrame(
+        {
+            "step_index": [0, 1, 2, 3],
+            "rikka_timestamp_s": [float("nan"), 0.0, 0.6, 1.2],
+            "rikka_x": [0.0, 0.0, 0.1, 0.2],
+            "rikka_y": [0.0, 0.0, 0.0, 0.0],
+            "x": [10.0, 10.0, 100.0, 100.0],
+            "y": [20.0, 20.0, 20.0, 20.0],
+        }
+    )
+
+    enriched, cells = RikkaStayHeatmapAnalyzer().enrich_and_aggregate(
+        dataframe, request, trajectory
+    )
+
+    assert list(enriched.columns[-2:]) == ["speed_mps", "is_stay"]
+    assert enriched["speed_mps"].iloc[:2].isna().all()
+    assert enriched["speed_mps"].iloc[2:].tolist() == pytest.approx([1 / 6, 1 / 6])
+    assert enriched["is_stay"].tolist() == [False, False, True, True]
+    assert cells == [{"grid_column": 1, "grid_row": 0, "stay_cell_visit_count": 1}]
 
 
 class StubResponse:

--- a/apps/nozomi/tests/test_stay_heatmap.py
+++ b/apps/nozomi/tests/test_stay_heatmap.py
@@ -1,0 +1,190 @@
+import asyncio
+import json
+from typing import Any
+
+from fastapi import BackgroundTasks
+from fastapi.testclient import TestClient
+
+from src.analysis.stay_heatmap import StayHeatmapRunner
+from src.schemas.analysis import StayHeatmapAnalyzeRequest
+from src.server import app
+from src.usecases.submit_stay_heatmap import submit_stay_heatmap
+
+
+def valid_payload() -> dict[str, object]:
+    return {
+        "analysis_run_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "analysis_type": "stay_heatmap",
+        "definition_version": "original-v1",
+        "parameters": {"speed_threshold_mps": 0.5, "grid_size_m": 1.0},
+        "floor": {
+            "floor_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+            "map_width_px": 101,
+            "map_height_px": 201,
+            "scale_m_per_px": 0.01,
+        },
+        "trajectories": [
+            {
+                "trajectory_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+                "seq": 0,
+                "start": {"x_px": 10.0, "y_px": 20.0},
+                "source": {"download_url": "https://storage.invalid/input.csv"},
+                "output": {"upload_url": "https://storage.invalid/stay.csv"},
+            }
+        ],
+        "heatmap_output": {"upload_url": "https://storage.invalid/stay-heatmap.json"},
+        "callback": {
+            "url": "https://kaede.invalid/api/analysis-runs/callback",
+            "token": "signed-token",
+        },
+    }
+
+
+def test_endpoint_accepts_stay_heatmap_request(monkeypatch: Any) -> None:
+    calls: list[StayHeatmapAnalyzeRequest] = []
+
+    class StubRunner:
+        def run(self, request: StayHeatmapAnalyzeRequest) -> None:
+            calls.append(request)
+
+    monkeypatch.setattr(
+        "src.usecases.submit_stay_heatmap.get_stay_heatmap_runner",
+        lambda: StubRunner(),
+    )
+    response = TestClient(app).post("/stay-heatmaps/analyze", json=valid_payload())
+
+    assert response.status_code == 202
+    assert response.json() == {
+        "analysis_run_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "status": "accepted",
+    }
+    assert len(calls) == 1
+
+
+def test_schema_rejects_unknown_field_and_invalid_sequence() -> None:
+    unknown = valid_payload()
+    unknown["unknown"] = True
+    assert (
+        TestClient(app).post("/stay-heatmaps/analyze", json=unknown).status_code == 422
+    )
+
+    invalid_seq = valid_payload()
+    invalid_seq["trajectories"][0]["seq"] = 1  # type: ignore[index]
+    assert (
+        TestClient(app).post("/stay-heatmaps/analyze", json=invalid_seq).status_code
+        == 422
+    )
+
+
+def test_submit_registers_background_runner(monkeypatch: Any) -> None:
+    request = StayHeatmapAnalyzeRequest.model_validate(valid_payload())
+    background_tasks = BackgroundTasks()
+    calls: list[StayHeatmapAnalyzeRequest] = []
+
+    class StubRunner:
+        def run(self, payload: StayHeatmapAnalyzeRequest) -> None:
+            calls.append(payload)
+
+    monkeypatch.setattr(
+        "src.usecases.submit_stay_heatmap.get_stay_heatmap_runner",
+        lambda: StubRunner(),
+    )
+    response = submit_stay_heatmap(request, background_tasks)
+    for task in background_tasks.tasks:
+        asyncio.run(task())
+
+    assert response.status == "accepted"
+    assert calls == [request]
+
+
+class StubResponse:
+    def __init__(self, body: bytes = b"") -> None:
+        self.body = body
+        self.status = 200
+
+    def __enter__(self) -> StubResponse:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self.body
+
+
+def test_runner_processes_trajectories_and_uploads_artifacts(monkeypatch: Any) -> None:
+    requests: list[tuple[str, str, bytes | None, str | None]] = []
+
+    def fake_urlopen(request: Any, timeout: int) -> StubResponse:
+        assert timeout == 120
+        url = request.full_url if hasattr(request, "full_url") else str(request)
+        method = request.get_method() if hasattr(request, "get_method") else "GET"
+        body = getattr(request, "data", None)
+        content_type = (
+            request.get_header("Content-type")
+            if hasattr(request, "get_header")
+            else None
+        )
+        requests.append((url, method, body, content_type))
+        if url.endswith("input.csv"):
+            return StubResponse(
+                b"step_index,rikka_timestamp_s,rikka_x,rikka_y,x,y\n"
+                b"0,,0,0,10,20\n1,0,0,0,10,20\n2,1,0.1,0,11,20\n"
+            )
+        return StubResponse()
+
+    class StubAnalyzer:
+        def enrich_and_aggregate(self, dataframe, request, trajectory):
+            enriched = dataframe.copy()
+            enriched["speed_mps"] = [float("nan"), float("nan"), 0.1]
+            enriched["is_stay"] = [False, False, True]
+            return enriched, [
+                {"grid_column": 0, "grid_row": 0, "stay_cell_visit_count": 1}
+            ]
+
+    monkeypatch.setattr("src.analysis.stay_heatmap.urlopen", fake_urlopen)
+    StayHeatmapRunner(StubAnalyzer()).run(
+        StayHeatmapAnalyzeRequest.model_validate(valid_payload())
+    )
+
+    assert [request[1] for request in requests] == ["GET", "PUT", "PUT", "POST"]
+    csv_body = requests[1][2]
+    assert csv_body is not None
+    assert csv_body.endswith(b",0.100000,true\n")
+    artifact_body = requests[2][2]
+    assert artifact_body is not None
+    artifact = json.loads(artifact_body)
+    assert artifact["grid"] == {"size_m": 1.0, "column_count": 2, "row_count": 3}
+    assert artifact["trajectories"][0]["cells"][0]["stay_cell_visit_count"] == 1
+    callback = json.loads(requests[3][2])
+    assert callback == {
+        "analysis_run_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "status": "completed",
+        "callback_token": "signed-token",
+    }
+
+
+def test_runner_reports_invalid_csv(monkeypatch: Any) -> None:
+    requests: list[Any] = []
+
+    def fake_urlopen(request: Any, timeout: int) -> StubResponse:
+        requests.append(request)
+        url = request.full_url if hasattr(request, "full_url") else str(request)
+        return (
+            StubResponse(b"not,a,valid,trajectory\n")
+            if url.endswith("input.csv")
+            else StubResponse()
+        )
+
+    class RejectingAnalyzer:
+        def enrich_and_aggregate(self, dataframe, request, trajectory):
+            raise ValueError("missing columns")
+
+    monkeypatch.setattr("src.analysis.stay_heatmap.urlopen", fake_urlopen)
+    StayHeatmapRunner(RejectingAnalyzer()).run(
+        StayHeatmapAnalyzeRequest.model_validate(valid_payload())
+    )
+
+    callback = json.loads(requests[-1].data)
+    assert callback["status"] == "failed"
+    assert callback["error_code"] == "INVALID_TRAJECTORY_CSV"

--- a/apps/nozomi/tests/test_stay_heatmap.py
+++ b/apps/nozomi/tests/test_stay_heatmap.py
@@ -76,6 +76,25 @@ def test_schema_rejects_unknown_field_and_invalid_sequence() -> None:
     )
 
 
+def test_schema_rejects_duplicate_trajectory_and_start_outside_floor() -> None:
+    duplicate = valid_payload()
+    trajectories = duplicate["trajectories"]
+    assert isinstance(trajectories, list)
+    first_trajectory = trajectories[0]
+    assert isinstance(first_trajectory, dict)
+    trajectories.append({**first_trajectory, "seq": 1})
+    assert (
+        TestClient(app).post("/stay-heatmaps/analyze", json=duplicate).status_code
+        == 422
+    )
+
+    outside = valid_payload()
+    outside["trajectories"][0]["start"]["x_px"] = 101  # type: ignore[index]
+    assert (
+        TestClient(app).post("/stay-heatmaps/analyze", json=outside).status_code == 422
+    )
+
+
 def test_submit_registers_background_runner(monkeypatch: Any) -> None:
     request = StayHeatmapAnalyzeRequest.model_validate(valid_payload())
     background_tasks = BackgroundTasks()
@@ -156,7 +175,9 @@ def test_runner_processes_trajectories_and_uploads_artifacts(monkeypatch: Any) -
     artifact = json.loads(artifact_body)
     assert artifact["grid"] == {"size_m": 1.0, "column_count": 2, "row_count": 3}
     assert artifact["trajectories"][0]["cells"][0]["stay_cell_visit_count"] == 1
-    callback = json.loads(requests[3][2])
+    callback_body = requests[3][2]
+    assert callback_body is not None
+    callback = json.loads(callback_body)
     assert callback == {
         "analysis_run_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
         "status": "completed",
@@ -188,3 +209,83 @@ def test_runner_reports_invalid_csv(monkeypatch: Any) -> None:
     callback = json.loads(requests[-1].data)
     assert callback["status"] == "failed"
     assert callback["error_code"] == "INVALID_TRAJECTORY_CSV"
+
+
+def test_runner_reports_trajectory_download_failure(monkeypatch: Any) -> None:
+    requests: list[Any] = []
+
+    def fake_urlopen(request: Any, timeout: int) -> StubResponse:
+        requests.append(request)
+        if isinstance(request, str):
+            raise OSError("storage unavailable")
+        return StubResponse()
+
+    class UnusedAnalyzer:
+        def enrich_and_aggregate(self, dataframe, request, trajectory):
+            raise AssertionError("analyzer must not be called")
+
+    monkeypatch.setattr("src.analysis.stay_heatmap.urlopen", fake_urlopen)
+    StayHeatmapRunner(UnusedAnalyzer()).run(
+        StayHeatmapAnalyzeRequest.model_validate(valid_payload())
+    )
+
+    callback = json.loads(requests[-1].data)
+    assert callback["status"] == "failed"
+    assert callback["error_code"] == "TRAJECTORY_DOWNLOAD_FAILED"
+    assert "storage unavailable" not in callback["error_message"]
+
+
+def test_runner_reports_analysis_processing_failure(monkeypatch: Any) -> None:
+    requests: list[Any] = []
+
+    def fake_urlopen(request: Any, timeout: int) -> StubResponse:
+        requests.append(request)
+        url = request.full_url if hasattr(request, "full_url") else str(request)
+        if url.endswith("input.csv"):
+            return StubResponse(b"step_index\n0\n")
+        return StubResponse()
+
+    class FailingAnalyzer:
+        def enrich_and_aggregate(self, dataframe, request, trajectory):
+            raise RuntimeError("rikka internal details")
+
+    monkeypatch.setattr("src.analysis.stay_heatmap.urlopen", fake_urlopen)
+    StayHeatmapRunner(FailingAnalyzer()).run(
+        StayHeatmapAnalyzeRequest.model_validate(valid_payload())
+    )
+
+    callback = json.loads(requests[-1].data)
+    assert callback["status"] == "failed"
+    assert callback["error_code"] == "ANALYSIS_PROCESSING_FAILED"
+    assert "rikka internal details" not in callback["error_message"]
+
+
+def test_runner_reports_artifact_upload_failure(monkeypatch: Any) -> None:
+    requests: list[Any] = []
+
+    def fake_urlopen(request: Any, timeout: int) -> StubResponse:
+        requests.append(request)
+        url = request.full_url if hasattr(request, "full_url") else str(request)
+        method = request.get_method() if hasattr(request, "get_method") else "GET"
+        if url.endswith("input.csv"):
+            return StubResponse(b"step_index\n0\n")
+        if method == "PUT":
+            raise OSError("storage write failed")
+        return StubResponse()
+
+    class StubAnalyzer:
+        def enrich_and_aggregate(self, dataframe, request, trajectory):
+            enriched = dataframe.copy()
+            enriched["speed_mps"] = [float("nan")]
+            enriched["is_stay"] = [False]
+            return enriched, []
+
+    monkeypatch.setattr("src.analysis.stay_heatmap.urlopen", fake_urlopen)
+    StayHeatmapRunner(StubAnalyzer()).run(
+        StayHeatmapAnalyzeRequest.model_validate(valid_payload())
+    )
+
+    callback = json.loads(requests[-1].data)
+    assert callback["status"] == "failed"
+    assert callback["error_code"] == "ARTIFACT_UPLOAD_FAILED"
+    assert "storage write failed" not in callback["error_message"]

--- a/apps/nozomi/uv.lock
+++ b/apps/nozomi/uv.lock
@@ -535,6 +535,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },
+    { name = "pandas" },
     { name = "pydantic" },
     { name = "rikka" },
     { name = "scalar-fastapi" },
@@ -551,8 +552,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.1" },
+    { name = "pandas", specifier = ">=3.0.1" },
     { name = "pydantic", specifier = ">=2.12.5" },
-    { name = "rikka", git = "https://github.com/kajiLabTeam/rikka.git" },
+    { name = "rikka", git = "https://github.com/kajiLabTeam/rikka.git?rev=ebbf7978f8c12829bb891c149cbf1985ab846529" },
     { name = "scalar-fastapi", specifier = ">=1.4.1" },
     { name = "sentry-sdk", specifier = ">=2.54.0" },
 ]
@@ -926,7 +928,7 @@ wheels = [
 [[package]]
 name = "rikka"
 version = "0.1.0"
-source = { git = "https://github.com/kajiLabTeam/rikka.git#233e3e4d38cd05661489f8447a7021ce918d7621" }
+source = { git = "https://github.com/kajiLabTeam/rikka.git?rev=ebbf7978f8c12829bb891c149cbf1985ab846529#ebbf7978f8c12829bb891c149cbf1985ab846529" }
 dependencies = [
     { name = "click" },
     { name = "matplotlib" },

--- a/db/migrations/20260804010000_add_floor_map_dimensions.sql
+++ b/db/migrations/20260804010000_add_floor_map_dimensions.sql
@@ -1,0 +1,27 @@
+-- migrate:up
+
+ALTER TABLE floors
+  ADD COLUMN map_width_px integer,
+  ADD COLUMN map_height_px integer,
+  ADD CONSTRAINT floors_map_dimensions_presence_chk CHECK (
+    (map_width_px IS NULL AND map_height_px IS NULL)
+    OR (map_width_px IS NOT NULL AND map_height_px IS NOT NULL)
+  ),
+  ADD CONSTRAINT floors_map_dimensions_bounds_chk CHECK (
+    map_width_px IS NULL
+    OR (
+      map_width_px > 0
+      AND map_height_px > 0
+      AND map_width_px <= 20000
+      AND map_height_px <= 20000
+      AND map_width_px::bigint * map_height_px::bigint <= 100000000
+    )
+  );
+
+-- migrate:down
+
+ALTER TABLE floors
+  DROP CONSTRAINT floors_map_dimensions_bounds_chk,
+  DROP CONSTRAINT floors_map_dimensions_presence_chk,
+  DROP COLUMN map_height_px,
+  DROP COLUMN map_width_px;

--- a/db/migrations/20260804020000_add_analysis_runs.sql
+++ b/db/migrations/20260804020000_add_analysis_runs.sql
@@ -1,0 +1,62 @@
+-- migrate:up
+
+CREATE TABLE analysis_runs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid NOT NULL REFERENCES organizations(id),
+  floor_id uuid NOT NULL REFERENCES floors(id),
+  analysis_type text NOT NULL,
+  status text NOT NULL DEFAULT 'accepted',
+  parameters jsonb NOT NULL,
+  definition_version text NOT NULL,
+  error_code text,
+  started_at timestamptz,
+  deadline_at timestamptz NOT NULL DEFAULT (now() + interval '60 minutes'),
+  finished_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT analysis_runs_analysis_type_nonempty_chk CHECK (length(btrim(analysis_type)) > 0),
+  CONSTRAINT analysis_runs_definition_version_nonempty_chk
+    CHECK (length(btrim(definition_version)) > 0),
+  CONSTRAINT analysis_runs_parameters_object_chk CHECK (jsonb_typeof(parameters) = 'object'),
+  CONSTRAINT analysis_runs_status_chk
+    CHECK (status IN ('accepted', 'processing', 'completed', 'failed')),
+  CONSTRAINT analysis_runs_state_chk CHECK (
+    (status = 'accepted' AND started_at IS NULL AND finished_at IS NULL AND error_code IS NULL)
+    OR (
+      status = 'processing'
+      AND started_at IS NOT NULL
+      AND finished_at IS NULL
+      AND error_code IS NULL
+    )
+    OR (
+      status = 'completed'
+      AND started_at IS NOT NULL
+      AND finished_at IS NOT NULL
+      AND error_code IS NULL
+    )
+    OR (
+      status = 'failed'
+      AND finished_at IS NOT NULL
+      AND length(btrim(error_code)) > 0
+    )
+  )
+);
+
+CREATE INDEX analysis_runs_organization_created_at_id_idx
+  ON analysis_runs (organization_id, created_at DESC, id DESC);
+
+CREATE TABLE analysis_run_trajectories (
+  analysis_run_id uuid NOT NULL REFERENCES analysis_runs(id) ON DELETE CASCADE,
+  trajectory_id uuid NOT NULL REFERENCES trajectories(id),
+  seq integer NOT NULL CHECK (seq >= 0),
+  PRIMARY KEY (analysis_run_id, trajectory_id),
+  UNIQUE (analysis_run_id, seq)
+);
+
+CREATE INDEX analysis_run_trajectories_trajectory_id_idx
+  ON analysis_run_trajectories (trajectory_id);
+
+-- migrate:down
+
+DROP TABLE analysis_run_trajectories;
+DROP TABLE analysis_runs;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -80,6 +80,10 @@ CREATE TABLE public.floors (
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
     organization_id uuid NOT NULL,
+    map_width_px integer,
+    map_height_px integer,
+    CONSTRAINT floors_map_dimensions_bounds_chk CHECK (((map_width_px IS NULL) OR ((map_width_px > 0) AND (map_height_px > 0) AND (map_width_px <= 20000) AND (map_height_px <= 20000) AND (((map_width_px)::bigint * (map_height_px)::bigint) <= 100000000)))),
+    CONSTRAINT floors_map_dimensions_presence_chk CHECK ((((map_width_px IS NULL) AND (map_height_px IS NULL)) OR ((map_width_px IS NOT NULL) AND (map_height_px IS NOT NULL)))),
     CONSTRAINT floors_image_object_path_format_chk CHECK (((image_object_path ~ '^maps/[0-9a-fA-F-]+/[0-9a-fA-F-]+\.(svg|png)$'::text) OR (image_object_path ~ '^organizations/[0-9a-fA-F-]+/floors/[0-9a-fA-F-]+/map\.(svg|png)$'::text)))
 );
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -34,6 +34,44 @@ SET default_tablespace = '';
 SET default_table_access_method = heap;
 
 --
+-- Name: analysis_runs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.analysis_runs (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    floor_id uuid NOT NULL,
+    analysis_type text NOT NULL,
+    status text DEFAULT 'accepted'::text NOT NULL,
+    parameters jsonb NOT NULL,
+    definition_version text NOT NULL,
+    error_code text,
+    started_at timestamp with time zone,
+    deadline_at timestamp with time zone DEFAULT (now() + '01:00:00'::interval) NOT NULL,
+    finished_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT analysis_runs_analysis_type_nonempty_chk CHECK ((length(btrim(analysis_type)) > 0)),
+    CONSTRAINT analysis_runs_definition_version_nonempty_chk CHECK ((length(btrim(definition_version)) > 0)),
+    CONSTRAINT analysis_runs_parameters_object_chk CHECK ((jsonb_typeof(parameters) = 'object'::text)),
+    CONSTRAINT analysis_runs_state_chk CHECK ((((status = 'accepted'::text) AND (started_at IS NULL) AND (finished_at IS NULL) AND (error_code IS NULL)) OR ((status = 'processing'::text) AND (started_at IS NOT NULL) AND (finished_at IS NULL) AND (error_code IS NULL)) OR ((status = 'completed'::text) AND (started_at IS NOT NULL) AND (finished_at IS NOT NULL) AND (error_code IS NULL)) OR ((status = 'failed'::text) AND (finished_at IS NOT NULL) AND (length(btrim(error_code)) > 0)))),
+    CONSTRAINT analysis_runs_status_chk CHECK ((status = ANY (ARRAY['accepted'::text, 'processing'::text, 'completed'::text, 'failed'::text])))
+);
+
+
+--
+-- Name: analysis_run_trajectories; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.analysis_run_trajectories (
+    analysis_run_id uuid NOT NULL,
+    trajectory_id uuid NOT NULL,
+    seq integer NOT NULL,
+    CONSTRAINT analysis_run_trajectories_seq_check CHECK ((seq >= 0))
+);
+
+
+--
 -- Name: auth_identities; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -319,6 +357,22 @@ CREATE TABLE public.users (
 -- Name: auth_identities auth_identities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY public.analysis_runs
+    ADD CONSTRAINT analysis_runs_pkey PRIMARY KEY (id);
+
+
+ALTER TABLE ONLY public.analysis_run_trajectories
+    ADD CONSTRAINT analysis_run_trajectories_pkey PRIMARY KEY (analysis_run_id, trajectory_id);
+
+
+ALTER TABLE ONLY public.analysis_run_trajectories
+    ADD CONSTRAINT analysis_run_trajectories_analysis_run_id_seq_key UNIQUE (analysis_run_id, seq);
+
+
+--
+-- Name: auth_identities auth_identities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.auth_identities
     ADD CONSTRAINT auth_identities_pkey PRIMARY KEY (id);
 
@@ -497,6 +551,16 @@ ALTER TABLE ONLY public.users
 
 ALTER TABLE ONLY public.users
     ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: auth_identities_one_google_identity_per_user; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX analysis_runs_organization_created_at_id_idx ON public.analysis_runs USING btree (organization_id, created_at DESC, id DESC);
+
+
+CREATE INDEX analysis_run_trajectories_trajectory_id_idx ON public.analysis_run_trajectories USING btree (trajectory_id);
 
 
 --
@@ -805,6 +869,26 @@ CREATE TRIGGER set_updated_at_trajectories BEFORE UPDATE ON public.trajectories 
 --
 
 CREATE TRIGGER set_updated_at_users BEFORE UPDATE ON public.users FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+
+--
+-- Name: auth_identities auth_identities_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.analysis_runs
+    ADD CONSTRAINT analysis_runs_floor_id_fkey FOREIGN KEY (floor_id) REFERENCES public.floors(id);
+
+
+ALTER TABLE ONLY public.analysis_runs
+    ADD CONSTRAINT analysis_runs_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+ALTER TABLE ONLY public.analysis_run_trajectories
+    ADD CONSTRAINT analysis_run_trajectories_analysis_run_id_fkey FOREIGN KEY (analysis_run_id) REFERENCES public.analysis_runs(id) ON DELETE CASCADE;
+
+
+ALTER TABLE ONLY public.analysis_run_trajectories
+    ADD CONSTRAINT analysis_run_trajectories_trajectory_id_fkey FOREIGN KEY (trajectory_id) REFERENCES public.trajectories(id);
 
 
 --

--- a/storage/README.md
+++ b/storage/README.md
@@ -67,3 +67,31 @@ make up ENV=local
 - `8333` は S3 API のため、ブラウザで直接開くと `Access Denied` になる
 - `8888` は Filer UI 用ポート
 - `9333` は SeaweedFS の管理情報確認用ポート
+
+## 既存floor mapの画像寸法を移行する
+
+`floors.map_width_px`と`map_height_px`が未設定の環境では、Kaedeコンテナ内で次を実行する。
+`backfill`はobject storage上のPNG IHDRまたはSVG viewBoxから寸法を取得し、未設定行だけを更新する。
+
+```sh
+node dist/cli/floor-map-dimension-backfill.js backfill
+node dist/cli/floor-map-dimension-backfill.js verify
+```
+
+開発環境ではmise経由で実行できる。
+
+```sh
+mise exec -- pnpm floor-map-dimension-backfill -- backfill
+mise exec -- pnpm floor-map-dimension-backfill -- verify
+```
+
+特定floorだけを再実行する場合は`--floor-id`を付ける。
+
+```sh
+node dist/cli/floor-map-dimension-backfill.js backfill --floor-id <UUID>
+```
+
+各floorの結果と最後の集計がJSON Linesで標準出力へ出る。`failed`が1件以上ある場合は終了コード1に
+なるため、objectの存在、拡張子、PNGのIHDRまたはSVGの`viewBox="0 0 width height"`、DBに保存済みの
+寸法との不一致を確認する。`backfill`は保存済み寸法を上書きせず、再実行できる。移行後に`verify`を
+実行し、最後の集計で`failed: 0`であることを確認する。


### PR DESCRIPTION
関連Issue: https://github.com/kajiLabTeam/okarin/issues/200

## 概要

滞在セル訪問回数ヒートマップPoCのうち、OkarinのKaede／Nozomi側を統合します。

## 作業内容

- floor mapの画像幅・高さを保存し、既存データ用backfill／verify CLIを追加
- analysis runと入力trajectoryのDB schema・repositoryを追加
- run作成、一覧、詳細、結果取得、callback APIを追加
- 固定artifact keyと署名URL、Nozomi依頼、timeout確定を追加
- Nozomiに非同期stay heatmap endpointとRikka adapterを追加
- callback、入力検証、失敗系を含むKaede／Nozomiテストを追加

各機能は10ファイル以内の個別PR #205〜#215でレビュー可能な単位に分割し、`200/main`へ統合しています。

## 検証内容

- Kaede TypeScript型検査：成功
- Kaede ESLint：成功
- Kaede unit test：77 files / 429 tests 成功
- Kaede DB test：23 files / 202 tests 成功
- Nozomi Ruff・format check：成功
- Nozomi mypy：成功
- Nozomi pytest：33 tests 成功

## PoCとして含めないもの

- ETag・versioning・条件付きPUT、artifact管理テーブル
- size上限、並列負荷制御、cache、保存期限、failed object清掃
- floor寸法列のNOT NULL化
- Mio画面、A/B比較

## Rikka連携

- Rikka draft PR: https://github.com/kajiLabTeam/rikka/pull/21
- 固定commit: `ebbf7978f8c12829bb891c149cbf1985ab846529`

Nozomiの依存定義とlockfileをこのSHAへ固定し、実Rikka adapterで速度・滞在判定・cell集計まで通ることをテストしています。Rikka PRは方針どおりmainへマージせず、remoteの`200/feature-stay-analysis`ブランチに保持しています。

設計ドキュメントは方針どおり本PRへ含めていません。
