### PR TITLE
KaedeとNozomiの解析契約テストを追加

### DIFF
--- a/apps/kaede/src/services/nozomi/analyze-client.test.ts
+++ b/apps/kaede/src/services/nozomi/analyze-client.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resetRuntimeConfigForTests } from '../../config/runtime.js'
+import { callbackRequestSchema } from '../../schemas/trajectories.js'
+import { submitAnalyzeRequest } from './analyze-client.js'
+import type { AnalyzeRequestPayload } from './analyze-client.js'
+
+interface TrajectoryAnalysisContract {
+  analyze_request: AnalyzeRequestPayload
+  accepted_response: {
+    trajectory_id: string
+    status: 'accepted'
+  }
+  completed_callback: unknown
+}
+
+const contract = JSON.parse(
+  readFileSync(
+    new URL('../../../../../contracts/kaede-nozomi/trajectory-analysis.json', import.meta.url),
+    'utf8'
+  )
+) as TrajectoryAnalysisContract
+
+describe('Kaede-Nozomi trajectory analysis contract', () => {
+  const originalFetch = globalThis.fetch
+  const originalNozomiInternalEndpoint = process.env.NOZOMI_INTERNAL_ENDPOINT
+  const originalNozomiRequestTimeoutMs = process.env.NOZOMI_REQUEST_TIMEOUT_MS
+
+  beforeEach(() => {
+    process.env.NOZOMI_INTERNAL_ENDPOINT = 'http://nozomi:8000'
+    process.env.NOZOMI_REQUEST_TIMEOUT_MS = '1000'
+    resetRuntimeConfigForTests()
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    vi.restoreAllMocks()
+    if (originalNozomiInternalEndpoint === undefined) {
+      delete process.env.NOZOMI_INTERNAL_ENDPOINT
+    } else {
+      process.env.NOZOMI_INTERNAL_ENDPOINT = originalNozomiInternalEndpoint
+    }
+    if (originalNozomiRequestTimeoutMs === undefined) {
+      delete process.env.NOZOMI_REQUEST_TIMEOUT_MS
+    } else {
+      process.env.NOZOMI_REQUEST_TIMEOUT_MS = originalNozomiRequestTimeoutMs
+    }
+    resetRuntimeConfigForTests()
+  })
+
+  it('organization-aware storage payload is sent without authentication context', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(contract.accepted_response), {
+        status: 202,
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+    globalThis.fetch = fetchMock as typeof fetch
+
+    await expect(submitAnalyzeRequest(contract.analyze_request)).resolves.toEqual(
+      contract.accepted_response
+    )
+
+    const [, request] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(typeof request.body).toBe('string')
+    if (typeof request.body !== 'string') {
+      throw new TypeError('Kaede-Nozomi request body must be JSON text')
+    }
+    expect(JSON.parse(request.body)).toEqual(contract.analyze_request)
+    expect(contract.analyze_request.result_object_key).toMatch(
+      /^organizations\/[0-9a-f-]+\/trajectories\/[0-9a-f-]+\/analyzed\/result\.csv$/
+    )
+    expect(contract.analyze_request).not.toHaveProperty('user_id')
+    expect(contract.analyze_request).not.toHaveProperty('membership_id')
+    expect(contract.analyze_request).not.toHaveProperty('session_id')
+  })
+
+  it('accepts the completed callback emitted by Nozomi', () => {
+    expect(callbackRequestSchema.parse(contract.completed_callback)).toEqual(
+      contract.completed_callback
+    )
+  })
+})

--- a/apps/nozomi/tests/test_kaede_contract.py
+++ b/apps/nozomi/tests/test_kaede_contract.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+from typing import Any, cast
+
+from src.schemas.analysis import AnalyzeRequest
+
+CONTRACT_PATH = (
+    Path(__file__).parents[3]
+    / "contracts"
+    / "kaede-nozomi"
+    / "trajectory-analysis.json"
+)
+
+
+def load_contract() -> dict[str, Any]:
+    return cast(dict[str, Any], json.loads(CONTRACT_PATH.read_text()))
+
+
+def test_kaede_analyze_request_matches_nozomi_schema() -> None:
+    contract = load_contract()
+    payload = contract["analyze_request"]
+
+    request = AnalyzeRequest.model_validate(payload)
+
+    assert request.model_dump(mode="json", exclude_none=True) == payload
+    assert set(payload).isdisjoint({"user_id", "membership_id", "session_id"})
+    assert request.result_object_key.startswith("organizations/")
+
+
+def test_nozomi_completed_callback_preserves_kaede_correlation_values() -> None:
+    contract = load_contract()
+    request = contract["analyze_request"]
+    callback = contract["completed_callback"]
+
+    assert callback == {
+        "trajectory_id": request["trajectory_id"],
+        "status": "completed",
+        "callback_token": request["callback_token"],
+        "result_object_key": request["result_object_key"],
+    }

--- a/contracts/kaede-nozomi/trajectory-analysis.json
+++ b/contracts/kaede-nozomi/trajectory-analysis.json
@@ -1,0 +1,35 @@
+{
+  "analyze_request": {
+    "trajectory_id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+    "recording_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+    "floor_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    "floor_scale": 0.01,
+    "constraints": [
+      {
+        "seq": 0,
+        "point_type": "start",
+        "x": 12.34,
+        "y": 56.78,
+        "direction": 90.0
+      }
+    ],
+    "raw_data_urls": {
+      "acce": "https://storage.example.test/raw/acce.csv?signature=acce",
+      "gyro": "https://storage.example.test/raw/gyro.csv?signature=gyro"
+    },
+    "result_upload_url": "https://storage.example.test/result.csv?signature=result",
+    "result_object_key": "organizations/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/trajectories/dddddddd-dddd-4ddd-8ddd-dddddddddddd/analyzed/result.csv",
+    "callback_url": "https://kaede.example.test/api/trajectories/callback",
+    "callback_token": "signed-callback-token"
+  },
+  "accepted_response": {
+    "trajectory_id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+    "status": "accepted"
+  },
+  "completed_callback": {
+    "trajectory_id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+    "status": "completed",
+    "callback_token": "signed-callback-token",
+    "result_object_key": "organizations/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/trajectories/dddddddd-dddd-4ddd-8ddd-dddddddddddd/analyzed/result.csv"
+  }
+}


### PR DESCRIPTION
## 変更内容

- KaedeとNozomiで共有するtrajectory analysis契約fixtureを追加
- KaedeがfixtureどおりのAnalyze requestを送信できることを検証
- Nozomiが同じrequestを受理し、callback correlation値を維持することを検証
- `user_id`、`membership_id`、`session_id`を解析契約へ含めないことを固定

## 変更理由

#219の認証・Membershipモデル変更をNozomiへ波及させず、KaedeとNozomiの解析境界が従来どおり維持されることをMio着手前に確認できるようにするためです。

## 影響範囲

production codeの変更はありません。Kaede/Nozomiの契約fixtureと回帰testのみです。

## 検証

- Kaede ESLint: PASS
- Kaede TypeScript typecheck: PASS
- Kaede focused Vitest: 2 PASS
- Nozomi Ruff: PASS
- Nozomi Mypy: PASS
- Nozomi focused Pytest: 2 PASS
- Nozomi全体Pytest: 35 PASS / 1 FAIL
  - 既存venvに`rikka.stay_analysis`がない環境依存の既存testのみ失敗
- pre-commit hook: PASS

## 関連Issue

Relates to #219
