### PR TITLE
Rikkaの滞在分析実装をNozomiへ接続

### DIFF
--- a/apps/nozomi/pyproject.toml
+++ b/apps/nozomi/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
     "fastapi[standard]>=0.135.1",
+    "pandas>=3.0.1",
     "pydantic>=2.12.5",
     "rikka",
     "sentry-sdk>=2.54.0",
@@ -32,7 +33,7 @@ dev = [
 ]
 
 [tool.uv.sources]
-rikka = { git = "https://github.com/kajiLabTeam/rikka.git" }
+rikka = { git = "https://github.com/kajiLabTeam/rikka.git", rev = "ebbf7978f8c12829bb891c149cbf1985ab846529" }
 
 [tool.ruff]
 line-length = 88

--- a/apps/nozomi/tests/test_stay_heatmap.py
+++ b/apps/nozomi/tests/test_stay_heatmap.py
@@ -2,10 +2,12 @@ import asyncio
 import json
 from typing import Any
 
+import pandas as pd
+import pytest
 from fastapi import BackgroundTasks
 from fastapi.testclient import TestClient
 
-from src.analysis.stay_heatmap import StayHeatmapRunner
+from src.analysis.stay_heatmap import RikkaStayHeatmapAnalyzer, StayHeatmapRunner
 from src.schemas.analysis import StayHeatmapAnalyzeRequest
 from src.server import app
 from src.usecases.submit_stay_heatmap import submit_stay_heatmap
@@ -114,6 +116,31 @@ def test_submit_registers_background_runner(monkeypatch: Any) -> None:
 
     assert response.status == "accepted"
     assert calls == [request]
+
+
+def test_rikka_adapter_enriches_and_aggregates_real_implementation() -> None:
+    request = StayHeatmapAnalyzeRequest.model_validate(valid_payload())
+    trajectory = request.trajectories[0]
+    dataframe = pd.DataFrame(
+        {
+            "step_index": [0, 1, 2, 3],
+            "rikka_timestamp_s": [float("nan"), 0.0, 0.6, 1.2],
+            "rikka_x": [0.0, 0.0, 0.1, 0.2],
+            "rikka_y": [0.0, 0.0, 0.0, 0.0],
+            "x": [10.0, 10.0, 100.0, 100.0],
+            "y": [20.0, 20.0, 20.0, 20.0],
+        }
+    )
+
+    enriched, cells = RikkaStayHeatmapAnalyzer().enrich_and_aggregate(
+        dataframe, request, trajectory
+    )
+
+    assert list(enriched.columns[-2:]) == ["speed_mps", "is_stay"]
+    assert enriched["speed_mps"].iloc[:2].isna().all()
+    assert enriched["speed_mps"].iloc[2:].tolist() == pytest.approx([1 / 6, 1 / 6])
+    assert enriched["is_stay"].tolist() == [False, False, True, True]
+    assert cells == [{"grid_column": 1, "grid_row": 0, "stay_cell_visit_count": 1}]
 
 
 class StubResponse:

--- a/apps/nozomi/uv.lock
+++ b/apps/nozomi/uv.lock
@@ -535,6 +535,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },
+    { name = "pandas" },
     { name = "pydantic" },
     { name = "rikka" },
     { name = "scalar-fastapi" },
@@ -551,8 +552,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.1" },
+    { name = "pandas", specifier = ">=3.0.1" },
     { name = "pydantic", specifier = ">=2.12.5" },
-    { name = "rikka", git = "https://github.com/kajiLabTeam/rikka.git" },
+    { name = "rikka", git = "https://github.com/kajiLabTeam/rikka.git?rev=ebbf7978f8c12829bb891c149cbf1985ab846529" },
     { name = "scalar-fastapi", specifier = ">=1.4.1" },
     { name = "sentry-sdk", specifier = ">=2.54.0" },
 ]
@@ -926,7 +928,7 @@ wheels = [
 [[package]]
 name = "rikka"
 version = "0.1.0"
-source = { git = "https://github.com/kajiLabTeam/rikka.git#233e3e4d38cd05661489f8447a7021ce918d7621" }
+source = { git = "https://github.com/kajiLabTeam/rikka.git?rev=ebbf7978f8c12829bb891c149cbf1985ab846529#ebbf7978f8c12829bb891c149cbf1985ab846529" }
 dependencies = [
     { name = "click" },
     { name = "matplotlib" },


### PR DESCRIPTION
関連Issue: https://github.com/kajiLabTeam/okarin/issues/200

関連Rikka PR: https://github.com/kajiLabTeam/rikka/pull/21

## 概要

Nozomiが利用するRikkaを、滞在分析実装を含むcommit SHAへ固定します。

## 作業内容

- Rikka依存を`ebbf7978f8c12829bb891c149cbf1985ab846529`へ固定
- Nozomiが直接importするpandasを直接依存として追加
- `uv.lock`を固定SHAへ更新
- 実際の`RikkaStayHeatmapAnalyzer`で速度・滞在判定・cell集計を確認する統合テストを追加

Rikka PR #21はユーザー方針によりmainへマージせず、draftのまま保持しています。固定SHAはremoteの`200/feature-stay-analysis`ブランチから取得できます。

## 検証内容

- `uv lock --check`: 成功
- `uv sync --frozen`: remote feature SHAから取得・build・install成功
- Ruff format／check: 成功
- mypy: 成功
- pytest: 34件成功
- pre-commit: 成功
- `git diff --check`: 成功
