### PR TITLE
複数Organization認証のDatabase構造を追加

### DIFF
--- a/apps/kaede/src/services/db/generated.ts
+++ b/apps/kaede/src/services/db/generated.ts
@@ -10,6 +10,8 @@ export type Generated<T> =
     ? ColumnType<S, I | undefined, U>
     : ColumnType<T, T | undefined, T>
 
+export type Int8 = ColumnType<string, bigint | number | string, bigint | number | string>
+
 export type Json = JsonValue
 
 export type JsonArray = JsonValue[]
@@ -22,19 +24,9 @@ export type JsonPrimitive = boolean | number | string | null
 
 export type JsonValue = JsonArray | JsonObject | JsonPrimitive
 
-export type Timestamp = ColumnType<Date, Date | string, Date | string>
+export type Numeric = ColumnType<string, number | string, number | string>
 
-export interface AuthIdentities {
-  created_at: Generated<Timestamp>
-  email: string
-  email_verified: Generated<boolean>
-  hosted_domain: string | null
-  id: Generated<string>
-  provider: string
-  provider_subject: string
-  updated_at: Generated<Timestamp>
-  user_id: string
-}
+export type Timestamp = ColumnType<Date, Date | string, Date | string>
 
 export interface AnalysisRuns {
   analysis_type: string
@@ -58,6 +50,50 @@ export interface AnalysisRunTrajectories {
   trajectory_id: string
 }
 
+export interface AuditEvents {
+  action: string
+  actor_membership_id: string | null
+  actor_user_id: string | null
+  after_values: Json | null
+  before_values: Json | null
+  changed_fields: string[]
+  id: Generated<string>
+  occurred_at: Generated<Timestamp>
+  organization_id: string | null
+  request_id: string | null
+  target_id: string
+  target_type: string
+}
+
+export interface AuthenticationEvents {
+  auth_method: string | null
+  credential_reference_id: string | null
+  event_type: string
+  failure_code: string | null
+  id: Generated<string>
+  ip_address_hash: string | null
+  membership_id: string | null
+  occurred_at: Generated<Timestamp>
+  organization_id: string | null
+  outcome: string
+  request_id: string | null
+  session_id: string | null
+  user_agent: string | null
+  user_id: string | null
+}
+
+export interface AuthIdentities {
+  created_at: Generated<Timestamp>
+  email: string
+  email_verified: Generated<boolean>
+  hosted_domain: string | null
+  id: Generated<string>
+  provider: string
+  provider_subject: string
+  updated_at: Generated<Timestamp>
+  user_id: string
+}
+
 export interface Buildings {
   created_at: Generated<Timestamp>
   id: Generated<string>
@@ -79,6 +115,44 @@ export interface Floors {
   name: string
   organization_id: string
   scale: number | null
+  updated_at: Generated<Timestamp>
+}
+
+export interface OidcIdentities {
+  created_at: Generated<Timestamp>
+  id: Generated<string>
+  issuer: string
+  last_claimed_email: string | null
+  last_claimed_email_verified: boolean | null
+  subject: string
+  updated_at: Generated<Timestamp>
+  user_id: string
+}
+
+export interface OidcLoginTransactions {
+  consumed_at: Timestamp | null
+  created_at: Generated<Timestamp>
+  expires_at: Timestamp
+  id: Generated<string>
+  intent: string
+  invite_id: string | null
+  nonce: string
+  organization_id: string
+  organization_oidc_provider_id: string
+  pkce_code_verifier_ciphertext: string
+  return_to: string
+  session_id: string | null
+  state_hash: string
+}
+
+export interface OrganizationAuthSettings {
+  created_at: Generated<Timestamp>
+  local_auth_enabled: boolean
+  membership_grant_ttl_seconds: number
+  oidc_auth_enabled: boolean
+  organization_id: string
+  policy_version: Generated<Int8>
+  reauthentication_interval_seconds: number
   updated_at: Generated<Timestamp>
 }
 
@@ -107,12 +181,15 @@ export interface OrganizationInviteRedemptions {
 
 export interface OrganizationInvites {
   created_at: Generated<Timestamp>
+  created_by_membership_id: string | null
   created_by_user_id: string
   email: string
   expires_at: Timestamp
   id: Generated<string>
   max_uses: Generated<number>
   organization_id: string
+  redeemed_at: Timestamp | null
+  redeemed_membership_id: string | null
   revoked_at: Timestamp | null
   role: Generated<string>
   token_hash: string
@@ -120,12 +197,66 @@ export interface OrganizationInvites {
   used_count: Generated<number>
 }
 
-export interface OrganizationMemberships {
+export interface OrganizationLocalCredentials {
   created_at: Generated<Timestamp>
+  enabled: Generated<boolean>
+  failed_login_attempts: Generated<number>
+  id: Generated<string>
+  locked_until: Timestamp | null
+  login_email: string
+  membership_id: string
+  normalized_login_email: string
   organization_id: string
-  role: string
+  password_changed_at: Generated<Timestamp>
+  password_hash: string
+  updated_at: Generated<Timestamp>
+}
+
+export interface OrganizationMemberOidcIdentities {
+  created_at: Generated<Timestamp>
+  id: Generated<string>
+  membership_id: string
+  oidc_identity_id: string
+  organization_id: string
+  organization_oidc_provider_id: string
+  revoked_at: Timestamp | null
   updated_at: Generated<Timestamp>
   user_id: string
+}
+
+export interface OrganizationMemberProfiles {
+  created_at: Generated<Timestamp>
+  display_name: string | null
+  height_meters: Numeric | null
+  membership_id: string
+  stride_length_meters: Numeric | null
+  updated_at: Generated<Timestamp>
+}
+
+export interface OrganizationMemberships {
+  created_at: Generated<Timestamp>
+  id: Generated<string | null>
+  joined_at: Generated<Timestamp | null>
+  left_at: Timestamp | null
+  organization_id: string
+  role: string
+  status: Generated<string | null>
+  updated_at: Generated<Timestamp>
+  user_id: string
+}
+
+export interface OrganizationOidcProviders {
+  allowed_hosted_domains: string[] | null
+  client_id: string
+  client_secret_ref: string | null
+  created_at: Generated<Timestamp>
+  enabled: Generated<boolean>
+  id: Generated<string>
+  issuer: string
+  name: string
+  organization_id: string
+  scopes: string[]
+  updated_at: Generated<Timestamp>
 }
 
 export interface Organizations {
@@ -133,6 +264,7 @@ export interface Organizations {
   id: Generated<string>
   name: string
   slug: Generated<string>
+  status: Generated<string | null>
   updated_at: Generated<Timestamp>
 }
 
@@ -142,6 +274,7 @@ export interface Pedestrians {
   display_name: string
   height: number | null
   id: Generated<string>
+  membership_id: string | null
   organization_id: string
   stride_length: number | null
   updated_at: Generated<Timestamp>
@@ -159,6 +292,21 @@ export interface Recordings {
   updated_at: Generated<Timestamp>
   upload_status: Generated<string>
   upload_targets: string[]
+}
+
+export interface SessionMembershipAuthentications {
+  auth_method: string
+  authenticated_at: Timestamp
+  created_at: Generated<Timestamp>
+  expires_at: Timestamp
+  local_credential_id: string | null
+  member_oidc_identity_id: string | null
+  membership_id: string
+  policy_version: Int8
+  revoked_at: Timestamp | null
+  session_id: string
+  updated_at: Generated<Timestamp>
+  user_id: string
 }
 
 export interface Sessions {
@@ -199,7 +347,18 @@ export interface UserActivationTokens {
   user_id: string
 }
 
+export interface UserProfiles {
+  created_at: Generated<Timestamp>
+  display_name: string
+  locale: Generated<string>
+  timezone: Generated<string>
+  updated_at: Generated<Timestamp>
+  user_id: string
+}
+
 export interface Users {
+  contact_email: string | null
+  contact_email_verified_at: Timestamp | null
   created_at: Generated<Timestamp>
   display_name: string
   email: string
@@ -207,6 +366,7 @@ export interface Users {
   global_role: Generated<string>
   id: Generated<string>
   locked_until: Timestamp | null
+  normalized_contact_email: string | null
   password_changed_at: Timestamp | null
   password_hash: string | null
   status: string
@@ -216,18 +376,29 @@ export interface Users {
 export interface DB {
   analysis_run_trajectories: AnalysisRunTrajectories
   analysis_runs: AnalysisRuns
+  audit_events: AuditEvents
   auth_identities: AuthIdentities
+  authentication_events: AuthenticationEvents
   buildings: Buildings
   floors: Floors
+  oidc_identities: OidcIdentities
+  oidc_login_transactions: OidcLoginTransactions
+  organization_auth_settings: OrganizationAuthSettings
   organization_creation_requests: OrganizationCreationRequests
   organization_invite_redemptions: OrganizationInviteRedemptions
   organization_invites: OrganizationInvites
+  organization_local_credentials: OrganizationLocalCredentials
+  organization_member_oidc_identities: OrganizationMemberOidcIdentities
+  organization_member_profiles: OrganizationMemberProfiles
   organization_memberships: OrganizationMemberships
+  organization_oidc_providers: OrganizationOidcProviders
   organizations: Organizations
   pedestrians: Pedestrians
   recordings: Recordings
+  session_membership_authentications: SessionMembershipAuthentications
   sessions: Sessions
   trajectories: Trajectories
   user_activation_tokens: UserActivationTokens
+  user_profiles: UserProfiles
   users: Users
 }

--- a/apps/kaede/tests/db/helpers.ts
+++ b/apps/kaede/tests/db/helpers.ts
@@ -5,6 +5,17 @@ import type { DB } from '../../src/services/db/generated.js'
 export const resetDatabase = async (db: Kysely<DB>) => {
   await sql`
     TRUNCATE TABLE
+      audit_events,
+      authentication_events,
+      oidc_login_transactions,
+      session_membership_authentications,
+      organization_member_oidc_identities,
+      oidc_identities,
+      organization_local_credentials,
+      organization_oidc_providers,
+      organization_auth_settings,
+      organization_member_profiles,
+      user_profiles,
       sessions,
       organization_invite_redemptions,
       organization_invites,

--- a/apps/kaede/tests/services/db/multi-organization-auth-expand-migration.test.ts
+++ b/apps/kaede/tests/services/db/multi-organization-auth-expand-migration.test.ts
@@ -1,0 +1,193 @@
+import { sql } from 'kysely'
+import { afterAll, describe, expect, it } from 'vitest'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createDb } from '../../../src/services/db/client.js'
+
+const db = createDb()
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const loadExpandUpSql = async () => {
+  const migrationPath = path.resolve(
+    __dirname,
+    '../../../../../db/migrations/20260811010000_add_multi_org_membership_columns.sql'
+  )
+  const migration = await readFile(migrationPath, 'utf8')
+  const upSql = migration.split('-- migrate:down')[0]?.replace('-- migrate:up', '').trim()
+
+  if (!upSql) {
+    throw new Error('multi-organization expand migration up SQL was not found')
+  }
+
+  return upSql
+}
+
+const loadInviteExpandDownSql = async () => {
+  const migrationPath = path.resolve(
+    __dirname,
+    '../../../../../db/migrations/20260811010500_expand_organization_invites.sql'
+  )
+  const migration = await readFile(migrationPath, 'utf8')
+  const downSql = migration.split('-- migrate:down')[1]?.trim()
+
+  if (!downSql) {
+    throw new Error('organization invite expand migration down SQL was not found')
+  }
+
+  return downSql
+}
+
+describe('multi-organization auth expand migration', () => {
+  afterAll(async () => {
+    await db.destroy()
+  })
+
+  it('既存Membershipをbackfillせず、新規insertにだけdefaultを適用する', async () => {
+    const upSql = await loadExpandUpSql()
+
+    await db
+      .transaction()
+      .execute(async (trx) => {
+        await sql.raw('CREATE SCHEMA multi_org_expand_compat').execute(trx)
+        await sql.raw('SET LOCAL search_path TO multi_org_expand_compat, public').execute(trx)
+        await sql
+          .raw(
+            `
+          CREATE TABLE users (
+            id uuid PRIMARY KEY,
+            email text NOT NULL,
+            display_name text NOT NULL
+          );
+          CREATE TABLE organizations (
+            id uuid PRIMARY KEY,
+            name text NOT NULL
+          );
+          CREATE TABLE organization_memberships (
+            organization_id uuid NOT NULL,
+            user_id uuid NOT NULL,
+            role text NOT NULL,
+            PRIMARY KEY (organization_id, user_id)
+          );
+          CREATE TABLE sessions (
+            id uuid PRIMARY KEY,
+            user_id uuid NOT NULL,
+            session_hash text NOT NULL,
+            expires_at timestamptz NOT NULL,
+            revoked_at timestamptz
+          );
+          INSERT INTO users (id, email, display_name)
+          VALUES
+            ('20000000-0000-0000-0000-000000000001', 'existing@example.com', 'Existing'),
+            ('20000000-0000-0000-0000-000000000002', 'new@example.com', 'New');
+          INSERT INTO organizations (id, name)
+          VALUES ('10000000-0000-0000-0000-000000000001', 'Existing Organization');
+          INSERT INTO organization_memberships (organization_id, user_id, role)
+          VALUES (
+            '10000000-0000-0000-0000-000000000001',
+            '20000000-0000-0000-0000-000000000001',
+            'member'
+          );
+        `
+          )
+          .execute(trx)
+
+        await sql.raw(upSql).execute(trx)
+
+        await sql
+          .raw(
+            `
+          INSERT INTO organization_memberships (organization_id, user_id, role)
+          VALUES (
+            '10000000-0000-0000-0000-000000000001',
+            '20000000-0000-0000-0000-000000000002',
+            'member'
+          );
+        `
+          )
+          .execute(trx)
+
+        const rows = await sql<{
+          user_id: string
+          id_is_null: boolean
+          status: string | null
+          joined_at_is_null: boolean
+        }>`
+          SELECT
+            user_id,
+            id IS NULL AS id_is_null,
+            status,
+            joined_at IS NULL AS joined_at_is_null
+          FROM organization_memberships
+          ORDER BY user_id
+        `.execute(trx)
+
+        expect(rows.rows).toEqual([
+          {
+            user_id: '20000000-0000-0000-0000-000000000001',
+            id_is_null: true,
+            status: null,
+            joined_at_is_null: true,
+          },
+          {
+            user_id: '20000000-0000-0000-0000-000000000002',
+            id_is_null: false,
+            status: 'active',
+            joined_at_is_null: false,
+          },
+        ])
+
+        throw new Error('rollback multi-organization expand compatibility test')
+      })
+      .catch((error: unknown) => {
+        if (
+          !(error instanceof Error) ||
+          error.message !== 'rollback multi-organization expand compatibility test'
+        ) {
+          throw error
+        }
+      })
+  })
+
+  it('manager Inviteが存在する場合はrole制約をmemberへ戻さず安全に停止する', async () => {
+    const downSql = await loadInviteExpandDownSql()
+
+    await expect(
+      db.transaction().execute(async (trx) => {
+        const user = await trx
+          .insertInto('users')
+          .values({
+            email: 'invite-down@example.com',
+            display_name: 'Invite Down',
+            password_hash: 'hash',
+            global_role: 'none',
+            status: 'active',
+          })
+          .returning('id')
+          .executeTakeFirstOrThrow()
+        const organization = await trx
+          .insertInto('organizations')
+          .values({ name: 'Invite Down Organization' })
+          .returning('id')
+          .executeTakeFirstOrThrow()
+
+        await trx
+          .insertInto('organization_invites')
+          .values({
+            organization_id: organization.id,
+            token_hash: 'invite-down-manager-token',
+            email: 'invitee@example.com',
+            role: 'manager',
+            expires_at: new Date('2026-08-18T00:00:00.000Z'),
+            created_by_user_id: user.id,
+          })
+          .execute()
+
+        await sql.raw(downSql).execute(trx)
+      })
+    ).rejects.toThrow(
+      'cannot rollback organization invite role expansion while non-member invites exist'
+    )
+  })
+})

--- a/apps/kaede/tests/services/db/multi-organization-auth-schema.test.ts
+++ b/apps/kaede/tests/services/db/multi-organization-auth-schema.test.ts
@@ -1,0 +1,565 @@
+import { sql } from 'kysely'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { createDb } from '../../../src/services/db/client.js'
+import { resetDatabase } from '../../db/helpers.js'
+
+const db = createDb()
+const passwordHash =
+  '$argon2id$v=19$m=65536,t=3,p=4$ZHVtbXk$zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'
+
+const createUser = async (suffix: string) =>
+  db
+    .insertInto('users')
+    .values({
+      email: `${suffix}@example.com`,
+      contact_email: 'shared-contact@example.com',
+      normalized_contact_email: 'shared-contact@example.com',
+      display_name: suffix,
+      password_hash: passwordHash,
+      global_role: 'none',
+      status: 'active',
+      password_changed_at: new Date('2026-08-11T00:00:00.000Z'),
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+const createOrganization = async (suffix: string) =>
+  db
+    .insertInto('organizations')
+    .values({ name: `Organization ${suffix}` })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+const createMembership = async (
+  organizationId: string,
+  userId: string,
+  role: 'member' | 'manager' | 'owner' = 'member'
+) => {
+  const membership = await db
+    .insertInto('organization_memberships')
+    .values({ organization_id: organizationId, user_id: userId, role })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+  if (!membership.id) {
+    throw new Error('new membership must receive an id from the expand-schema default')
+  }
+
+  return { ...membership, id: membership.id }
+}
+
+describe('multi-organization auth expand schema', () => {
+  beforeEach(async () => {
+    await resetDatabase(db)
+  })
+
+  afterAll(async () => {
+    await db.destroy()
+  })
+
+  it('既存Kaedeと同じinsert payloadを維持し、新規Membershipだけにdefaultを設定する', async () => {
+    const user = await db
+      .insertInto('users')
+      .values({
+        email: 'legacy@example.com',
+        display_name: 'Legacy User',
+        password_hash: passwordHash,
+        global_role: 'none',
+        status: 'active',
+        password_changed_at: new Date('2026-08-11T00:00:00.000Z'),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const organization = await db
+      .insertInto('organizations')
+      .values({ name: 'Legacy Organization' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const membership = await db
+      .insertInto('organization_memberships')
+      .values({ organization_id: organization.id, user_id: user.id, role: 'member' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    await expect(
+      db
+        .insertInto('sessions')
+        .values({
+          user_id: user.id,
+          session_hash: 'legacy-session',
+          expires_at: new Date('2026-08-12T00:00:00.000Z'),
+          auth_method: 'password',
+        })
+        .execute()
+    ).resolves.toBeDefined()
+
+    await expect(
+      db
+        .insertInto('organization_invites')
+        .values({
+          organization_id: organization.id,
+          token_hash: 'legacy-invite-token',
+          email: 'legacy-invitee@example.com',
+          role: 'member',
+          max_uses: 1,
+          used_count: 0,
+          expires_at: new Date('2026-08-18T00:00:00.000Z'),
+          created_by_user_id: user.id,
+        })
+        .execute()
+    ).resolves.toBeDefined()
+
+    expect(user.contact_email).toBeNull()
+    expect(organization.status).toBe('active')
+    expect(membership.id).not.toBeNull()
+    expect(membership.status).toBe('active')
+    expect(membership.joined_at).toBeInstanceOf(Date)
+    expect(membership.left_at).toBeNull()
+  })
+
+  it('contact email はUser間およびLocal login emailと重複できる', async () => {
+    const organization = await createOrganization('contact-email')
+    const firstUser = await createUser('contact-first')
+    const secondUser = await createUser('contact-second')
+    const membership = await createMembership(organization.id, firstUser.id)
+
+    await expect(
+      db
+        .insertInto('organization_local_credentials')
+        .values({
+          membership_id: membership.id,
+          organization_id: organization.id,
+          login_email: 'shared-contact@example.com',
+          normalized_login_email: 'shared-contact@example.com',
+          password_hash: passwordHash,
+        })
+        .execute()
+    ).resolves.toBeDefined()
+
+    expect(firstUser.contact_email).toBe(secondUser.contact_email)
+  })
+
+  it('Local CredentialはMembershipのOrganizationと一致し、有効emailはOrganization内で一意になる', async () => {
+    const firstOrganization = await createOrganization('local-first')
+    const secondOrganization = await createOrganization('local-second')
+    const firstUser = await createUser('local-first')
+    const secondUser = await createUser('local-second')
+    const firstMembership = await createMembership(firstOrganization.id, firstUser.id)
+    const secondMembership = await createMembership(firstOrganization.id, secondUser.id)
+
+    await expect(
+      db
+        .insertInto('organization_local_credentials')
+        .values({
+          membership_id: firstMembership.id,
+          organization_id: secondOrganization.id,
+          login_email: 'local@example.com',
+          normalized_login_email: 'local@example.com',
+          password_hash: passwordHash,
+        })
+        .execute()
+    ).rejects.toMatchObject({ code: '23503' })
+
+    await db
+      .insertInto('organization_local_credentials')
+      .values({
+        membership_id: firstMembership.id,
+        organization_id: firstOrganization.id,
+        login_email: 'local@example.com',
+        normalized_login_email: 'local@example.com',
+        password_hash: passwordHash,
+      })
+      .execute()
+
+    await expect(
+      db
+        .insertInto('organization_local_credentials')
+        .values({
+          membership_id: secondMembership.id,
+          organization_id: firstOrganization.id,
+          login_email: 'LOCAL@example.com',
+          normalized_login_email: 'local@example.com',
+          password_hash: passwordHash,
+        })
+        .execute()
+    ).rejects.toMatchObject({ code: '23505' })
+  })
+
+  it('OIDC LinkはMembership・IdentityのUserとProviderのOrganizationを一致させる', async () => {
+    const firstOrganization = await createOrganization('oidc-first')
+    const secondOrganization = await createOrganization('oidc-second')
+    const firstUser = await createUser('oidc-first')
+    const secondUser = await createUser('oidc-second')
+    const membership = await createMembership(firstOrganization.id, firstUser.id)
+    const firstIdentity = await db
+      .insertInto('oidc_identities')
+      .values({
+        user_id: firstUser.id,
+        issuer: 'https://accounts.google.com',
+        subject: 'subject-first-user',
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const secondIdentity = await db
+      .insertInto('oidc_identities')
+      .values({
+        user_id: secondUser.id,
+        issuer: 'https://accounts.google.com',
+        subject: 'subject-second-user',
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const firstProvider = await db
+      .insertInto('organization_oidc_providers')
+      .values({
+        organization_id: firstOrganization.id,
+        name: 'Google First',
+        issuer: 'https://accounts.google.com',
+        client_id: 'first-client-id',
+        scopes: ['openid'],
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const secondProvider = await db
+      .insertInto('organization_oidc_providers')
+      .values({
+        organization_id: secondOrganization.id,
+        name: 'Google Second',
+        issuer: 'https://accounts.google.com',
+        client_id: 'second-client-id',
+        scopes: ['openid'],
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    await expect(
+      db
+        .insertInto('organization_member_oidc_identities')
+        .values({
+          membership_id: membership.id,
+          organization_id: firstOrganization.id,
+          user_id: firstUser.id,
+          organization_oidc_provider_id: secondProvider.id,
+          oidc_identity_id: firstIdentity.id,
+        })
+        .execute()
+    ).rejects.toMatchObject({ code: '23503' })
+
+    await expect(
+      db
+        .insertInto('organization_member_oidc_identities')
+        .values({
+          membership_id: membership.id,
+          organization_id: firstOrganization.id,
+          user_id: firstUser.id,
+          organization_oidc_provider_id: firstProvider.id,
+          oidc_identity_id: secondIdentity.id,
+        })
+        .execute()
+    ).rejects.toMatchObject({ code: '23503' })
+
+    await expect(
+      db
+        .insertInto('organization_member_oidc_identities')
+        .values({
+          membership_id: membership.id,
+          organization_id: firstOrganization.id,
+          user_id: firstUser.id,
+          organization_oidc_provider_id: firstProvider.id,
+          oidc_identity_id: firstIdentity.id,
+        })
+        .execute()
+    ).resolves.toBeDefined()
+  })
+
+  it('Session GrantはSession・MembershipのUser一致と認証元の排他を保証する', async () => {
+    const organization = await createOrganization('grant')
+    const firstUser = await createUser('grant-first')
+    const secondUser = await createUser('grant-second')
+    const membership = await createMembership(organization.id, firstUser.id)
+    const credential = await db
+      .insertInto('organization_local_credentials')
+      .values({
+        membership_id: membership.id,
+        organization_id: organization.id,
+        login_email: 'grant@example.com',
+        normalized_login_email: 'grant@example.com',
+        password_hash: passwordHash,
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const secondUserSession = await db
+      .insertInto('sessions')
+      .values({
+        user_id: secondUser.id,
+        session_hash: 'second-user-session',
+        expires_at: new Date('2026-08-13T00:00:00.000Z'),
+        auth_method: 'password',
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    await expect(
+      db
+        .insertInto('session_membership_authentications')
+        .values({
+          session_id: secondUserSession.id,
+          membership_id: membership.id,
+          user_id: firstUser.id,
+          auth_method: 'local',
+          policy_version: 1,
+          local_credential_id: credential.id,
+          authenticated_at: new Date('2026-08-11T00:00:00.000Z'),
+          expires_at: new Date('2026-08-12T00:00:00.000Z'),
+        })
+        .execute()
+    ).rejects.toMatchObject({ code: '23503' })
+
+    const firstUserSession = await db
+      .insertInto('sessions')
+      .values({
+        user_id: firstUser.id,
+        session_hash: 'first-user-session',
+        expires_at: new Date('2026-08-13T00:00:00.000Z'),
+        auth_method: 'password',
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    await expect(
+      db
+        .insertInto('session_membership_authentications')
+        .values({
+          session_id: firstUserSession.id,
+          membership_id: membership.id,
+          user_id: firstUser.id,
+          auth_method: 'local',
+          policy_version: 1,
+          local_credential_id: null,
+          authenticated_at: new Date('2026-08-11T00:00:00.000Z'),
+          expires_at: new Date('2026-08-12T00:00:00.000Z'),
+        })
+        .execute()
+    ).rejects.toMatchObject({ code: '23514' })
+  })
+
+  it('Session Grantは別MembershipのLocal/OIDC認証元を参照できない', async () => {
+    const firstOrganization = await createOrganization('grant-source-first')
+    const secondOrganization = await createOrganization('grant-source-second')
+    const user = await createUser('grant-source')
+    const firstMembership = await createMembership(firstOrganization.id, user.id)
+    const secondMembership = await createMembership(secondOrganization.id, user.id)
+    const secondCredential = await db
+      .insertInto('organization_local_credentials')
+      .values({
+        membership_id: secondMembership.id,
+        organization_id: secondOrganization.id,
+        login_email: 'second-grant@example.com',
+        normalized_login_email: 'second-grant@example.com',
+        password_hash: passwordHash,
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const identity = await db
+      .insertInto('oidc_identities')
+      .values({
+        user_id: user.id,
+        issuer: 'https://accounts.google.com',
+        subject: 'grant-source-subject',
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const secondProvider = await db
+      .insertInto('organization_oidc_providers')
+      .values({
+        organization_id: secondOrganization.id,
+        name: 'Second Google',
+        issuer: 'https://accounts.google.com',
+        client_id: 'second-grant-client',
+        scopes: ['openid'],
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const secondOidcLink = await db
+      .insertInto('organization_member_oidc_identities')
+      .values({
+        membership_id: secondMembership.id,
+        organization_id: secondOrganization.id,
+        user_id: user.id,
+        organization_oidc_provider_id: secondProvider.id,
+        oidc_identity_id: identity.id,
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const session = await db
+      .insertInto('sessions')
+      .values({
+        user_id: user.id,
+        session_hash: 'grant-source-session',
+        expires_at: new Date('2026-08-13T00:00:00.000Z'),
+        auth_method: 'password',
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const grantBase = {
+      session_id: session.id,
+      membership_id: firstMembership.id,
+      user_id: user.id,
+      policy_version: 1,
+      authenticated_at: new Date('2026-08-11T00:00:00.000Z'),
+      expires_at: new Date('2026-08-12T00:00:00.000Z'),
+    }
+
+    await expect(
+      db
+        .insertInto('session_membership_authentications')
+        .values({
+          ...grantBase,
+          auth_method: 'local',
+          local_credential_id: secondCredential.id,
+        })
+        .execute()
+    ).rejects.toMatchObject({ code: '23503' })
+
+    await expect(
+      db
+        .insertInto('session_membership_authentications')
+        .values({
+          ...grantBase,
+          auth_method: 'oidc',
+          member_oidc_identity_id: secondOidcLink.id,
+        })
+        .execute()
+    ).rejects.toMatchObject({ code: '23503' })
+  })
+
+  it('Membership退出日時と認証Policyの期間をCHECKで保証する', async () => {
+    const organization = await createOrganization('checks')
+    const user = await createUser('checks')
+
+    await expect(
+      db
+        .insertInto('organization_memberships')
+        .values({
+          organization_id: organization.id,
+          user_id: user.id,
+          role: 'member',
+          status: 'left',
+          left_at: null,
+        })
+        .execute()
+    ).rejects.toMatchObject({ code: '23514' })
+
+    await expect(
+      db
+        .insertInto('organization_auth_settings')
+        .values({
+          organization_id: organization.id,
+          local_auth_enabled: true,
+          oidc_auth_enabled: false,
+          policy_version: 1,
+          membership_grant_ttl_seconds: 300,
+          reauthentication_interval_seconds: 301,
+        })
+        .execute()
+    ).rejects.toMatchObject({ code: '23514' })
+
+    await expect(
+      db
+        .insertInto('organization_auth_settings')
+        .values({
+          organization_id: organization.id,
+          local_auth_enabled: false,
+          oidc_auth_enabled: false,
+          policy_version: 1,
+          membership_grant_ttl_seconds: 300,
+          reauthentication_interval_seconds: 300,
+        })
+        .execute()
+    ).rejects.toMatchObject({ code: '23514' })
+  })
+
+  it('OIDC ProviderはNULLを含むscope配列をopenidありとして誤認しない', async () => {
+    const organization = await createOrganization('provider-scope')
+
+    await expect(
+      db
+        .insertInto('organization_oidc_providers')
+        .values({
+          organization_id: organization.id,
+          name: 'Invalid Scopes',
+          issuer: 'https://accounts.google.com',
+          client_id: 'invalid-scopes-client',
+          scopes: [],
+        })
+        .execute()
+    ).rejects.toMatchObject({ code: '23514' })
+
+    await expect(
+      sql`
+        INSERT INTO organization_oidc_providers (
+          organization_id,
+          name,
+          issuer,
+          client_id,
+          scopes
+        ) VALUES (
+          ${organization.id},
+          'Null Scope',
+          'https://accounts.google.com',
+          'null-scope-client',
+          ARRAY[NULL]::text[]
+        )
+      `.execute(db)
+    ).rejects.toMatchObject({ code: '23514' })
+
+    await expect(
+      db
+        .insertInto('organization_oidc_providers')
+        .values({
+          organization_id: organization.id,
+          name: 'Valid Scopes',
+          issuer: 'https://accounts.google.com',
+          client_id: 'valid-scopes-client',
+          scopes: ['email', 'openid'],
+        })
+        .execute()
+    ).resolves.toBeDefined()
+  })
+
+  it('PedestrianとInvite redemptionはMembershipのOrganization境界を越えられない', async () => {
+    const firstOrganization = await createOrganization('tenant-first')
+    const secondOrganization = await createOrganization('tenant-second')
+    const user = await createUser('tenant')
+    const membership = await createMembership(firstOrganization.id, user.id)
+
+    await expect(
+      db
+        .insertInto('pedestrians')
+        .values({
+          display_name: 'Tenant Pedestrian',
+          organization_id: secondOrganization.id,
+          membership_id: membership.id,
+        })
+        .execute()
+    ).rejects.toMatchObject({ code: '23503' })
+
+    await expect(
+      db
+        .insertInto('organization_invites')
+        .values({
+          organization_id: secondOrganization.id,
+          token_hash: 'redeemed-invite-token',
+          email: 'invitee@example.com',
+          role: 'member',
+          max_uses: 1,
+          used_count: 0,
+          expires_at: new Date('2026-08-18T00:00:00.000Z'),
+          created_by_user_id: user.id,
+          redeemed_at: new Date('2026-08-11T00:00:00.000Z'),
+          redeemed_membership_id: membership.id,
+        })
+        .execute()
+    ).rejects.toMatchObject({ code: '23503' })
+  })
+})

--- a/apps/kaede/tests/services/db/oidc-onboarding-schema.test.ts
+++ b/apps/kaede/tests/services/db/oidc-onboarding-schema.test.ts
@@ -122,7 +122,7 @@ describe('OIDC onboarding schema', () => {
     ).rejects.toThrow()
   })
 
-  it('organization invite は member role と usage bounds を制約する', async () => {
+  it('organization invite は member/manager role と usage bounds を制約する', async () => {
     const user = await createUser('invite-creator@example.com')
     const organization = await createOrganization()
 
@@ -134,6 +134,23 @@ describe('OIDC onboarding schema', () => {
           token_hash: 'invite-token-hash',
           email: 'invitee@example.com',
           role: 'manager',
+          max_uses: 1,
+          used_count: 0,
+          expires_at: new Date('2026-06-17T00:00:00.000Z'),
+          revoked_at: null,
+          created_by_user_id: user.id,
+        })
+        .execute()
+    ).resolves.toBeDefined()
+
+    await expect(
+      db
+        .insertInto('organization_invites')
+        .values({
+          organization_id: organization.id,
+          token_hash: 'owner-invite-token-hash',
+          email: 'owner@example.com',
+          role: 'owner',
           max_uses: 1,
           used_count: 0,
           expires_at: new Date('2026-06-17T00:00:00.000Z'),

--- a/db/migrations/20260811010000_add_multi_org_membership_columns.sql
+++ b/db/migrations/20260811010000_add_multi_org_membership_columns.sql
@@ -1,0 +1,60 @@
+-- migrate:up
+
+ALTER TABLE users
+  ADD COLUMN contact_email text,
+  ADD COLUMN normalized_contact_email text,
+  ADD COLUMN contact_email_verified_at timestamptz,
+  ADD CONSTRAINT users_contact_email_state_chk
+    CHECK (
+      contact_email IS NOT NULL
+      OR (
+        normalized_contact_email IS NULL
+        AND contact_email_verified_at IS NULL
+      )
+    ) NOT VALID;
+
+ALTER TABLE organizations
+  ADD COLUMN status text,
+  ADD CONSTRAINT organizations_status_chk
+    CHECK (status IN ('active', 'suspended')) NOT VALID;
+
+ALTER TABLE organizations
+  ALTER COLUMN status SET DEFAULT 'active';
+
+ALTER TABLE organization_memberships
+  ADD COLUMN id uuid,
+  ADD COLUMN status text,
+  ADD COLUMN joined_at timestamptz,
+  ADD COLUMN left_at timestamptz,
+  ADD CONSTRAINT organization_memberships_status_chk
+    CHECK (status IN ('active', 'suspended', 'left')) NOT VALID,
+  ADD CONSTRAINT organization_memberships_left_at_chk
+    CHECK (
+      (status = 'left' AND left_at IS NOT NULL)
+      OR (status <> 'left' AND left_at IS NULL)
+    ) NOT VALID;
+
+ALTER TABLE organization_memberships
+  ALTER COLUMN id SET DEFAULT gen_random_uuid(),
+  ALTER COLUMN status SET DEFAULT 'active',
+  ALTER COLUMN joined_at SET DEFAULT NOW();
+
+-- migrate:down
+
+ALTER TABLE organization_memberships
+  DROP CONSTRAINT IF EXISTS organization_memberships_left_at_chk,
+  DROP CONSTRAINT IF EXISTS organization_memberships_status_chk,
+  DROP COLUMN IF EXISTS left_at,
+  DROP COLUMN IF EXISTS joined_at,
+  DROP COLUMN IF EXISTS status,
+  DROP COLUMN IF EXISTS id;
+
+ALTER TABLE organizations
+  DROP CONSTRAINT IF EXISTS organizations_status_chk,
+  DROP COLUMN IF EXISTS status;
+
+ALTER TABLE users
+  DROP CONSTRAINT IF EXISTS users_contact_email_state_chk,
+  DROP COLUMN IF EXISTS contact_email_verified_at,
+  DROP COLUMN IF EXISTS normalized_contact_email,
+  DROP COLUMN IF EXISTS contact_email;

--- a/db/migrations/20260811010051_add_membership_id_index.sql
+++ b/db/migrations/20260811010051_add_membership_id_index.sql
@@ -1,0 +1,10 @@
+-- migrate:up transaction:false
+
+-- Keep this as a standalone unique index so the Backfill PR can promote it with
+-- ADD PRIMARY KEY USING INDEX without rebuilding it.
+CREATE UNIQUE INDEX CONCURRENTLY organization_memberships_id_key
+  ON organization_memberships (id);
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS organization_memberships_id_key;

--- a/db/migrations/20260811010052_add_membership_id_user_index.sql
+++ b/db/migrations/20260811010052_add_membership_id_user_index.sql
@@ -1,0 +1,8 @@
+-- migrate:up transaction:false
+
+CREATE UNIQUE INDEX CONCURRENTLY organization_memberships_id_user_key
+  ON organization_memberships (id, user_id);
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS organization_memberships_id_user_key;

--- a/db/migrations/20260811010053_add_membership_id_organization_index.sql
+++ b/db/migrations/20260811010053_add_membership_id_organization_index.sql
@@ -1,0 +1,8 @@
+-- migrate:up transaction:false
+
+CREATE UNIQUE INDEX CONCURRENTLY organization_memberships_id_organization_key
+  ON organization_memberships (id, organization_id);
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS organization_memberships_id_organization_key;

--- a/db/migrations/20260811010054_add_membership_user_status_index.sql
+++ b/db/migrations/20260811010054_add_membership_user_status_index.sql
@@ -1,0 +1,8 @@
+-- migrate:up transaction:false
+
+CREATE INDEX CONCURRENTLY organization_memberships_user_status_idx
+  ON organization_memberships (user_id, status);
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS organization_memberships_user_status_idx;

--- a/db/migrations/20260811010055_add_membership_org_status_role_index.sql
+++ b/db/migrations/20260811010055_add_membership_org_status_role_index.sql
@@ -1,0 +1,8 @@
+-- migrate:up transaction:false
+
+CREATE INDEX CONCURRENTLY organization_memberships_org_status_role_idx
+  ON organization_memberships (organization_id, status, role);
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS organization_memberships_org_status_role_idx;

--- a/db/migrations/20260811010056_add_session_id_user_index.sql
+++ b/db/migrations/20260811010056_add_session_id_user_index.sql
@@ -1,0 +1,8 @@
+-- migrate:up transaction:false
+
+CREATE UNIQUE INDEX CONCURRENTLY sessions_id_user_key
+  ON sessions (id, user_id);
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS sessions_id_user_key;

--- a/db/migrations/20260811010057_add_session_active_user_index.sql
+++ b/db/migrations/20260811010057_add_session_active_user_index.sql
@@ -1,0 +1,9 @@
+-- migrate:up transaction:false
+
+CREATE INDEX CONCURRENTLY sessions_active_user_idx
+  ON sessions (user_id)
+  WHERE revoked_at IS NULL;
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS sessions_active_user_idx;

--- a/db/migrations/20260811010058_add_session_active_expiry_index.sql
+++ b/db/migrations/20260811010058_add_session_active_expiry_index.sql
@@ -1,0 +1,9 @@
+-- migrate:up transaction:false
+
+CREATE INDEX CONCURRENTLY sessions_active_expires_at_idx
+  ON sessions (expires_at)
+  WHERE revoked_at IS NULL;
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS sessions_active_expires_at_idx;

--- a/db/migrations/20260811010100_create_profiles_and_auth_policy.sql
+++ b/db/migrations/20260811010100_create_profiles_and_auth_policy.sql
@@ -1,0 +1,88 @@
+-- migrate:up
+
+CREATE TABLE user_profiles (
+  user_id uuid PRIMARY KEY REFERENCES users(id) ON DELETE RESTRICT,
+  display_name text NOT NULL,
+  locale text NOT NULL DEFAULT 'ja-JP',
+  timezone text NOT NULL DEFAULT 'Asia/Tokyo',
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  CONSTRAINT user_profiles_display_name_chk
+    CHECK (length(btrim(display_name)) BETWEEN 1 AND 255),
+  CONSTRAINT user_profiles_locale_nonempty_chk
+    CHECK (length(btrim(locale)) > 0),
+  CONSTRAINT user_profiles_timezone_nonempty_chk
+    CHECK (length(btrim(timezone)) > 0)
+);
+
+CREATE TABLE organization_member_profiles (
+  membership_id uuid PRIMARY KEY
+    REFERENCES organization_memberships(id) ON DELETE RESTRICT,
+  display_name text,
+  height_meters numeric(5, 3),
+  stride_length_meters numeric(5, 3),
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  CONSTRAINT organization_member_profiles_display_name_chk
+    CHECK (
+      display_name IS NULL
+      OR length(btrim(display_name)) BETWEEN 1 AND 255
+    ),
+  CONSTRAINT organization_member_profiles_height_positive_chk
+    CHECK (height_meters IS NULL OR height_meters > 0),
+  CONSTRAINT organization_member_profiles_stride_positive_chk
+    CHECK (stride_length_meters IS NULL OR stride_length_meters > 0)
+);
+
+CREATE TABLE organization_auth_settings (
+  organization_id uuid PRIMARY KEY
+    REFERENCES organizations(id) ON DELETE RESTRICT,
+  local_auth_enabled boolean NOT NULL,
+  oidc_auth_enabled boolean NOT NULL,
+  policy_version bigint NOT NULL DEFAULT 1,
+  membership_grant_ttl_seconds integer NOT NULL,
+  reauthentication_interval_seconds integer NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  CONSTRAINT organization_auth_settings_policy_version_chk
+    CHECK (policy_version >= 1),
+  CONSTRAINT organization_auth_settings_grant_ttl_chk
+    CHECK (membership_grant_ttl_seconds > 0),
+  CONSTRAINT organization_auth_settings_reauth_interval_chk
+    CHECK (reauthentication_interval_seconds > 0),
+  CONSTRAINT organization_auth_settings_reauth_lte_ttl_chk
+    CHECK (
+      reauthentication_interval_seconds <= membership_grant_ttl_seconds
+    ),
+  CONSTRAINT organization_auth_settings_auth_method_chk
+    CHECK (
+      local_auth_enabled OR oidc_auth_enabled
+    )
+);
+
+CREATE TRIGGER set_updated_at_user_profiles
+BEFORE UPDATE ON user_profiles
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_updated_at_organization_member_profiles
+BEFORE UPDATE ON organization_member_profiles
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_updated_at_organization_auth_settings
+BEFORE UPDATE ON organization_auth_settings
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at();
+
+-- migrate:down
+
+DROP TRIGGER IF EXISTS set_updated_at_organization_auth_settings
+  ON organization_auth_settings;
+DROP TRIGGER IF EXISTS set_updated_at_organization_member_profiles
+  ON organization_member_profiles;
+DROP TRIGGER IF EXISTS set_updated_at_user_profiles ON user_profiles;
+
+DROP TABLE IF EXISTS organization_auth_settings;
+DROP TABLE IF EXISTS organization_member_profiles;
+DROP TABLE IF EXISTS user_profiles;

--- a/db/migrations/20260811010200_add_pedestrian_membership.sql
+++ b/db/migrations/20260811010200_add_pedestrian_membership.sql
@@ -1,0 +1,17 @@
+-- migrate:up
+
+ALTER TABLE pedestrians
+  ADD COLUMN membership_id uuid;
+
+ALTER TABLE pedestrians
+  ADD CONSTRAINT pedestrians_membership_organization_fkey
+  FOREIGN KEY (membership_id, organization_id)
+  REFERENCES organization_memberships(id, organization_id)
+  ON DELETE RESTRICT
+  NOT VALID;
+
+-- migrate:down
+
+ALTER TABLE pedestrians
+  DROP CONSTRAINT IF EXISTS pedestrians_membership_organization_fkey,
+  DROP COLUMN IF EXISTS membership_id;

--- a/db/migrations/20260811010250_add_pedestrian_membership_index.sql
+++ b/db/migrations/20260811010250_add_pedestrian_membership_index.sql
@@ -1,0 +1,9 @@
+-- migrate:up transaction:false
+
+CREATE UNIQUE INDEX CONCURRENTLY pedestrians_membership_id_key
+  ON pedestrians (membership_id)
+  WHERE membership_id IS NOT NULL;
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS pedestrians_membership_id_key;

--- a/db/migrations/20260811010300_create_membership_credentials_and_oidc_links.sql
+++ b/db/migrations/20260811010300_create_membership_credentials_and_oidc_links.sql
@@ -1,0 +1,171 @@
+-- migrate:up
+
+CREATE TABLE organization_oidc_providers (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE RESTRICT,
+  name text NOT NULL,
+  issuer text NOT NULL,
+  client_id text NOT NULL,
+  client_secret_ref text,
+  scopes text[] NOT NULL,
+  allowed_hosted_domains text[],
+  enabled boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  CONSTRAINT organization_oidc_providers_name_nonempty_chk
+    CHECK (length(btrim(name)) > 0),
+  CONSTRAINT organization_oidc_providers_issuer_nonempty_chk
+    CHECK (length(btrim(issuer)) > 0),
+  CONSTRAINT organization_oidc_providers_client_id_nonempty_chk
+    CHECK (length(btrim(client_id)) > 0),
+  CONSTRAINT organization_oidc_providers_openid_scope_chk
+    CHECK (COALESCE('openid' = ANY(scopes), false)),
+  CONSTRAINT organization_oidc_providers_hosted_domains_nonempty_chk
+    CHECK (
+      allowed_hosted_domains IS NULL
+      OR cardinality(allowed_hosted_domains) > 0
+    ),
+  CONSTRAINT organization_oidc_providers_org_issuer_client_key
+    UNIQUE (organization_id, issuer, client_id),
+  CONSTRAINT organization_oidc_providers_id_org_key
+    UNIQUE (id, organization_id)
+);
+
+CREATE TABLE organization_local_credentials (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  membership_id uuid NOT NULL,
+  organization_id uuid NOT NULL,
+  login_email text NOT NULL,
+  normalized_login_email text NOT NULL,
+  password_hash text NOT NULL,
+  password_changed_at timestamptz NOT NULL DEFAULT NOW(),
+  failed_login_attempts integer NOT NULL DEFAULT 0,
+  locked_until timestamptz,
+  enabled boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  CONSTRAINT organization_local_credentials_membership_key
+    UNIQUE (membership_id),
+  CONSTRAINT organization_local_credentials_id_membership_key
+    UNIQUE (id, membership_id),
+  CONSTRAINT organization_local_credentials_membership_org_fkey
+    FOREIGN KEY (membership_id, organization_id)
+    REFERENCES organization_memberships(id, organization_id)
+    ON DELETE RESTRICT,
+  CONSTRAINT organization_local_credentials_login_email_nonempty_chk
+    CHECK (length(btrim(login_email)) > 0),
+  CONSTRAINT organization_local_credentials_normalized_email_nonempty_chk
+    CHECK (length(btrim(normalized_login_email)) > 0),
+  CONSTRAINT organization_local_credentials_password_hash_nonempty_chk
+    CHECK (length(btrim(password_hash)) > 0),
+  CONSTRAINT organization_local_credentials_failed_attempts_chk
+    CHECK (failed_login_attempts >= 0)
+);
+
+CREATE UNIQUE INDEX organization_local_credentials_active_email_key
+  ON organization_local_credentials (
+    organization_id,
+    normalized_login_email
+  )
+  WHERE enabled;
+
+CREATE TABLE oidc_identities (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  issuer text NOT NULL,
+  subject text NOT NULL,
+  last_claimed_email text,
+  last_claimed_email_verified boolean,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  CONSTRAINT oidc_identities_issuer_nonempty_chk
+    CHECK (length(btrim(issuer)) > 0),
+  CONSTRAINT oidc_identities_subject_nonempty_chk
+    CHECK (length(btrim(subject)) > 0),
+  CONSTRAINT oidc_identities_issuer_subject_key
+    UNIQUE (issuer, subject),
+  CONSTRAINT oidc_identities_id_user_key
+    UNIQUE (id, user_id)
+);
+
+CREATE TABLE organization_member_oidc_identities (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  membership_id uuid NOT NULL,
+  organization_id uuid NOT NULL,
+  user_id uuid NOT NULL,
+  organization_oidc_provider_id uuid NOT NULL,
+  oidc_identity_id uuid NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  revoked_at timestamptz,
+  CONSTRAINT organization_member_oidc_membership_user_fkey
+    FOREIGN KEY (membership_id, user_id)
+    REFERENCES organization_memberships(id, user_id)
+    ON DELETE RESTRICT,
+  CONSTRAINT organization_member_oidc_identity_user_fkey
+    FOREIGN KEY (oidc_identity_id, user_id)
+    REFERENCES oidc_identities(id, user_id)
+    ON DELETE RESTRICT,
+  CONSTRAINT organization_member_oidc_membership_org_fkey
+    FOREIGN KEY (membership_id, organization_id)
+    REFERENCES organization_memberships(id, organization_id)
+    ON DELETE RESTRICT,
+  CONSTRAINT organization_member_oidc_provider_org_fkey
+    FOREIGN KEY (organization_oidc_provider_id, organization_id)
+    REFERENCES organization_oidc_providers(id, organization_id)
+    ON DELETE RESTRICT,
+  CONSTRAINT organization_member_oidc_id_membership_key
+    UNIQUE (id, membership_id),
+  CONSTRAINT organization_member_oidc_link_key
+    UNIQUE (
+      membership_id,
+      organization_oidc_provider_id,
+      oidc_identity_id
+    )
+);
+
+CREATE UNIQUE INDEX organization_member_oidc_active_provider_identity_key
+  ON organization_member_oidc_identities (
+    organization_oidc_provider_id,
+    oidc_identity_id
+  )
+  WHERE revoked_at IS NULL;
+
+CREATE INDEX organization_member_oidc_active_membership_idx
+  ON organization_member_oidc_identities (membership_id)
+  WHERE revoked_at IS NULL;
+
+CREATE TRIGGER set_updated_at_organization_oidc_providers
+BEFORE UPDATE ON organization_oidc_providers
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_updated_at_organization_local_credentials
+BEFORE UPDATE ON organization_local_credentials
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_updated_at_oidc_identities
+BEFORE UPDATE ON oidc_identities
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_updated_at_organization_member_oidc_identities
+BEFORE UPDATE ON organization_member_oidc_identities
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at();
+
+-- migrate:down
+
+DROP TRIGGER IF EXISTS set_updated_at_organization_member_oidc_identities
+  ON organization_member_oidc_identities;
+DROP TRIGGER IF EXISTS set_updated_at_oidc_identities ON oidc_identities;
+DROP TRIGGER IF EXISTS set_updated_at_organization_local_credentials
+  ON organization_local_credentials;
+DROP TRIGGER IF EXISTS set_updated_at_organization_oidc_providers
+  ON organization_oidc_providers;
+
+DROP TABLE IF EXISTS organization_member_oidc_identities;
+DROP TABLE IF EXISTS oidc_identities;
+DROP TABLE IF EXISTS organization_local_credentials;
+DROP TABLE IF EXISTS organization_oidc_providers;

--- a/db/migrations/20260811010400_create_membership_session_grants.sql
+++ b/db/migrations/20260811010400_create_membership_session_grants.sql
@@ -1,0 +1,182 @@
+-- migrate:up
+
+CREATE TABLE session_membership_authentications (
+  session_id uuid NOT NULL,
+  membership_id uuid NOT NULL,
+  user_id uuid NOT NULL,
+  auth_method text NOT NULL,
+  policy_version bigint NOT NULL,
+  local_credential_id uuid,
+  member_oidc_identity_id uuid,
+  authenticated_at timestamptz NOT NULL,
+  expires_at timestamptz NOT NULL,
+  revoked_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (session_id, membership_id),
+  CONSTRAINT session_membership_auth_session_user_fkey
+    FOREIGN KEY (session_id, user_id)
+    REFERENCES sessions(id, user_id)
+    ON DELETE RESTRICT,
+  CONSTRAINT session_membership_auth_membership_user_fkey
+    FOREIGN KEY (membership_id, user_id)
+    REFERENCES organization_memberships(id, user_id)
+    ON DELETE RESTRICT,
+  CONSTRAINT session_membership_auth_local_source_fkey
+    FOREIGN KEY (local_credential_id, membership_id)
+    REFERENCES organization_local_credentials(id, membership_id)
+    ON DELETE RESTRICT,
+  CONSTRAINT session_membership_auth_oidc_source_fkey
+    FOREIGN KEY (member_oidc_identity_id, membership_id)
+    REFERENCES organization_member_oidc_identities(id, membership_id)
+    ON DELETE RESTRICT,
+  CONSTRAINT session_membership_auth_policy_version_chk
+    CHECK (policy_version >= 1),
+  CONSTRAINT session_membership_auth_expiry_chk
+    CHECK (expires_at > authenticated_at),
+  CONSTRAINT session_membership_auth_source_chk
+    CHECK (
+      (
+        auth_method = 'local'
+        AND local_credential_id IS NOT NULL
+        AND member_oidc_identity_id IS NULL
+      )
+      OR
+      (
+        auth_method = 'oidc'
+        AND local_credential_id IS NULL
+        AND member_oidc_identity_id IS NOT NULL
+      )
+    )
+);
+
+CREATE INDEX session_membership_auth_active_membership_idx
+  ON session_membership_authentications (membership_id)
+  WHERE revoked_at IS NULL;
+
+CREATE INDEX session_membership_auth_active_local_credential_idx
+  ON session_membership_authentications (local_credential_id)
+  WHERE revoked_at IS NULL;
+
+CREATE INDEX session_membership_auth_active_oidc_identity_idx
+  ON session_membership_authentications (member_oidc_identity_id)
+  WHERE revoked_at IS NULL;
+
+CREATE TABLE oidc_login_transactions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  state_hash text NOT NULL UNIQUE,
+  organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE RESTRICT,
+  organization_oidc_provider_id uuid NOT NULL,
+  session_id uuid REFERENCES sessions(id) ON DELETE RESTRICT,
+  invite_id uuid REFERENCES organization_invites(id) ON DELETE RESTRICT,
+  intent text NOT NULL,
+  nonce text NOT NULL,
+  pkce_code_verifier_ciphertext text NOT NULL,
+  return_to text NOT NULL,
+  expires_at timestamptz NOT NULL,
+  consumed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  CONSTRAINT oidc_login_transactions_provider_org_fkey
+    FOREIGN KEY (organization_oidc_provider_id, organization_id)
+    REFERENCES organization_oidc_providers(id, organization_id)
+    ON DELETE RESTRICT,
+  CONSTRAINT oidc_login_transactions_state_hash_nonempty_chk
+    CHECK (length(btrim(state_hash)) > 0),
+  CONSTRAINT oidc_login_transactions_nonce_nonempty_chk
+    CHECK (length(btrim(nonce)) > 0),
+  CONSTRAINT oidc_login_transactions_pkce_nonempty_chk
+    CHECK (length(btrim(pkce_code_verifier_ciphertext)) > 0),
+  CONSTRAINT oidc_login_transactions_return_to_chk
+    CHECK (
+      left(return_to, 1) = '/'
+      AND left(return_to, 2) <> '//'
+      AND position(E'\\' IN return_to) = 0
+    ),
+  CONSTRAINT oidc_login_transactions_intent_chk
+    CHECK (intent IN ('login', 'reauthenticate', 'accept_invite', 'link_identity')),
+  CONSTRAINT oidc_login_transactions_intent_state_chk
+    CHECK (
+      (intent = 'login' AND session_id IS NULL AND invite_id IS NULL)
+      OR (intent = 'reauthenticate' AND session_id IS NOT NULL AND invite_id IS NULL)
+      OR (intent = 'accept_invite' AND invite_id IS NOT NULL)
+      OR (intent = 'link_identity' AND session_id IS NOT NULL AND invite_id IS NULL)
+    )
+);
+
+CREATE INDEX oidc_login_transactions_expires_at_idx
+  ON oidc_login_transactions (expires_at);
+
+CREATE TABLE authentication_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  occurred_at timestamptz NOT NULL DEFAULT NOW(),
+  event_type text NOT NULL,
+  outcome text NOT NULL,
+  failure_code text,
+  user_id uuid,
+  organization_id uuid,
+  membership_id uuid,
+  session_id uuid,
+  auth_method text,
+  credential_reference_id uuid,
+  request_id text,
+  ip_address_hash text,
+  user_agent text,
+  CONSTRAINT authentication_events_event_type_nonempty_chk
+    CHECK (length(btrim(event_type)) > 0),
+  CONSTRAINT authentication_events_outcome_chk
+    CHECK (outcome IN ('success', 'failure')),
+  CONSTRAINT authentication_events_auth_method_chk
+    CHECK (auth_method IS NULL OR auth_method IN ('local', 'oidc'))
+);
+
+CREATE INDEX authentication_events_org_occurred_at_idx
+  ON authentication_events (organization_id, occurred_at DESC);
+
+CREATE INDEX authentication_events_user_occurred_at_idx
+  ON authentication_events (user_id, occurred_at DESC);
+
+CREATE INDEX authentication_events_occurred_at_idx
+  ON authentication_events (occurred_at);
+
+CREATE TABLE audit_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  occurred_at timestamptz NOT NULL DEFAULT NOW(),
+  actor_user_id uuid,
+  actor_membership_id uuid,
+  organization_id uuid,
+  target_type text NOT NULL,
+  target_id uuid NOT NULL,
+  action text NOT NULL,
+  changed_fields text[] NOT NULL,
+  before_values jsonb,
+  after_values jsonb,
+  request_id text,
+  CONSTRAINT audit_events_target_type_nonempty_chk
+    CHECK (length(btrim(target_type)) > 0),
+  CONSTRAINT audit_events_action_nonempty_chk
+    CHECK (length(btrim(action)) > 0)
+);
+
+CREATE INDEX audit_events_org_occurred_at_idx
+  ON audit_events (organization_id, occurred_at DESC);
+
+CREATE INDEX audit_events_target_occurred_at_idx
+  ON audit_events (target_type, target_id, occurred_at DESC);
+
+CREATE INDEX audit_events_occurred_at_idx
+  ON audit_events (occurred_at);
+
+CREATE TRIGGER set_updated_at_session_membership_authentications
+BEFORE UPDATE ON session_membership_authentications
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at();
+
+-- migrate:down
+
+DROP TRIGGER IF EXISTS set_updated_at_session_membership_authentications
+  ON session_membership_authentications;
+
+DROP TABLE IF EXISTS audit_events;
+DROP TABLE IF EXISTS authentication_events;
+DROP TABLE IF EXISTS oidc_login_transactions;
+DROP TABLE IF EXISTS session_membership_authentications;

--- a/db/migrations/20260811010500_expand_organization_invites.sql
+++ b/db/migrations/20260811010500_expand_organization_invites.sql
@@ -1,0 +1,57 @@
+-- migrate:up
+
+ALTER TABLE organization_invites
+  ADD COLUMN created_by_membership_id uuid,
+  ADD COLUMN redeemed_at timestamptz,
+  ADD COLUMN redeemed_membership_id uuid,
+  ADD CONSTRAINT organization_invites_creator_org_fkey
+    FOREIGN KEY (created_by_membership_id, organization_id)
+    REFERENCES organization_memberships(id, organization_id)
+    ON DELETE RESTRICT
+    NOT VALID,
+  ADD CONSTRAINT organization_invites_redeemed_membership_org_fkey
+    FOREIGN KEY (redeemed_membership_id, organization_id)
+    REFERENCES organization_memberships(id, organization_id)
+    ON DELETE RESTRICT
+    NOT VALID,
+  ADD CONSTRAINT organization_invites_redemption_state_chk
+    CHECK (
+      (redeemed_at IS NULL AND redeemed_membership_id IS NULL)
+      OR (redeemed_at IS NOT NULL AND redeemed_membership_id IS NOT NULL)
+    ) NOT VALID,
+  ADD CONSTRAINT organization_invites_revoked_redeemed_chk
+    CHECK (revoked_at IS NULL OR redeemed_at IS NULL) NOT VALID;
+
+ALTER TABLE organization_invites
+  DROP CONSTRAINT organization_invites_role_chk,
+  ADD CONSTRAINT organization_invites_role_chk
+    CHECK (role IN ('member', 'manager')) NOT VALID;
+
+-- migrate:down
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM organization_invites
+    WHERE role <> 'member'
+  ) THEN
+    RAISE EXCEPTION
+      'cannot rollback organization invite role expansion while non-member invites exist';
+  END IF;
+END
+$$;
+
+ALTER TABLE organization_invites
+  DROP CONSTRAINT organization_invites_role_chk,
+  ADD CONSTRAINT organization_invites_role_chk
+    CHECK (role = 'member');
+
+ALTER TABLE organization_invites
+  DROP CONSTRAINT IF EXISTS organization_invites_revoked_redeemed_chk,
+  DROP CONSTRAINT IF EXISTS organization_invites_redemption_state_chk,
+  DROP CONSTRAINT IF EXISTS organization_invites_redeemed_membership_org_fkey,
+  DROP CONSTRAINT IF EXISTS organization_invites_creator_org_fkey,
+  DROP COLUMN IF EXISTS redeemed_membership_id,
+  DROP COLUMN IF EXISTS redeemed_at,
+  DROP COLUMN IF EXISTS created_by_membership_id;

--- a/db/migrations/20260811010551_add_invite_redeemed_membership_index.sql
+++ b/db/migrations/20260811010551_add_invite_redeemed_membership_index.sql
@@ -1,0 +1,8 @@
+-- migrate:up transaction:false
+
+CREATE UNIQUE INDEX CONCURRENTLY organization_invites_redeemed_membership_key
+  ON organization_invites (redeemed_membership_id);
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS organization_invites_redeemed_membership_key;

--- a/db/migrations/20260811010552_add_invite_org_created_index.sql
+++ b/db/migrations/20260811010552_add_invite_org_created_index.sql
@@ -1,0 +1,8 @@
+-- migrate:up transaction:false
+
+CREATE INDEX CONCURRENTLY organization_invites_org_created_at_idx
+  ON organization_invites (organization_id, created_at DESC);
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS organization_invites_org_created_at_idx;

--- a/db/migrations/20260811010553_add_invite_active_expiry_index.sql
+++ b/db/migrations/20260811010553_add_invite_active_expiry_index.sql
@@ -1,0 +1,9 @@
+-- migrate:up transaction:false
+
+CREATE INDEX CONCURRENTLY organization_invites_active_expires_at_idx
+  ON organization_invites (expires_at)
+  WHERE revoked_at IS NULL AND redeemed_at IS NULL;
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS organization_invites_active_expires_at_idx;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,7 +1,7 @@
 \restrict dbmate
 
--- Dumped from database version 17.9
--- Dumped by pg_dump version 18.3
+-- Dumped from database version 17.10
+-- Dumped by pg_dump version 18.4
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -34,6 +34,18 @@ SET default_tablespace = '';
 SET default_table_access_method = heap;
 
 --
+-- Name: analysis_run_trajectories; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.analysis_run_trajectories (
+    analysis_run_id uuid NOT NULL,
+    trajectory_id uuid NOT NULL,
+    seq integer NOT NULL,
+    CONSTRAINT analysis_run_trajectories_seq_check CHECK ((seq >= 0))
+);
+
+
+--
 -- Name: analysis_runs; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -60,14 +72,24 @@ CREATE TABLE public.analysis_runs (
 
 
 --
--- Name: analysis_run_trajectories; Type: TABLE; Schema: public; Owner: -
+-- Name: audit_events; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.analysis_run_trajectories (
-    analysis_run_id uuid NOT NULL,
-    trajectory_id uuid NOT NULL,
-    seq integer NOT NULL,
-    CONSTRAINT analysis_run_trajectories_seq_check CHECK ((seq >= 0))
+CREATE TABLE public.audit_events (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    occurred_at timestamp with time zone DEFAULT now() NOT NULL,
+    actor_user_id uuid,
+    actor_membership_id uuid,
+    organization_id uuid,
+    target_type text NOT NULL,
+    target_id uuid NOT NULL,
+    action text NOT NULL,
+    changed_fields text[] NOT NULL,
+    before_values jsonb,
+    after_values jsonb,
+    request_id text,
+    CONSTRAINT audit_events_action_nonempty_chk CHECK ((length(btrim(action)) > 0)),
+    CONSTRAINT audit_events_target_type_nonempty_chk CHECK ((length(btrim(target_type)) > 0))
 );
 
 
@@ -86,6 +108,31 @@ CREATE TABLE public.auth_identities (
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
     CONSTRAINT auth_identities_provider_chk CHECK ((provider = 'google'::text))
+);
+
+
+--
+-- Name: authentication_events; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.authentication_events (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    occurred_at timestamp with time zone DEFAULT now() NOT NULL,
+    event_type text NOT NULL,
+    outcome text NOT NULL,
+    failure_code text,
+    user_id uuid,
+    organization_id uuid,
+    membership_id uuid,
+    session_id uuid,
+    auth_method text,
+    credential_reference_id uuid,
+    request_id text,
+    ip_address_hash text,
+    user_agent text,
+    CONSTRAINT authentication_events_auth_method_chk CHECK (((auth_method IS NULL) OR (auth_method = ANY (ARRAY['local'::text, 'oidc'::text])))),
+    CONSTRAINT authentication_events_event_type_nonempty_chk CHECK ((length(btrim(event_type)) > 0)),
+    CONSTRAINT authentication_events_outcome_chk CHECK ((outcome = ANY (ARRAY['success'::text, 'failure'::text])))
 );
 
 
@@ -120,9 +167,75 @@ CREATE TABLE public.floors (
     organization_id uuid NOT NULL,
     map_width_px integer,
     map_height_px integer,
+    CONSTRAINT floors_image_object_path_format_chk CHECK (((image_object_path ~ '^maps/[0-9a-fA-F-]+/[0-9a-fA-F-]+\.(svg|png)$'::text) OR (image_object_path ~ '^organizations/[0-9a-fA-F-]+/floors/[0-9a-fA-F-]+/map\.(svg|png)$'::text))),
     CONSTRAINT floors_map_dimensions_bounds_chk CHECK (((map_width_px IS NULL) OR ((map_width_px > 0) AND (map_height_px > 0) AND (map_width_px <= 20000) AND (map_height_px <= 20000) AND (((map_width_px)::bigint * (map_height_px)::bigint) <= 100000000)))),
-    CONSTRAINT floors_map_dimensions_presence_chk CHECK ((((map_width_px IS NULL) AND (map_height_px IS NULL)) OR ((map_width_px IS NOT NULL) AND (map_height_px IS NOT NULL)))),
-    CONSTRAINT floors_image_object_path_format_chk CHECK (((image_object_path ~ '^maps/[0-9a-fA-F-]+/[0-9a-fA-F-]+\.(svg|png)$'::text) OR (image_object_path ~ '^organizations/[0-9a-fA-F-]+/floors/[0-9a-fA-F-]+/map\.(svg|png)$'::text)))
+    CONSTRAINT floors_map_dimensions_presence_chk CHECK ((((map_width_px IS NULL) AND (map_height_px IS NULL)) OR ((map_width_px IS NOT NULL) AND (map_height_px IS NOT NULL))))
+);
+
+
+--
+-- Name: oidc_identities; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.oidc_identities (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    user_id uuid NOT NULL,
+    issuer text NOT NULL,
+    subject text NOT NULL,
+    last_claimed_email text,
+    last_claimed_email_verified boolean,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT oidc_identities_issuer_nonempty_chk CHECK ((length(btrim(issuer)) > 0)),
+    CONSTRAINT oidc_identities_subject_nonempty_chk CHECK ((length(btrim(subject)) > 0))
+);
+
+
+--
+-- Name: oidc_login_transactions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.oidc_login_transactions (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    state_hash text NOT NULL,
+    organization_id uuid NOT NULL,
+    organization_oidc_provider_id uuid NOT NULL,
+    session_id uuid,
+    invite_id uuid,
+    intent text NOT NULL,
+    nonce text NOT NULL,
+    pkce_code_verifier_ciphertext text NOT NULL,
+    return_to text NOT NULL,
+    expires_at timestamp with time zone NOT NULL,
+    consumed_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT oidc_login_transactions_intent_chk CHECK ((intent = ANY (ARRAY['login'::text, 'reauthenticate'::text, 'accept_invite'::text, 'link_identity'::text]))),
+    CONSTRAINT oidc_login_transactions_intent_state_chk CHECK ((((intent = 'login'::text) AND (session_id IS NULL) AND (invite_id IS NULL)) OR ((intent = 'reauthenticate'::text) AND (session_id IS NOT NULL) AND (invite_id IS NULL)) OR ((intent = 'accept_invite'::text) AND (invite_id IS NOT NULL)) OR ((intent = 'link_identity'::text) AND (session_id IS NOT NULL) AND (invite_id IS NULL)))),
+    CONSTRAINT oidc_login_transactions_nonce_nonempty_chk CHECK ((length(btrim(nonce)) > 0)),
+    CONSTRAINT oidc_login_transactions_pkce_nonempty_chk CHECK ((length(btrim(pkce_code_verifier_ciphertext)) > 0)),
+    CONSTRAINT oidc_login_transactions_return_to_chk CHECK ((("left"(return_to, 1) = '/'::text) AND ("left"(return_to, 2) <> '//'::text) AND (POSITION(('\'::text) IN (return_to)) = 0))),
+    CONSTRAINT oidc_login_transactions_state_hash_nonempty_chk CHECK ((length(btrim(state_hash)) > 0))
+);
+
+
+--
+-- Name: organization_auth_settings; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.organization_auth_settings (
+    organization_id uuid NOT NULL,
+    local_auth_enabled boolean NOT NULL,
+    oidc_auth_enabled boolean NOT NULL,
+    policy_version bigint DEFAULT 1 NOT NULL,
+    membership_grant_ttl_seconds integer NOT NULL,
+    reauthentication_interval_seconds integer NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT organization_auth_settings_auth_method_chk CHECK ((local_auth_enabled OR oidc_auth_enabled)),
+    CONSTRAINT organization_auth_settings_grant_ttl_chk CHECK ((membership_grant_ttl_seconds > 0)),
+    CONSTRAINT organization_auth_settings_policy_version_chk CHECK ((policy_version >= 1)),
+    CONSTRAINT organization_auth_settings_reauth_interval_chk CHECK ((reauthentication_interval_seconds > 0)),
+    CONSTRAINT organization_auth_settings_reauth_lte_ttl_chk CHECK ((reauthentication_interval_seconds <= membership_grant_ttl_seconds))
 );
 
 
@@ -183,12 +296,72 @@ CREATE TABLE public.organization_invites (
     created_by_user_id uuid NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_by_membership_id uuid,
+    redeemed_at timestamp with time zone,
+    redeemed_membership_id uuid,
     CONSTRAINT organization_invites_email_nonempty_chk CHECK ((length(btrim(email)) > 0)),
     CONSTRAINT organization_invites_max_uses_chk CHECK ((max_uses > 0)),
-    CONSTRAINT organization_invites_role_chk CHECK ((role = 'member'::text)),
     CONSTRAINT organization_invites_token_hash_nonempty_chk CHECK ((length(btrim(token_hash)) > 0)),
     CONSTRAINT organization_invites_usage_bounds_chk CHECK ((used_count <= max_uses)),
     CONSTRAINT organization_invites_used_count_chk CHECK ((used_count >= 0))
+);
+
+
+--
+-- Name: organization_local_credentials; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.organization_local_credentials (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    membership_id uuid NOT NULL,
+    organization_id uuid NOT NULL,
+    login_email text NOT NULL,
+    normalized_login_email text NOT NULL,
+    password_hash text NOT NULL,
+    password_changed_at timestamp with time zone DEFAULT now() NOT NULL,
+    failed_login_attempts integer DEFAULT 0 NOT NULL,
+    locked_until timestamp with time zone,
+    enabled boolean DEFAULT true NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT organization_local_credentials_failed_attempts_chk CHECK ((failed_login_attempts >= 0)),
+    CONSTRAINT organization_local_credentials_login_email_nonempty_chk CHECK ((length(btrim(login_email)) > 0)),
+    CONSTRAINT organization_local_credentials_normalized_email_nonempty_chk CHECK ((length(btrim(normalized_login_email)) > 0)),
+    CONSTRAINT organization_local_credentials_password_hash_nonempty_chk CHECK ((length(btrim(password_hash)) > 0))
+);
+
+
+--
+-- Name: organization_member_oidc_identities; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.organization_member_oidc_identities (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    membership_id uuid NOT NULL,
+    organization_id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    organization_oidc_provider_id uuid NOT NULL,
+    oidc_identity_id uuid NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    revoked_at timestamp with time zone
+);
+
+
+--
+-- Name: organization_member_profiles; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.organization_member_profiles (
+    membership_id uuid NOT NULL,
+    display_name text,
+    height_meters numeric(5,3),
+    stride_length_meters numeric(5,3),
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT organization_member_profiles_display_name_chk CHECK (((display_name IS NULL) OR ((length(btrim(display_name)) >= 1) AND (length(btrim(display_name)) <= 255)))),
+    CONSTRAINT organization_member_profiles_height_positive_chk CHECK (((height_meters IS NULL) OR (height_meters > (0)::numeric))),
+    CONSTRAINT organization_member_profiles_stride_positive_chk CHECK (((stride_length_meters IS NULL) OR (stride_length_meters > (0)::numeric)))
 );
 
 
@@ -202,7 +375,35 @@ CREATE TABLE public.organization_memberships (
     role text NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    id uuid DEFAULT gen_random_uuid(),
+    status text DEFAULT 'active'::text,
+    joined_at timestamp with time zone DEFAULT now(),
+    left_at timestamp with time zone,
     CONSTRAINT organization_memberships_role_chk CHECK ((role = ANY (ARRAY['member'::text, 'manager'::text, 'owner'::text])))
+);
+
+
+--
+-- Name: organization_oidc_providers; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.organization_oidc_providers (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    name text NOT NULL,
+    issuer text NOT NULL,
+    client_id text NOT NULL,
+    client_secret_ref text,
+    scopes text[] NOT NULL,
+    allowed_hosted_domains text[],
+    enabled boolean DEFAULT true NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT organization_oidc_providers_client_id_nonempty_chk CHECK ((length(btrim(client_id)) > 0)),
+    CONSTRAINT organization_oidc_providers_hosted_domains_nonempty_chk CHECK (((allowed_hosted_domains IS NULL) OR (cardinality(allowed_hosted_domains) > 0))),
+    CONSTRAINT organization_oidc_providers_issuer_nonempty_chk CHECK ((length(btrim(issuer)) > 0)),
+    CONSTRAINT organization_oidc_providers_name_nonempty_chk CHECK ((length(btrim(name)) > 0)),
+    CONSTRAINT organization_oidc_providers_openid_scope_chk CHECK (COALESCE(('openid'::text = ANY (scopes)), false))
 );
 
 
@@ -216,6 +417,7 @@ CREATE TABLE public.organizations (
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
     slug text DEFAULT ('org-'::text || replace((gen_random_uuid())::text, '-'::text, ''::text)) NOT NULL,
+    status text DEFAULT 'active'::text,
     CONSTRAINT organizations_name_nonempty_chk CHECK ((length(btrim(name)) > 0)),
     CONSTRAINT organizations_slug_format_chk CHECK (((slug ~ '^[a-z0-9]+(-[a-z0-9]+)*$'::text) AND ((length(slug) >= 3) AND (length(slug) <= 63)))),
     CONSTRAINT organizations_slug_reserved_chk CHECK ((slug <> ALL (ARRAY['admin'::text, 'api'::text, 'auth'::text, 'platform'::text, 'new'::text, 'settings'::text])))
@@ -236,6 +438,7 @@ CREATE TABLE public.pedestrians (
     display_name text NOT NULL,
     user_id uuid,
     organization_id uuid NOT NULL,
+    membership_id uuid,
     CONSTRAINT pedestrians_display_name_nonempty_chk CHECK ((length(btrim(display_name)) > 0))
 );
 
@@ -267,6 +470,29 @@ CREATE TABLE public.recordings (
 
 CREATE TABLE public.schema_migrations (
     version character varying NOT NULL
+);
+
+
+--
+-- Name: session_membership_authentications; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.session_membership_authentications (
+    session_id uuid NOT NULL,
+    membership_id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    auth_method text NOT NULL,
+    policy_version bigint NOT NULL,
+    local_credential_id uuid,
+    member_oidc_identity_id uuid,
+    authenticated_at timestamp with time zone NOT NULL,
+    expires_at timestamp with time zone NOT NULL,
+    revoked_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT session_membership_auth_expiry_chk CHECK ((expires_at > authenticated_at)),
+    CONSTRAINT session_membership_auth_policy_version_chk CHECK ((policy_version >= 1)),
+    CONSTRAINT session_membership_auth_source_chk CHECK ((((auth_method = 'local'::text) AND (local_credential_id IS NOT NULL) AND (member_oidc_identity_id IS NULL)) OR ((auth_method = 'oidc'::text) AND (local_credential_id IS NULL) AND (member_oidc_identity_id IS NOT NULL))))
 );
 
 
@@ -330,6 +556,23 @@ CREATE TABLE public.user_activation_tokens (
 
 
 --
+-- Name: user_profiles; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_profiles (
+    user_id uuid NOT NULL,
+    display_name text NOT NULL,
+    locale text DEFAULT 'ja-JP'::text NOT NULL,
+    timezone text DEFAULT 'Asia/Tokyo'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT user_profiles_display_name_chk CHECK (((length(btrim(display_name)) >= 1) AND (length(btrim(display_name)) <= 255))),
+    CONSTRAINT user_profiles_locale_nonempty_chk CHECK ((length(btrim(locale)) > 0)),
+    CONSTRAINT user_profiles_timezone_nonempty_chk CHECK ((length(btrim(timezone)) > 0))
+);
+
+
+--
 -- Name: users; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -345,6 +588,9 @@ CREATE TABLE public.users (
     failed_login_attempts integer DEFAULT 0 NOT NULL,
     locked_until timestamp with time zone,
     status text NOT NULL,
+    contact_email text,
+    normalized_contact_email text,
+    contact_email_verified_at timestamp with time zone,
     CONSTRAINT users_display_name_nonempty_chk CHECK ((length(btrim(display_name)) > 0)),
     CONSTRAINT users_email_nonempty_chk CHECK ((length(btrim(email)) > 0)),
     CONSTRAINT users_global_role_chk CHECK ((global_role = ANY (ARRAY['none'::text, 'admin'::text]))),
@@ -354,19 +600,35 @@ CREATE TABLE public.users (
 
 
 --
--- Name: auth_identities auth_identities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: analysis_run_trajectories analysis_run_trajectories_analysis_run_id_seq_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.analysis_run_trajectories
+    ADD CONSTRAINT analysis_run_trajectories_analysis_run_id_seq_key UNIQUE (analysis_run_id, seq);
+
+
+--
+-- Name: analysis_run_trajectories analysis_run_trajectories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.analysis_run_trajectories
+    ADD CONSTRAINT analysis_run_trajectories_pkey PRIMARY KEY (analysis_run_id, trajectory_id);
+
+
+--
+-- Name: analysis_runs analysis_runs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.analysis_runs
     ADD CONSTRAINT analysis_runs_pkey PRIMARY KEY (id);
 
 
-ALTER TABLE ONLY public.analysis_run_trajectories
-    ADD CONSTRAINT analysis_run_trajectories_pkey PRIMARY KEY (analysis_run_id, trajectory_id);
+--
+-- Name: audit_events audit_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
-
-ALTER TABLE ONLY public.analysis_run_trajectories
-    ADD CONSTRAINT analysis_run_trajectories_analysis_run_id_seq_key UNIQUE (analysis_run_id, seq);
+ALTER TABLE ONLY public.audit_events
+    ADD CONSTRAINT audit_events_pkey PRIMARY KEY (id);
 
 
 --
@@ -386,6 +648,14 @@ ALTER TABLE ONLY public.auth_identities
 
 
 --
+-- Name: authentication_events authentication_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.authentication_events
+    ADD CONSTRAINT authentication_events_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: buildings buildings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -399,6 +669,54 @@ ALTER TABLE ONLY public.buildings
 
 ALTER TABLE ONLY public.floors
     ADD CONSTRAINT floors_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: oidc_identities oidc_identities_id_user_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oidc_identities
+    ADD CONSTRAINT oidc_identities_id_user_key UNIQUE (id, user_id);
+
+
+--
+-- Name: oidc_identities oidc_identities_issuer_subject_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oidc_identities
+    ADD CONSTRAINT oidc_identities_issuer_subject_key UNIQUE (issuer, subject);
+
+
+--
+-- Name: oidc_identities oidc_identities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oidc_identities
+    ADD CONSTRAINT oidc_identities_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: oidc_login_transactions oidc_login_transactions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oidc_login_transactions
+    ADD CONSTRAINT oidc_login_transactions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: oidc_login_transactions oidc_login_transactions_state_hash_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oidc_login_transactions
+    ADD CONSTRAINT oidc_login_transactions_state_hash_key UNIQUE (state_hash);
+
+
+--
+-- Name: organization_auth_settings organization_auth_settings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_auth_settings
+    ADD CONSTRAINT organization_auth_settings_pkey PRIMARY KEY (organization_id);
 
 
 --
@@ -434,6 +752,30 @@ ALTER TABLE ONLY public.organization_invites
 
 
 --
+-- Name: organization_invites organization_invites_redemption_state_chk; Type: CHECK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE public.organization_invites
+    ADD CONSTRAINT organization_invites_redemption_state_chk CHECK ((((redeemed_at IS NULL) AND (redeemed_membership_id IS NULL)) OR ((redeemed_at IS NOT NULL) AND (redeemed_membership_id IS NOT NULL)))) NOT VALID;
+
+
+--
+-- Name: organization_invites organization_invites_revoked_redeemed_chk; Type: CHECK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE public.organization_invites
+    ADD CONSTRAINT organization_invites_revoked_redeemed_chk CHECK (((revoked_at IS NULL) OR (redeemed_at IS NULL))) NOT VALID;
+
+
+--
+-- Name: organization_invites organization_invites_role_chk; Type: CHECK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE public.organization_invites
+    ADD CONSTRAINT organization_invites_role_chk CHECK ((role = ANY (ARRAY['member'::text, 'manager'::text]))) NOT VALID;
+
+
+--
 -- Name: organization_invites organization_invites_token_hash_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -442,11 +784,107 @@ ALTER TABLE ONLY public.organization_invites
 
 
 --
+-- Name: organization_local_credentials organization_local_credentials_id_membership_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_local_credentials
+    ADD CONSTRAINT organization_local_credentials_id_membership_key UNIQUE (id, membership_id);
+
+
+--
+-- Name: organization_local_credentials organization_local_credentials_membership_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_local_credentials
+    ADD CONSTRAINT organization_local_credentials_membership_key UNIQUE (membership_id);
+
+
+--
+-- Name: organization_local_credentials organization_local_credentials_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_local_credentials
+    ADD CONSTRAINT organization_local_credentials_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: organization_member_oidc_identities organization_member_oidc_id_membership_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_member_oidc_identities
+    ADD CONSTRAINT organization_member_oidc_id_membership_key UNIQUE (id, membership_id);
+
+
+--
+-- Name: organization_member_oidc_identities organization_member_oidc_identities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_member_oidc_identities
+    ADD CONSTRAINT organization_member_oidc_identities_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: organization_member_oidc_identities organization_member_oidc_link_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_member_oidc_identities
+    ADD CONSTRAINT organization_member_oidc_link_key UNIQUE (membership_id, organization_oidc_provider_id, oidc_identity_id);
+
+
+--
+-- Name: organization_member_profiles organization_member_profiles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_member_profiles
+    ADD CONSTRAINT organization_member_profiles_pkey PRIMARY KEY (membership_id);
+
+
+--
+-- Name: organization_memberships organization_memberships_left_at_chk; Type: CHECK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE public.organization_memberships
+    ADD CONSTRAINT organization_memberships_left_at_chk CHECK ((((status = 'left'::text) AND (left_at IS NOT NULL)) OR ((status <> 'left'::text) AND (left_at IS NULL)))) NOT VALID;
+
+
+--
 -- Name: organization_memberships organization_memberships_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.organization_memberships
     ADD CONSTRAINT organization_memberships_pkey PRIMARY KEY (organization_id, user_id);
+
+
+--
+-- Name: organization_memberships organization_memberships_status_chk; Type: CHECK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE public.organization_memberships
+    ADD CONSTRAINT organization_memberships_status_chk CHECK ((status = ANY (ARRAY['active'::text, 'suspended'::text, 'left'::text]))) NOT VALID;
+
+
+--
+-- Name: organization_oidc_providers organization_oidc_providers_id_org_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_oidc_providers
+    ADD CONSTRAINT organization_oidc_providers_id_org_key UNIQUE (id, organization_id);
+
+
+--
+-- Name: organization_oidc_providers organization_oidc_providers_org_issuer_client_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_oidc_providers
+    ADD CONSTRAINT organization_oidc_providers_org_issuer_client_key UNIQUE (organization_id, issuer, client_id);
+
+
+--
+-- Name: organization_oidc_providers organization_oidc_providers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_oidc_providers
+    ADD CONSTRAINT organization_oidc_providers_pkey PRIMARY KEY (id);
 
 
 --
@@ -463,6 +901,14 @@ ALTER TABLE ONLY public.organizations
 
 ALTER TABLE ONLY public.organizations
     ADD CONSTRAINT organizations_slug_key UNIQUE (slug);
+
+
+--
+-- Name: organizations organizations_status_chk; Type: CHECK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE public.organizations
+    ADD CONSTRAINT organizations_status_chk CHECK ((status = ANY (ARRAY['active'::text, 'suspended'::text]))) NOT VALID;
 
 
 --
@@ -495,6 +941,14 @@ ALTER TABLE ONLY public.recordings
 
 ALTER TABLE ONLY public.schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: session_membership_authentications session_membership_authentications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.session_membership_authentications
+    ADD CONSTRAINT session_membership_authentications_pkey PRIMARY KEY (session_id, membership_id);
 
 
 --
@@ -538,6 +992,22 @@ ALTER TABLE ONLY public.user_activation_tokens
 
 
 --
+-- Name: user_profiles user_profiles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_profiles
+    ADD CONSTRAINT user_profiles_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: users users_contact_email_state_chk; Type: CHECK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE public.users
+    ADD CONSTRAINT users_contact_email_state_chk CHECK (((contact_email IS NOT NULL) OR ((normalized_contact_email IS NULL) AND (contact_email_verified_at IS NULL)))) NOT VALID;
+
+
+--
 -- Name: users users_email_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -554,13 +1024,38 @@ ALTER TABLE ONLY public.users
 
 
 --
--- Name: auth_identities_one_google_identity_per_user; Type: INDEX; Schema: public; Owner: -
+-- Name: analysis_run_trajectories_trajectory_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX analysis_run_trajectories_trajectory_id_idx ON public.analysis_run_trajectories USING btree (trajectory_id);
+
+
+--
+-- Name: analysis_runs_organization_created_at_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX analysis_runs_organization_created_at_id_idx ON public.analysis_runs USING btree (organization_id, created_at DESC, id DESC);
 
 
-CREATE INDEX analysis_run_trajectories_trajectory_id_idx ON public.analysis_run_trajectories USING btree (trajectory_id);
+--
+-- Name: audit_events_occurred_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX audit_events_occurred_at_idx ON public.audit_events USING btree (occurred_at);
+
+
+--
+-- Name: audit_events_org_occurred_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX audit_events_org_occurred_at_idx ON public.audit_events USING btree (organization_id, occurred_at DESC);
+
+
+--
+-- Name: audit_events_target_occurred_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX audit_events_target_occurred_at_idx ON public.audit_events USING btree (target_type, target_id, occurred_at DESC);
 
 
 --
@@ -575,6 +1070,27 @@ CREATE UNIQUE INDEX auth_identities_one_google_identity_per_user ON public.auth_
 --
 
 CREATE INDEX auth_identities_user_id_idx ON public.auth_identities USING btree (user_id);
+
+
+--
+-- Name: authentication_events_occurred_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX authentication_events_occurred_at_idx ON public.authentication_events USING btree (occurred_at);
+
+
+--
+-- Name: authentication_events_org_occurred_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX authentication_events_org_occurred_at_idx ON public.authentication_events USING btree (organization_id, occurred_at DESC);
+
+
+--
+-- Name: authentication_events_user_occurred_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX authentication_events_user_occurred_at_idx ON public.authentication_events USING btree (user_id, occurred_at DESC);
 
 
 --
@@ -596,6 +1112,13 @@ CREATE INDEX floors_building_id_idx ON public.floors USING btree (building_id);
 --
 
 CREATE INDEX floors_organization_id_idx ON public.floors USING btree (organization_id);
+
+
+--
+-- Name: oidc_login_transactions_expires_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX oidc_login_transactions_expires_at_idx ON public.oidc_login_transactions USING btree (expires_at);
 
 
 --
@@ -627,6 +1150,13 @@ CREATE INDEX organization_invite_redemptions_user_id_idx ON public.organization_
 
 
 --
+-- Name: organization_invites_active_expires_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX organization_invites_active_expires_at_idx ON public.organization_invites USING btree (expires_at) WHERE ((revoked_at IS NULL) AND (redeemed_at IS NULL));
+
+
+--
 -- Name: organization_invites_created_by_user_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -648,6 +1178,13 @@ CREATE INDEX organization_invites_expires_at_idx ON public.organization_invites 
 
 
 --
+-- Name: organization_invites_org_created_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX organization_invites_org_created_at_idx ON public.organization_invites USING btree (organization_id, created_at DESC);
+
+
+--
 -- Name: organization_invites_organization_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -655,10 +1192,80 @@ CREATE INDEX organization_invites_organization_id_idx ON public.organization_inv
 
 
 --
+-- Name: organization_invites_redeemed_membership_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX organization_invites_redeemed_membership_key ON public.organization_invites USING btree (redeemed_membership_id);
+
+
+--
+-- Name: organization_local_credentials_active_email_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX organization_local_credentials_active_email_key ON public.organization_local_credentials USING btree (organization_id, normalized_login_email) WHERE enabled;
+
+
+--
+-- Name: organization_member_oidc_active_membership_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX organization_member_oidc_active_membership_idx ON public.organization_member_oidc_identities USING btree (membership_id) WHERE (revoked_at IS NULL);
+
+
+--
+-- Name: organization_member_oidc_active_provider_identity_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX organization_member_oidc_active_provider_identity_key ON public.organization_member_oidc_identities USING btree (organization_oidc_provider_id, oidc_identity_id) WHERE (revoked_at IS NULL);
+
+
+--
+-- Name: organization_memberships_id_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX organization_memberships_id_key ON public.organization_memberships USING btree (id);
+
+
+--
+-- Name: organization_memberships_id_organization_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX organization_memberships_id_organization_key ON public.organization_memberships USING btree (id, organization_id);
+
+
+--
+-- Name: organization_memberships_id_user_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX organization_memberships_id_user_key ON public.organization_memberships USING btree (id, user_id);
+
+
+--
+-- Name: organization_memberships_org_status_role_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX organization_memberships_org_status_role_idx ON public.organization_memberships USING btree (organization_id, status, role);
+
+
+--
 -- Name: organization_memberships_user_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX organization_memberships_user_id_idx ON public.organization_memberships USING btree (user_id);
+
+
+--
+-- Name: organization_memberships_user_status_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX organization_memberships_user_status_idx ON public.organization_memberships USING btree (user_id, status);
+
+
+--
+-- Name: pedestrians_membership_id_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX pedestrians_membership_id_key ON public.pedestrians USING btree (membership_id) WHERE (membership_id IS NOT NULL);
 
 
 --
@@ -704,10 +1311,52 @@ CREATE INDEX recordings_pedestrian_id_created_at_active_idx ON public.recordings
 
 
 --
+-- Name: session_membership_auth_active_local_credential_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX session_membership_auth_active_local_credential_idx ON public.session_membership_authentications USING btree (local_credential_id) WHERE (revoked_at IS NULL);
+
+
+--
+-- Name: session_membership_auth_active_membership_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX session_membership_auth_active_membership_idx ON public.session_membership_authentications USING btree (membership_id) WHERE (revoked_at IS NULL);
+
+
+--
+-- Name: session_membership_auth_active_oidc_identity_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX session_membership_auth_active_oidc_identity_idx ON public.session_membership_authentications USING btree (member_oidc_identity_id) WHERE (revoked_at IS NULL);
+
+
+--
+-- Name: sessions_active_expires_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sessions_active_expires_at_idx ON public.sessions USING btree (expires_at) WHERE (revoked_at IS NULL);
+
+
+--
+-- Name: sessions_active_user_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sessions_active_user_idx ON public.sessions USING btree (user_id) WHERE (revoked_at IS NULL);
+
+
+--
 -- Name: sessions_expires_at_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX sessions_expires_at_idx ON public.sessions USING btree (expires_at);
+
+
+--
+-- Name: sessions_id_user_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX sessions_id_user_key ON public.sessions USING btree (id, user_id);
 
 
 --
@@ -725,17 +1374,17 @@ CREATE INDEX sessions_user_id_idx ON public.sessions USING btree (user_id);
 
 
 --
--- Name: trajectories_organization_id_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX trajectories_organization_id_idx ON public.trajectories USING btree (organization_id);
-
-
---
 -- Name: trajectories_organization_created_at_id_active_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX trajectories_organization_created_at_id_active_idx ON public.trajectories USING btree (organization_id, created_at DESC, id DESC) WHERE (deleted_at IS NULL);
+
+
+--
+-- Name: trajectories_organization_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX trajectories_organization_id_idx ON public.trajectories USING btree (organization_id);
 
 
 --
@@ -816,6 +1465,20 @@ CREATE TRIGGER set_updated_at_floors BEFORE UPDATE ON public.floors FOR EACH ROW
 
 
 --
+-- Name: oidc_identities set_updated_at_oidc_identities; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER set_updated_at_oidc_identities BEFORE UPDATE ON public.oidc_identities FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+
+--
+-- Name: organization_auth_settings set_updated_at_organization_auth_settings; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER set_updated_at_organization_auth_settings BEFORE UPDATE ON public.organization_auth_settings FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+
+--
 -- Name: organization_creation_requests set_updated_at_organization_creation_requests; Type: TRIGGER; Schema: public; Owner: -
 --
 
@@ -830,10 +1493,38 @@ CREATE TRIGGER set_updated_at_organization_invites BEFORE UPDATE ON public.organ
 
 
 --
+-- Name: organization_local_credentials set_updated_at_organization_local_credentials; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER set_updated_at_organization_local_credentials BEFORE UPDATE ON public.organization_local_credentials FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+
+--
+-- Name: organization_member_oidc_identities set_updated_at_organization_member_oidc_identities; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER set_updated_at_organization_member_oidc_identities BEFORE UPDATE ON public.organization_member_oidc_identities FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+
+--
+-- Name: organization_member_profiles set_updated_at_organization_member_profiles; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER set_updated_at_organization_member_profiles BEFORE UPDATE ON public.organization_member_profiles FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+
+--
 -- Name: organization_memberships set_updated_at_organization_memberships; Type: TRIGGER; Schema: public; Owner: -
 --
 
 CREATE TRIGGER set_updated_at_organization_memberships BEFORE UPDATE ON public.organization_memberships FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+
+--
+-- Name: organization_oidc_providers set_updated_at_organization_oidc_providers; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER set_updated_at_organization_oidc_providers BEFORE UPDATE ON public.organization_oidc_providers FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
 
 
 --
@@ -858,10 +1549,24 @@ CREATE TRIGGER set_updated_at_recordings BEFORE UPDATE ON public.recordings FOR 
 
 
 --
+-- Name: session_membership_authentications set_updated_at_session_membership_authentications; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER set_updated_at_session_membership_authentications BEFORE UPDATE ON public.session_membership_authentications FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+
+--
 -- Name: trajectories set_updated_at_trajectories; Type: TRIGGER; Schema: public; Owner: -
 --
 
 CREATE TRIGGER set_updated_at_trajectories BEFORE UPDATE ON public.trajectories FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+
+--
+-- Name: user_profiles set_updated_at_user_profiles; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER set_updated_at_user_profiles BEFORE UPDATE ON public.user_profiles FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
 
 
 --
@@ -872,23 +1577,35 @@ CREATE TRIGGER set_updated_at_users BEFORE UPDATE ON public.users FOR EACH ROW E
 
 
 --
--- Name: auth_identities auth_identities_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: analysis_run_trajectories analysis_run_trajectories_analysis_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.analysis_run_trajectories
+    ADD CONSTRAINT analysis_run_trajectories_analysis_run_id_fkey FOREIGN KEY (analysis_run_id) REFERENCES public.analysis_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: analysis_run_trajectories analysis_run_trajectories_trajectory_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.analysis_run_trajectories
+    ADD CONSTRAINT analysis_run_trajectories_trajectory_id_fkey FOREIGN KEY (trajectory_id) REFERENCES public.trajectories(id);
+
+
+--
+-- Name: analysis_runs analysis_runs_floor_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.analysis_runs
     ADD CONSTRAINT analysis_runs_floor_id_fkey FOREIGN KEY (floor_id) REFERENCES public.floors(id);
 
 
+--
+-- Name: analysis_runs analysis_runs_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.analysis_runs
     ADD CONSTRAINT analysis_runs_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
-
-
-ALTER TABLE ONLY public.analysis_run_trajectories
-    ADD CONSTRAINT analysis_run_trajectories_analysis_run_id_fkey FOREIGN KEY (analysis_run_id) REFERENCES public.analysis_runs(id) ON DELETE CASCADE;
-
-
-ALTER TABLE ONLY public.analysis_run_trajectories
-    ADD CONSTRAINT analysis_run_trajectories_trajectory_id_fkey FOREIGN KEY (trajectory_id) REFERENCES public.trajectories(id);
 
 
 --
@@ -921,6 +1638,54 @@ ALTER TABLE ONLY public.floors
 
 ALTER TABLE ONLY public.floors
     ADD CONSTRAINT floors_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: oidc_identities oidc_identities_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oidc_identities
+    ADD CONSTRAINT oidc_identities_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: oidc_login_transactions oidc_login_transactions_invite_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oidc_login_transactions
+    ADD CONSTRAINT oidc_login_transactions_invite_id_fkey FOREIGN KEY (invite_id) REFERENCES public.organization_invites(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: oidc_login_transactions oidc_login_transactions_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oidc_login_transactions
+    ADD CONSTRAINT oidc_login_transactions_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: oidc_login_transactions oidc_login_transactions_provider_org_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oidc_login_transactions
+    ADD CONSTRAINT oidc_login_transactions_provider_org_fkey FOREIGN KEY (organization_oidc_provider_id, organization_id) REFERENCES public.organization_oidc_providers(id, organization_id) ON DELETE RESTRICT;
+
+
+--
+-- Name: oidc_login_transactions oidc_login_transactions_session_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oidc_login_transactions
+    ADD CONSTRAINT oidc_login_transactions_session_id_fkey FOREIGN KEY (session_id) REFERENCES public.sessions(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: organization_auth_settings organization_auth_settings_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_auth_settings
+    ADD CONSTRAINT organization_auth_settings_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE RESTRICT;
 
 
 --
@@ -972,11 +1737,75 @@ ALTER TABLE ONLY public.organization_invites
 
 
 --
+-- Name: organization_invites organization_invites_creator_org_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_invites
+    ADD CONSTRAINT organization_invites_creator_org_fkey FOREIGN KEY (created_by_membership_id, organization_id) REFERENCES public.organization_memberships(id, organization_id) ON DELETE RESTRICT NOT VALID;
+
+
+--
 -- Name: organization_invites organization_invites_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.organization_invites
     ADD CONSTRAINT organization_invites_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: organization_invites organization_invites_redeemed_membership_org_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_invites
+    ADD CONSTRAINT organization_invites_redeemed_membership_org_fkey FOREIGN KEY (redeemed_membership_id, organization_id) REFERENCES public.organization_memberships(id, organization_id) ON DELETE RESTRICT NOT VALID;
+
+
+--
+-- Name: organization_local_credentials organization_local_credentials_membership_org_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_local_credentials
+    ADD CONSTRAINT organization_local_credentials_membership_org_fkey FOREIGN KEY (membership_id, organization_id) REFERENCES public.organization_memberships(id, organization_id) ON DELETE RESTRICT;
+
+
+--
+-- Name: organization_member_oidc_identities organization_member_oidc_identity_user_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_member_oidc_identities
+    ADD CONSTRAINT organization_member_oidc_identity_user_fkey FOREIGN KEY (oidc_identity_id, user_id) REFERENCES public.oidc_identities(id, user_id) ON DELETE RESTRICT;
+
+
+--
+-- Name: organization_member_oidc_identities organization_member_oidc_membership_org_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_member_oidc_identities
+    ADD CONSTRAINT organization_member_oidc_membership_org_fkey FOREIGN KEY (membership_id, organization_id) REFERENCES public.organization_memberships(id, organization_id) ON DELETE RESTRICT;
+
+
+--
+-- Name: organization_member_oidc_identities organization_member_oidc_membership_user_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_member_oidc_identities
+    ADD CONSTRAINT organization_member_oidc_membership_user_fkey FOREIGN KEY (membership_id, user_id) REFERENCES public.organization_memberships(id, user_id) ON DELETE RESTRICT;
+
+
+--
+-- Name: organization_member_oidc_identities organization_member_oidc_provider_org_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_member_oidc_identities
+    ADD CONSTRAINT organization_member_oidc_provider_org_fkey FOREIGN KEY (organization_oidc_provider_id, organization_id) REFERENCES public.organization_oidc_providers(id, organization_id) ON DELETE RESTRICT;
+
+
+--
+-- Name: organization_member_profiles organization_member_profiles_membership_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_member_profiles
+    ADD CONSTRAINT organization_member_profiles_membership_id_fkey FOREIGN KEY (membership_id) REFERENCES public.organization_memberships(id) ON DELETE RESTRICT;
 
 
 --
@@ -993,6 +1822,22 @@ ALTER TABLE ONLY public.organization_memberships
 
 ALTER TABLE ONLY public.organization_memberships
     ADD CONSTRAINT organization_memberships_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: organization_oidc_providers organization_oidc_providers_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_oidc_providers
+    ADD CONSTRAINT organization_oidc_providers_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: pedestrians pedestrians_membership_organization_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.pedestrians
+    ADD CONSTRAINT pedestrians_membership_organization_fkey FOREIGN KEY (membership_id, organization_id) REFERENCES public.organization_memberships(id, organization_id) ON DELETE RESTRICT NOT VALID;
 
 
 --
@@ -1033,6 +1878,38 @@ ALTER TABLE ONLY public.recordings
 
 ALTER TABLE ONLY public.recordings
     ADD CONSTRAINT recordings_pedestrian_id_fkey FOREIGN KEY (pedestrian_id) REFERENCES public.pedestrians(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: session_membership_authentications session_membership_auth_local_source_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.session_membership_authentications
+    ADD CONSTRAINT session_membership_auth_local_source_fkey FOREIGN KEY (local_credential_id, membership_id) REFERENCES public.organization_local_credentials(id, membership_id) ON DELETE RESTRICT;
+
+
+--
+-- Name: session_membership_authentications session_membership_auth_membership_user_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.session_membership_authentications
+    ADD CONSTRAINT session_membership_auth_membership_user_fkey FOREIGN KEY (membership_id, user_id) REFERENCES public.organization_memberships(id, user_id) ON DELETE RESTRICT;
+
+
+--
+-- Name: session_membership_authentications session_membership_auth_oidc_source_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.session_membership_authentications
+    ADD CONSTRAINT session_membership_auth_oidc_source_fkey FOREIGN KEY (member_oidc_identity_id, membership_id) REFERENCES public.organization_member_oidc_identities(id, membership_id) ON DELETE RESTRICT;
+
+
+--
+-- Name: session_membership_authentications session_membership_auth_session_user_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.session_membership_authentications
+    ADD CONSTRAINT session_membership_auth_session_user_fkey FOREIGN KEY (session_id, user_id) REFERENCES public.sessions(id, user_id) ON DELETE RESTRICT;
 
 
 --
@@ -1092,6 +1969,14 @@ ALTER TABLE ONLY public.user_activation_tokens
 
 
 --
+-- Name: user_profiles user_profiles_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_profiles
+    ADD CONSTRAINT user_profiles_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE RESTRICT;
+
+
+--
 -- PostgreSQL database dump complete
 --
 
@@ -1117,4 +2002,26 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20260708010000'),
     ('20260728010000'),
     ('20260728010100'),
-    ('20260728010200');
+    ('20260728010200'),
+    ('20260728010300'),
+    ('20260801010000'),
+    ('20260804010000'),
+    ('20260804020000'),
+    ('20260811010000'),
+    ('20260811010051'),
+    ('20260811010052'),
+    ('20260811010053'),
+    ('20260811010054'),
+    ('20260811010055'),
+    ('20260811010056'),
+    ('20260811010057'),
+    ('20260811010058'),
+    ('20260811010100'),
+    ('20260811010200'),
+    ('20260811010250'),
+    ('20260811010300'),
+    ('20260811010400'),
+    ('20260811010500'),
+    ('20260811010551'),
+    ('20260811010552'),
+    ('20260811010553');


### PR DESCRIPTION
# issue番号

#219

# 変更内容(写真か動画も一緒に)

既存Kaedeと互換なExpand migrationとして、Membership UUID、Profile、Auth Policy、Credential、OIDC Link、Session Grant、Invite移行用Column、Event Tableを追加します。既存行のbackfill・NOT NULL化・認証切替は含みません。既存tableのIndexは1 migration/1 CREATE INDEX CONCURRENTLYへ分割しています。

# 影響範囲(あれば)

Database schema、Kysely生成型、DB constraint test。現行Columnと旧複合PKは維持します。DB test 213件、typecheck、lint、migration down/upを確認済みです。