### PR TITLE
分析callbackの認証除外漏れを修正

### DIFF
--- a/apps/kaede/src/server.test.ts
+++ b/apps/kaede/src/server.test.ts
@@ -130,4 +130,21 @@ describe('createApp auth wiring', { timeout: 60_000 }, () => {
       error_code: 'CALLBACK_PAYLOAD_INVALID',
     })
   })
+
+  it('/api/analysis-runs/callback は session なしでも callback route まで到達する', async () => {
+    const app = await createTestApp()
+
+    const response = await app.request('/api/analysis-runs/callback', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({}),
+    })
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.not.toMatchObject({
+      error_code: 'AUTH_UNAUTHENTICATED',
+    })
+  })
 })

--- a/apps/kaede/src/server.ts
+++ b/apps/kaede/src/server.ts
@@ -50,7 +50,7 @@ export const createApp = () => {
   app.use(
     '/api/*',
     requestActorMiddleware({
-      exemptPaths: ['/api/auth', '/api/trajectories/callback'],
+      exemptPaths: ['/api/auth', '/api/analysis-runs/callback', '/api/trajectories/callback'],
       sharedToken: runtimeConfig.app.apiSharedToken,
     })
   )


### PR DESCRIPTION
関連Issue: https://github.com/kajiLabTeam/okarin/issues/200

## 概要

Nozomiからのanalysis run callbackがsession認証で拒否され、artifact upload後もrunが`processing`のままになる問題を修正します。

## 原因

`requestActorMiddleware`の認証除外対象に`/api/analysis-runs/callback`がなく、callback token検証へ到達する前に`401 AUTH_UNAUTHENTICATED`を返していました。

## 作業内容

- `/api/analysis-runs/callback`をsession／shared token認証の除外対象へ追加
- sessionなしのPOSTが認証401ではなくcallback payload検証の400へ到達するserver-level回帰テストを追加

callback route内では従来どおり署名付きcallback tokenを検証します。

## 検証内容

- server test: 6件成功
- Kaede unit test: 77 files / 430 tests 成功
- ESLint: 成功
- TypeScript型検査: 成功
- pre-commit checks: 成功
- `git diff --check`: 成功
