### PR TITLE
Membership単位のLocal認証を追加

### DIFF
--- a/apps/kaede/src/middleware/request-actor.test.ts
+++ b/apps/kaede/src/middleware/request-actor.test.ts
@@ -3,15 +3,24 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { RequestActorHonoEnv } from './request-actor.js'
 import { getRequestActor, requestActorMiddleware } from './request-actor.js'
 
-const { findUserByIdMock, findValidSessionByTokenMock, listUserOrganizationMembershipsMock } =
-  vi.hoisted(() => ({
-    findUserByIdMock: vi.fn(),
-    findValidSessionByTokenMock: vi.fn(),
-    listUserOrganizationMembershipsMock: vi.fn(),
-  }))
+const {
+  findUserByIdMock,
+  findValidSessionByTokenMock,
+  hasLocalAuthenticationGrantBySessionIdMock,
+  listUserOrganizationMembershipsMock,
+} = vi.hoisted(() => ({
+  findUserByIdMock: vi.fn(),
+  findValidSessionByTokenMock: vi.fn(),
+  hasLocalAuthenticationGrantBySessionIdMock: vi.fn(),
+  listUserOrganizationMembershipsMock: vi.fn(),
+}))
 
 vi.mock('../services/auth/index.js', () => ({
   findValidSessionByToken: findValidSessionByTokenMock,
+}))
+
+vi.mock('../services/organization-local-auth/index.js', () => ({
+  hasLocalAuthenticationGrantBySessionId: hasLocalAuthenticationGrantBySessionIdMock,
 }))
 
 vi.mock('../services/users/index.js', () => ({
@@ -50,6 +59,7 @@ const mockActiveSessionUser = ({
   findValidSessionByTokenMock.mockResolvedValue({
     ok: true,
     session: {
+      id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       auth_method: authMethod,
       user_id: '11111111-1111-4111-8111-111111111111',
     },
@@ -73,6 +83,7 @@ const mockActiveSessionUser = ({
 describe('requestActorMiddleware', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    hasLocalAuthenticationGrantBySessionIdMock.mockResolvedValue(false)
   })
 
   it('正しい shared token があれば service client actor を設定する', async () => {
@@ -204,6 +215,23 @@ describe('requestActorMiddleware', () => {
     expect(response.status).toBe(200)
     const body = await response.json()
     expect(body.actor.account_state).toBe('active')
+  })
+
+  it('Membership Local Grantを持つsessionは共通password未設定でも利用できる', async () => {
+    mockActiveSessionUser({ passwordHash: null })
+    hasLocalAuthenticationGrantBySessionIdMock.mockResolvedValue(true)
+    const app = createTestApp()
+
+    const response = await app.request('/api/ping', {
+      headers: {
+        cookie: 'okarin_session=session-token',
+      },
+    })
+
+    expect(response.status).toBe(200)
+    expect(hasLocalAuthenticationGrantBySessionIdMock).toHaveBeenCalledWith(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+    )
   })
 
   it('membership がない user は pending_membership actor として設定する', async () => {

--- a/apps/kaede/src/middleware/request-actor.ts
+++ b/apps/kaede/src/middleware/request-actor.ts
@@ -4,6 +4,7 @@ import { timingSafeEqual } from 'node:crypto'
 import { sessionCookieName } from '../routes/auth/cookie.js'
 import { toAuthErrorResponse } from '../schemas/common.js'
 import { findValidSessionByToken } from '../services/auth/index.js'
+import { hasLocalAuthenticationGrantBySessionId } from '../services/organization-local-auth/index.js'
 import { findUserById, listUserOrganizationMemberships } from '../services/users/index.js'
 import { deriveAccountState } from '../usecases/authorization.js'
 import type { RequestActorHonoEnv } from './request-actor-context.js'
@@ -130,7 +131,12 @@ export const requestActorMiddleware = ({
     }
 
     if (sessionResult.session.auth_method === 'password' && !user.password_hash) {
-      return authError(c, 'AUTH_PASSWORD_CHANGE_REQUIRED')
+      const isMembershipLocalSession = await hasLocalAuthenticationGrantBySessionId(
+        sessionResult.session.id
+      )
+      if (!isMembershipLocalSession) {
+        return authError(c, 'AUTH_PASSWORD_CHANGE_REQUIRED')
+      }
     }
 
     const memberships = await listUserOrganizationMemberships(user.id)

--- a/apps/kaede/src/routes/organization-local-auth/index.ts
+++ b/apps/kaede/src/routes/organization-local-auth/index.ts
@@ -1,0 +1,6 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { registerLocalOrganizationLoginRoute } from './local-login.js'
+
+export const organizationLocalAuthRoutes = new OpenAPIHono()
+
+registerLocalOrganizationLoginRoute(organizationLocalAuthRoutes)

--- a/apps/kaede/src/routes/organization-local-auth/local-login.test.ts
+++ b/apps/kaede/src/routes/organization-local-auth/local-login.test.ts
@@ -1,0 +1,192 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { resetRuntimeConfigForTests } from '../../config/runtime.js'
+
+const { localLoginMock } = vi.hoisted(() => ({ localLoginMock: vi.fn() }))
+
+vi.mock('../../usecases/organization-local-auth/index.js', () => ({
+  loginToOrganizationWithLocalCredential: localLoginMock,
+}))
+
+import { organizationLocalAuthRoutes } from './index.js'
+
+const createTestApp = () => {
+  const app = new OpenAPIHono()
+  app.route('/api/organizations', organizationLocalAuthRoutes)
+  return app
+}
+
+describe('organization local auth route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.APP_ENV = 'local'
+    resetRuntimeConfigForTests()
+  })
+
+  afterEach(() => {
+    Reflect.deleteProperty(process.env, 'APP_ENV')
+    resetRuntimeConfigForTests()
+  })
+
+  it('新しいSessionのcookieとMembership Grantを返す', async () => {
+    localLoginMock.mockResolvedValue({
+      ok: true,
+      value: {
+        sessionToken: 'new-session-token',
+        session: {
+          id: '11111111-1111-4111-8111-111111111111',
+          expires_at: '2026-08-18T10:00:00.000Z',
+        },
+        membership: {
+          id: '22222222-2222-4222-8222-222222222222',
+          organization_id: '33333333-3333-4333-8333-333333333333',
+          role: 'member',
+          status: 'active',
+        },
+        grant: {
+          auth_method: 'local',
+          authenticated_at: '2026-08-11T10:00:00.000Z',
+          expires_at: '2026-08-11T18:00:00.000Z',
+        },
+        return_to: '/orgs/organization-a',
+      },
+    })
+
+    const response = await createTestApp().request(
+      '/api/organizations/organization-a/auth/local/login',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'user-agent': 'local-auth-test',
+          'x-request-id': 'request-id',
+        },
+        body: JSON.stringify({
+          login_email: 'local@example.test',
+          password: 'password',
+          return_to: '/orgs/organization-a',
+        }),
+      }
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('set-cookie')).toContain('okarin_session=new-session-token')
+    await expect(response.json()).resolves.toEqual({
+      session: { expires_at: '2026-08-18T10:00:00.000Z' },
+      membership: {
+        id: '22222222-2222-4222-8222-222222222222',
+        organization_id: '33333333-3333-4333-8333-333333333333',
+        role: 'member',
+        status: 'active',
+      },
+      grant: {
+        auth_method: 'local',
+        authenticated_at: '2026-08-11T10:00:00.000Z',
+        expires_at: '2026-08-11T18:00:00.000Z',
+      },
+      return_to: '/orgs/organization-a',
+    })
+    expect(localLoginMock).toHaveBeenCalledWith(
+      'organization-a',
+      undefined,
+      {
+        login_email: 'local@example.test',
+        password: 'password',
+        return_to: '/orgs/organization-a',
+      },
+      { requestId: 'request-id', userAgent: 'local-auth-test' }
+    )
+  })
+
+  it('reauthenticateでは既存Session cookieを渡し、新しいcookieを発行しない', async () => {
+    localLoginMock.mockResolvedValue({
+      ok: true,
+      value: {
+        session: {
+          id: '11111111-1111-4111-8111-111111111111',
+          expires_at: '2026-08-18T10:00:00.000Z',
+        },
+        membership: {
+          id: '22222222-2222-4222-8222-222222222222',
+          organization_id: '33333333-3333-4333-8333-333333333333',
+          role: 'member',
+          status: 'active',
+        },
+        grant: {
+          auth_method: 'local',
+          authenticated_at: '2026-08-11T10:00:00.000Z',
+          expires_at: '2026-08-11T18:00:00.000Z',
+        },
+        return_to: '/orgs/organization-a',
+      },
+    })
+
+    const response = await createTestApp().request(
+      '/api/organizations/organization-a/auth/local/login',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          cookie: 'okarin_session=existing-session-token',
+        },
+        body: JSON.stringify({
+          login_email: 'local@example.test',
+          password: 'password',
+          return_to: '/orgs/organization-a',
+        }),
+      }
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('set-cookie')).toBeNull()
+    expect(localLoginMock).toHaveBeenCalledWith(
+      'organization-a',
+      'existing-session-token',
+      expect.any(Object),
+      expect.any(Object)
+    )
+  })
+
+  it.each([
+    ['AUTH_INVALID_CREDENTIALS', 401],
+    ['AUTH_METHOD_NOT_ALLOWED', 403],
+    ['AUTH_IDENTITY_USER_MISMATCH', 403],
+    ['AUTH_CREDENTIAL_LOCKED', 429],
+  ])('%sをHTTP %iで返す', async (type, expectedStatus) => {
+    localLoginMock.mockResolvedValue({ ok: false, error: { type } })
+
+    const response = await createTestApp().request(
+      '/api/organizations/organization-a/auth/local/login',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          login_email: 'local@example.test',
+          password: 'password',
+          return_to: '/orgs/organization-a',
+        }),
+      }
+    )
+
+    expect(response.status).toBe(expectedStatus)
+    await expect(response.json()).resolves.toMatchObject({ error_code: type })
+  })
+
+  it('外部URL形式のreturn_toを拒否する', async () => {
+    const response = await createTestApp().request(
+      '/api/organizations/organization-a/auth/local/login',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          login_email: 'local@example.test',
+          password: 'password',
+          return_to: '//attacker.example.test',
+        }),
+      }
+    )
+
+    expect(response.status).toBe(400)
+    expect(localLoginMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/kaede/src/routes/organization-local-auth/local-login.ts
+++ b/apps/kaede/src/routes/organization-local-auth/local-login.ts
@@ -1,0 +1,129 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { errorResponseSchema } from '../../schemas/common.js'
+import {
+  localOrganizationLoginRequestSchema,
+  localOrganizationLoginResponseSchema,
+  organizationLocalAuthParamsSchema,
+} from '../../schemas/organization-local-auth.js'
+import { loginToOrganizationWithLocalCredential } from '../../usecases/organization-local-auth/index.js'
+import { getSessionTokenFromCookie, setSessionCookie } from '../auth/cookie.js'
+
+const localAuthError = (type: string) => {
+  switch (type) {
+    case 'AUTH_METHOD_NOT_ALLOWED':
+      return {
+        status: 403 as const,
+        body: {
+          error_code: type,
+          error_message: 'local authentication is not allowed for this organization',
+        },
+      }
+    case 'AUTH_IDENTITY_USER_MISMATCH':
+      return {
+        status: 403 as const,
+        body: {
+          error_code: type,
+          error_message: 'the credential belongs to a different user',
+        },
+      }
+    case 'AUTH_MEMBERSHIP_NOT_ACTIVE':
+      return {
+        status: 403 as const,
+        body: { error_code: type, error_message: 'organization membership is not active' },
+      }
+    case 'AUTH_USER_DISABLED':
+      return {
+        status: 403 as const,
+        body: { error_code: type, error_message: 'user is disabled' },
+      }
+    case 'AUTH_CREDENTIAL_LOCKED':
+      return {
+        status: 429 as const,
+        body: { error_code: type, error_message: 'local credential is temporarily locked' },
+      }
+    case 'AUTH_SESSION_EXPIRED':
+      return {
+        status: 401 as const,
+        body: { error_code: type, error_message: 'session expired' },
+      }
+    case 'AUTH_SESSION_REVOKED':
+      return {
+        status: 401 as const,
+        body: { error_code: type, error_message: 'session revoked' },
+      }
+    default:
+      return {
+        status: 401 as const,
+        body: {
+          error_code: 'AUTH_INVALID_CREDENTIALS',
+          error_message: 'invalid email or password',
+        },
+      }
+  }
+}
+
+export const registerLocalOrganizationLoginRoute = (app: OpenAPIHono) => {
+  const route = createRoute({
+    method: 'post',
+    path: '/{organizationSlug}/auth/local/login',
+    tags: ['Organization Auth'],
+    description: 'Membership単位のLocal CredentialでOrganizationへ認証する',
+    request: {
+      params: organizationLocalAuthParamsSchema,
+      body: {
+        content: { 'application/json': { schema: localOrganizationLoginRequestSchema } },
+      },
+    },
+    responses: {
+      200: {
+        description: 'local authentication succeeded',
+        content: { 'application/json': { schema: localOrganizationLoginResponseSchema } },
+      },
+      401: {
+        description: 'invalid credentials or session',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      403: {
+        description: 'local authentication is not allowed',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      429: {
+        description: 'credential is locked',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+    },
+  })
+
+  app.openapi(route, async (c) => {
+    const { organizationSlug } = c.req.valid('param')
+    const result = await loginToOrganizationWithLocalCredential(
+      organizationSlug,
+      getSessionTokenFromCookie(c),
+      c.req.valid('json'),
+      {
+        requestId: c.req.header('x-request-id'),
+        userAgent: c.req.header('user-agent'),
+      }
+    )
+
+    if (!result.ok) {
+      const error = localAuthError(result.error.type)
+      return c.json(error.body, error.status)
+    }
+
+    if (result.value.sessionToken) {
+      setSessionCookie(c, result.value.sessionToken)
+    }
+
+    return c.json(
+      {
+        session: { expires_at: result.value.session.expires_at },
+        membership: result.value.membership,
+        grant: result.value.grant,
+        return_to: result.value.return_to,
+      },
+      200
+    )
+  })
+}

--- a/apps/kaede/src/schemas/organization-local-auth.ts
+++ b/apps/kaede/src/schemas/organization-local-auth.ts
@@ -1,0 +1,42 @@
+import { z } from '@hono/zod-openapi'
+import { isoDatetimeSchema, membershipRoleSchema, uuidSchema } from './common.js'
+import { organizationSlugSchema } from './organizations.js'
+
+export const organizationLocalAuthParamsSchema = z
+  .object({ organizationSlug: organizationSlugSchema })
+  .openapi('OrganizationLocalAuthParams')
+
+export const localOrganizationLoginRequestSchema = z
+  .object({
+    login_email: z.string().email().max(255),
+    password: z.string().min(1).max(100),
+    return_to: z
+      .string()
+      .min(1)
+      .max(2048)
+      .refine(
+        (value) => value.startsWith('/') && !value.startsWith('//') && !value.includes('\\'),
+        'return_to must be a safe application-relative path'
+      ),
+  })
+  .openapi('LocalOrganizationLoginRequest')
+
+export const localOrganizationLoginResponseSchema = z
+  .object({
+    session: z.object({ expires_at: isoDatetimeSchema }),
+    membership: z.object({
+      id: uuidSchema,
+      organization_id: uuidSchema,
+      role: membershipRoleSchema,
+      status: z.literal('active'),
+    }),
+    grant: z.object({
+      auth_method: z.literal('local'),
+      authenticated_at: isoDatetimeSchema,
+      expires_at: isoDatetimeSchema,
+    }),
+    return_to: localOrganizationLoginRequestSchema.shape.return_to,
+  })
+  .openapi('LocalOrganizationLoginResponse')
+
+export type LocalOrganizationLoginRequest = z.infer<typeof localOrganizationLoginRequestSchema>

--- a/apps/kaede/src/server.ts
+++ b/apps/kaede/src/server.ts
@@ -6,6 +6,7 @@ import { HTTPException } from 'hono/http-exception'
 import { getRuntimeConfig } from './config/runtime.js'
 import { requestActorMiddleware } from './middleware/request-actor.js'
 import { registerApiRoutes } from './routes/index.js'
+import { organizationLocalAuthRoutes } from './routes/organization-local-auth/index.js'
 
 export const createApp = () => {
   const app = new OpenAPIHono()
@@ -31,6 +32,9 @@ export const createApp = () => {
       })
     )
   }
+
+  // Local loginはSessionなしでも利用でき、Sessionがある場合だけreauthenticateとして扱う。
+  app.route('/api/organizations', organizationLocalAuthRoutes)
 
   app.onError((err, c) => {
     Sentry.captureException(err)

--- a/apps/kaede/src/services/organization-local-auth/index.ts
+++ b/apps/kaede/src/services/organization-local-auth/index.ts
@@ -1,0 +1,9 @@
+export {
+  findLocalCredentialContextForUpdate,
+  findOrganizationLocalAuthPolicyBySlug,
+  hasLocalAuthenticationGrantBySessionId,
+  insertAuthenticationEvent,
+  normalizeLocalLoginEmail,
+  updateLocalCredentialAttempts,
+  upsertLocalMembershipGrant,
+} from './repository.js'

--- a/apps/kaede/src/services/organization-local-auth/repository.ts
+++ b/apps/kaede/src/services/organization-local-auth/repository.ts
@@ -1,0 +1,127 @@
+import type { Insertable, Selectable } from 'kysely'
+import type {
+  AuthenticationEvents,
+  OrganizationLocalCredentials,
+  SessionMembershipAuthentications,
+} from '../db/generated.js'
+import { db } from '../db/index.js'
+import type { DbExecutor } from '../executor.js'
+
+export type OrganizationLocalCredential = Selectable<OrganizationLocalCredentials>
+
+export const normalizeLocalLoginEmail = (email: string) => email.trim().toLowerCase()
+
+export const findOrganizationLocalAuthPolicyBySlug = async (
+  organizationSlug: string,
+  executor: DbExecutor = db
+) => {
+  return executor
+    .selectFrom('organizations as organization')
+    .innerJoin(
+      'organization_auth_settings as auth_settings',
+      'auth_settings.organization_id',
+      'organization.id'
+    )
+    .select([
+      'organization.id as organization_id',
+      'organization.status as organization_status',
+      'auth_settings.local_auth_enabled',
+      'auth_settings.policy_version',
+      'auth_settings.membership_grant_ttl_seconds',
+    ])
+    .where('organization.slug', '=', organizationSlug)
+    .executeTakeFirst()
+}
+
+export const findLocalCredentialContextForUpdate = async (
+  organizationId: string,
+  normalizedLoginEmail: string,
+  executor: DbExecutor
+) => {
+  return executor
+    .selectFrom('organization_local_credentials as credential')
+    .innerJoin(
+      'organization_memberships as membership',
+      'membership.id',
+      'credential.membership_id'
+    )
+    .innerJoin('users as user', 'user.id', 'membership.user_id')
+    .select([
+      'credential.id as credential_id',
+      'credential.membership_id',
+      'credential.organization_id',
+      'credential.password_hash',
+      'credential.failed_login_attempts',
+      'credential.locked_until',
+      'credential.enabled as credential_enabled',
+      'membership.user_id',
+      'membership.role as membership_role',
+      'membership.status as membership_status',
+      'user.status as user_status',
+    ])
+    .where('credential.organization_id', '=', organizationId)
+    .where('credential.normalized_login_email', '=', normalizedLoginEmail)
+    .where('credential.enabled', '=', true)
+    .forUpdate()
+    .executeTakeFirst()
+}
+
+export const updateLocalCredentialAttempts = async (
+  credentialId: string,
+  values: { failed_login_attempts: number; locked_until: Date | null },
+  executor: DbExecutor
+) => {
+  return executor
+    .updateTable('organization_local_credentials')
+    .set(values)
+    .where('id', '=', credentialId)
+    .executeTakeFirst()
+}
+
+export const hasLocalAuthenticationGrantBySessionId = async (
+  sessionId: string,
+  executor: DbExecutor = db
+) => {
+  const grant = await executor
+    .selectFrom('session_membership_authentications')
+    .select('session_id')
+    .where('session_id', '=', sessionId)
+    .where('auth_method', '=', 'local')
+    .executeTakeFirst()
+
+  return grant !== undefined
+}
+
+export const upsertLocalMembershipGrant = async (
+  grant: Insertable<SessionMembershipAuthentications>,
+  executor: DbExecutor
+) => {
+  return executor
+    .insertInto('session_membership_authentications')
+    .values(grant)
+    .onConflict((oc) =>
+      oc.columns(['session_id', 'membership_id']).doUpdateSet({
+        user_id: grant.user_id,
+        auth_method: grant.auth_method,
+        policy_version: grant.policy_version,
+        local_credential_id: grant.local_credential_id,
+        member_oidc_identity_id: null,
+        authenticated_at: grant.authenticated_at,
+        expires_at: grant.expires_at,
+        revoked_at: null,
+      })
+    )
+    .returningAll()
+    .executeTakeFirstOrThrow()
+}
+
+export const insertAuthenticationEvent = async (
+  event: Insertable<AuthenticationEvents>,
+  executor: DbExecutor
+) => {
+  return executor
+    .insertInto('authentication_events')
+    .values(event)
+    .returningAll()
+    .executeTakeFirstOrThrow()
+}

--- a/apps/kaede/src/usecases/organization-local-auth/index.ts
+++ b/apps/kaede/src/usecases/organization-local-auth/index.ts
@@ -1,0 +1,6 @@
+export { loginToOrganizationWithLocalCredential } from './login.js'
+export type {
+  LocalOrganizationLoginError,
+  LocalOrganizationLoginMetadata,
+  LocalOrganizationLoginResult,
+} from './login.js'

--- a/apps/kaede/src/usecases/organization-local-auth/login.ts
+++ b/apps/kaede/src/usecases/organization-local-auth/login.ts
@@ -1,0 +1,268 @@
+import type { LocalOrganizationLoginRequest } from '../../schemas/organization-local-auth.js'
+import { createSession, findValidSessionByToken } from '../../services/auth/index.js'
+import { verifyPassword } from '../../services/auth/password.js'
+import { db } from '../../services/db/index.js'
+import type { DbExecutor } from '../../services/executor.js'
+import {
+  findLocalCredentialContextForUpdate,
+  findOrganizationLocalAuthPolicyBySlug,
+  insertAuthenticationEvent,
+  normalizeLocalLoginEmail,
+  updateLocalCredentialAttempts,
+  upsertLocalMembershipGrant,
+} from '../../services/organization-local-auth/index.js'
+
+const MAX_FAILED_LOGIN_ATTEMPTS = 5
+const LOGIN_LOCK_DURATION_MS = 15 * 60 * 1000
+const DUMMY_PASSWORD_HASH =
+  '$argon2id$v=19$m=65536,t=3,p=4$x+P5/ReUqXmnmvL6nvl/sw$U6rmJ/nwCpXHwg93wQKEQxKBgVGC6n+ZSV1KumkR8i8'
+
+export type LocalOrganizationLoginError =
+  | { type: 'AUTH_INVALID_CREDENTIALS' }
+  | { type: 'AUTH_METHOD_NOT_ALLOWED' }
+  | { type: 'AUTH_CREDENTIAL_LOCKED' }
+  | { type: 'AUTH_IDENTITY_USER_MISMATCH' }
+  | { type: 'AUTH_MEMBERSHIP_NOT_ACTIVE' }
+  | { type: 'AUTH_USER_DISABLED' }
+  | { type: 'AUTH_SESSION_EXPIRED' }
+  | { type: 'AUTH_SESSION_REVOKED' }
+
+export type LocalOrganizationLoginResult =
+  | {
+      ok: true
+      value: {
+        sessionToken?: string
+        session: { id: string; expires_at: string }
+        membership: {
+          id: string
+          organization_id: string
+          role: 'member' | 'manager' | 'owner'
+          status: 'active'
+        }
+        grant: {
+          auth_method: 'local'
+          authenticated_at: string
+          expires_at: string
+        }
+        return_to: string
+      }
+    }
+  | { ok: false; error: LocalOrganizationLoginError }
+
+export interface LocalOrganizationLoginMetadata {
+  requestId?: string
+  userAgent?: string
+}
+
+const runInTransaction = async <T>(
+  executor: DbExecutor | undefined,
+  callback: (trx: DbExecutor) => Promise<T>
+): Promise<T> => {
+  const baseExecutor = executor ?? db
+
+  if ('transaction' in baseExecutor) {
+    return baseExecutor.transaction().execute((trx) => callback(trx))
+  }
+
+  return callback(baseExecutor)
+}
+
+const sessionError = (
+  error: 'SESSION_NOT_FOUND' | 'SESSION_EXPIRED' | 'SESSION_REVOKED'
+): LocalOrganizationLoginError => {
+  switch (error) {
+    case 'SESSION_EXPIRED':
+      return { type: 'AUTH_SESSION_EXPIRED' }
+    case 'SESSION_REVOKED':
+      return { type: 'AUTH_SESSION_REVOKED' }
+    case 'SESSION_NOT_FOUND':
+      return { type: 'AUTH_INVALID_CREDENTIALS' }
+  }
+}
+
+export const loginToOrganizationWithLocalCredential = async (
+  organizationSlug: string,
+  sessionToken: string | undefined,
+  payload: LocalOrganizationLoginRequest,
+  metadata: LocalOrganizationLoginMetadata = {},
+  now: Date = new Date(),
+  executor?: DbExecutor
+): Promise<LocalOrganizationLoginResult> => {
+  return runInTransaction(executor, async (trx) => {
+    const policy = await findOrganizationLocalAuthPolicyBySlug(organizationSlug, trx)
+
+    if (!policy?.local_auth_enabled || policy.organization_status !== 'active') {
+      return { ok: false, error: { type: 'AUTH_METHOD_NOT_ALLOWED' } } as const
+    }
+
+    const normalizedLoginEmail = normalizeLocalLoginEmail(payload.login_email)
+    const credential = await findLocalCredentialContextForUpdate(
+      policy.organization_id,
+      normalizedLoginEmail,
+      trx
+    )
+
+    if (!credential) {
+      await verifyPassword(DUMMY_PASSWORD_HASH, payload.password)
+      await insertAuthenticationEvent(
+        {
+          event_type: 'local_login',
+          outcome: 'failure',
+          failure_code: 'AUTH_INVALID_CREDENTIALS',
+          organization_id: policy.organization_id,
+          auth_method: 'local',
+          request_id: metadata.requestId ?? null,
+          user_agent: metadata.userAgent ?? null,
+        },
+        trx
+      )
+      return { ok: false, error: { type: 'AUTH_INVALID_CREDENTIALS' } } as const
+    }
+
+    const eventType = sessionToken ? 'local_reauthenticate' : 'local_login'
+    const eventContext = {
+      event_type: eventType,
+      user_id: credential.user_id,
+      organization_id: credential.organization_id,
+      membership_id: credential.membership_id,
+      auth_method: 'local' as const,
+      credential_reference_id: credential.credential_id,
+      request_id: metadata.requestId ?? null,
+      user_agent: metadata.userAgent ?? null,
+    }
+
+    if (credential.locked_until && credential.locked_until > now) {
+      await insertAuthenticationEvent(
+        {
+          ...eventContext,
+          outcome: 'failure',
+          failure_code: 'AUTH_CREDENTIAL_LOCKED',
+        },
+        trx
+      )
+      return { ok: false, error: { type: 'AUTH_CREDENTIAL_LOCKED' } } as const
+    }
+
+    const passwordMatches = await verifyPassword(credential.password_hash, payload.password)
+
+    if (!passwordMatches) {
+      const failedAttempts = credential.failed_login_attempts + 1
+      const lockedUntil =
+        failedAttempts >= MAX_FAILED_LOGIN_ATTEMPTS
+          ? new Date(now.getTime() + LOGIN_LOCK_DURATION_MS)
+          : null
+
+      await updateLocalCredentialAttempts(
+        credential.credential_id,
+        { failed_login_attempts: failedAttempts, locked_until: lockedUntil },
+        trx
+      )
+      await insertAuthenticationEvent(
+        {
+          ...eventContext,
+          outcome: 'failure',
+          failure_code: lockedUntil ? 'AUTH_CREDENTIAL_LOCKED' : 'AUTH_INVALID_CREDENTIALS',
+        },
+        trx
+      )
+      return lockedUntil
+        ? ({ ok: false, error: { type: 'AUTH_CREDENTIAL_LOCKED' } } as const)
+        : ({ ok: false, error: { type: 'AUTH_INVALID_CREDENTIALS' } } as const)
+    }
+
+    if (credential.user_status !== 'active') {
+      return { ok: false, error: { type: 'AUTH_USER_DISABLED' } } as const
+    }
+
+    if (credential.membership_status !== 'active' || !credential.membership_id) {
+      return { ok: false, error: { type: 'AUTH_MEMBERSHIP_NOT_ACTIVE' } } as const
+    }
+
+    let activeSession
+    let createdSessionToken: string | undefined
+
+    if (sessionToken) {
+      const sessionResult = await findValidSessionByToken(sessionToken, now, trx)
+      if (!sessionResult.ok) {
+        return { ok: false, error: sessionError(sessionResult.error) } as const
+      }
+      if (sessionResult.session.user_id !== credential.user_id) {
+        await insertAuthenticationEvent(
+          {
+            ...eventContext,
+            session_id: sessionResult.session.id,
+            outcome: 'failure',
+            failure_code: 'AUTH_IDENTITY_USER_MISMATCH',
+          },
+          trx
+        )
+        return { ok: false, error: { type: 'AUTH_IDENTITY_USER_MISMATCH' } } as const
+      }
+      activeSession = sessionResult.session
+    } else {
+      const created = await createSession(
+        { authMethod: 'password', userId: credential.user_id, now },
+        trx
+      )
+      activeSession = created.session
+      createdSessionToken = created.token
+    }
+
+    const authenticatedAt = now
+    const grantExpiresAt = new Date(
+      authenticatedAt.getTime() + policy.membership_grant_ttl_seconds * 1000
+    )
+    const grant = await upsertLocalMembershipGrant(
+      {
+        session_id: activeSession.id,
+        membership_id: credential.membership_id,
+        user_id: credential.user_id,
+        auth_method: 'local',
+        policy_version: policy.policy_version,
+        local_credential_id: credential.credential_id,
+        member_oidc_identity_id: null,
+        authenticated_at: authenticatedAt,
+        expires_at: grantExpiresAt,
+        revoked_at: null,
+      },
+      trx
+    )
+
+    await updateLocalCredentialAttempts(
+      credential.credential_id,
+      { failed_login_attempts: 0, locked_until: null },
+      trx
+    )
+    await insertAuthenticationEvent(
+      {
+        ...eventContext,
+        session_id: activeSession.id,
+        outcome: 'success',
+      },
+      trx
+    )
+
+    return {
+      ok: true,
+      value: {
+        sessionToken: createdSessionToken,
+        session: {
+          id: activeSession.id,
+          expires_at: activeSession.expires_at.toISOString(),
+        },
+        membership: {
+          id: credential.membership_id,
+          organization_id: credential.organization_id,
+          role: credential.membership_role as 'member' | 'manager' | 'owner',
+          status: 'active',
+        },
+        grant: {
+          auth_method: 'local',
+          authenticated_at: grant.authenticated_at.toISOString(),
+          expires_at: grant.expires_at.toISOString(),
+        },
+        return_to: payload.return_to,
+      },
+    }
+  })
+}

--- a/apps/kaede/tests/services/auth/organization-local-auth.test.ts
+++ b/apps/kaede/tests/services/auth/organization-local-auth.test.ts
@@ -1,0 +1,366 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { hashPassword } from '../../../src/services/auth/password.js'
+import { createSession } from '../../../src/services/auth/session-repository.js'
+import { createDb } from '../../../src/services/db/client.js'
+import { loginToOrganizationWithLocalCredential } from '../../../src/usecases/organization-local-auth/login.js'
+import { resetDatabase } from '../../db/helpers.js'
+
+const db = createDb()
+const now = new Date('2026-08-11T10:00:00.000Z')
+
+const createLocalMembership = async ({
+  organizationName,
+  organizationSlug,
+  legacyEmail,
+  loginEmail,
+  password,
+  contactEmail = null,
+}: {
+  organizationName: string
+  organizationSlug: string
+  legacyEmail: string
+  loginEmail: string
+  password: string
+  contactEmail?: string | null
+}) => {
+  const user = await db
+    .insertInto('users')
+    .values({
+      email: legacyEmail,
+      contact_email: contactEmail,
+      normalized_contact_email: contactEmail,
+      display_name: legacyEmail,
+      password_hash: null,
+      global_role: 'none',
+      status: 'active',
+      password_changed_at: null,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const organization = await db
+    .insertInto('organizations')
+    .values({ name: organizationName, slug: organizationSlug })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  await db
+    .insertInto('organization_auth_settings')
+    .values({
+      organization_id: organization.id,
+      local_auth_enabled: true,
+      oidc_auth_enabled: false,
+      membership_grant_ttl_seconds: 28_800,
+      reauthentication_interval_seconds: 14_400,
+    })
+    .execute()
+  const membership = await db
+    .insertInto('organization_memberships')
+    .values({ organization_id: organization.id, user_id: user.id, role: 'member' })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  if (!membership.id) throw new Error('membership id is required')
+  const credential = await db
+    .insertInto('organization_local_credentials')
+    .values({
+      membership_id: membership.id,
+      organization_id: organization.id,
+      login_email: loginEmail,
+      normalized_login_email: loginEmail.trim().toLowerCase(),
+      password_hash: await hashPassword(password),
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+  return { credential, membership: { ...membership, id: membership.id }, organization, user }
+}
+
+describe('organization local authentication', () => {
+  beforeEach(async () => {
+    await resetDatabase(db)
+  })
+
+  afterAll(async () => {
+    await db.destroy()
+  })
+
+  it('Organizationと正規化emailでCredentialを検索し、Sessionと対象Grantを作る', async () => {
+    const fixture = await createLocalMembership({
+      organizationName: 'Organization A',
+      organizationSlug: 'organization-a',
+      legacyEmail: 'legacy@example.test',
+      contactEmail: 'LOCAL@EXAMPLE.TEST',
+      loginEmail: 'local@example.test',
+      password: 'organization-a-password',
+    })
+
+    const result = await loginToOrganizationWithLocalCredential(
+      'organization-a',
+      undefined,
+      {
+        login_email: '  LOCAL@example.test  ',
+        password: 'organization-a-password',
+        return_to: '/orgs/organization-a/dashboard',
+      },
+      {},
+      now,
+      db
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.value.sessionToken).toBeDefined()
+    expect(result.value.membership.id).toBe(fixture.membership.id)
+    expect(result.value.grant).toEqual({
+      auth_method: 'local',
+      authenticated_at: now.toISOString(),
+      expires_at: '2026-08-11T18:00:00.000Z',
+    })
+
+    const grant = await db
+      .selectFrom('session_membership_authentications')
+      .selectAll()
+      .where('membership_id', '=', fixture.membership.id)
+      .executeTakeFirstOrThrow()
+    expect(grant.user_id).toBe(fixture.user.id)
+    expect(grant.local_credential_id).toBe(fixture.credential.id)
+    expect(grant.policy_version).toBe('1')
+    await expect(
+      db.selectFrom('authentication_events').selectAll().execute()
+    ).resolves.toMatchObject([{ outcome: 'success', event_type: 'local_login' }])
+  })
+
+  it('同じlogin emailでもOrganizationごとのpasswordを分離する', async () => {
+    await createLocalMembership({
+      organizationName: 'Organization A',
+      organizationSlug: 'organization-a',
+      legacyEmail: 'a@example.test',
+      loginEmail: 'shared@example.test',
+      password: 'organization-a-password',
+    })
+    const organizationB = await createLocalMembership({
+      organizationName: 'Organization B',
+      organizationSlug: 'organization-b',
+      legacyEmail: 'b@example.test',
+      loginEmail: 'shared@example.test',
+      password: 'organization-b-password',
+    })
+
+    const result = await loginToOrganizationWithLocalCredential(
+      'organization-b',
+      undefined,
+      {
+        login_email: 'shared@example.test',
+        password: 'organization-a-password',
+        return_to: '/orgs/organization-b',
+      },
+      {},
+      now,
+      db
+    )
+
+    expect(result).toEqual({ ok: false, error: { type: 'AUTH_INVALID_CREDENTIALS' } })
+    const credential = await db
+      .selectFrom('organization_local_credentials')
+      .selectAll()
+      .where('id', '=', organizationB.credential.id)
+      .executeTakeFirstOrThrow()
+    expect(credential.failed_login_attempts).toBe(1)
+  })
+
+  it('User contact_emailをLocal認証の検索キーにしない', async () => {
+    await createLocalMembership({
+      organizationName: 'Contact Organization',
+      organizationSlug: 'contact-organization',
+      legacyEmail: 'legacy-contact@example.test',
+      contactEmail: 'contact@example.test',
+      loginEmail: 'local-login@example.test',
+      password: 'local-password',
+    })
+
+    const result = await loginToOrganizationWithLocalCredential(
+      'contact-organization',
+      undefined,
+      {
+        login_email: 'contact@example.test',
+        password: 'local-password',
+        return_to: '/orgs/contact-organization',
+      },
+      {},
+      now,
+      db
+    )
+
+    expect(result).toEqual({ ok: false, error: { type: 'AUTH_INVALID_CREDENTIALS' } })
+  })
+
+  it('既存SessionのUserが一致すればSessionを維持し対象Membership Grantだけ追加する', async () => {
+    const organizationA = await createLocalMembership({
+      organizationName: 'Organization A',
+      organizationSlug: 'organization-a',
+      legacyEmail: 'same-user@example.test',
+      loginEmail: 'a-login@example.test',
+      password: 'password-a',
+    })
+    const organizationB = await db
+      .insertInto('organizations')
+      .values({ name: 'Organization B', slug: 'organization-b' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    await db
+      .insertInto('organization_auth_settings')
+      .values({
+        organization_id: organizationB.id,
+        local_auth_enabled: true,
+        oidc_auth_enabled: false,
+        membership_grant_ttl_seconds: 28_800,
+        reauthentication_interval_seconds: 14_400,
+      })
+      .execute()
+    const membershipB = await db
+      .insertInto('organization_memberships')
+      .values({ organization_id: organizationB.id, user_id: organizationA.user.id, role: 'member' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    if (!membershipB.id) throw new Error('membership id is required')
+    await db
+      .insertInto('organization_local_credentials')
+      .values({
+        membership_id: membershipB.id,
+        organization_id: organizationB.id,
+        login_email: 'b-login@example.test',
+        normalized_login_email: 'b-login@example.test',
+        password_hash: await hashPassword('password-b'),
+      })
+      .execute()
+    const existingSession = await createSession({ userId: organizationA.user.id, now }, db)
+
+    const result = await loginToOrganizationWithLocalCredential(
+      'organization-b',
+      existingSession.token,
+      {
+        login_email: 'b-login@example.test',
+        password: 'password-b',
+        return_to: '/orgs/organization-b',
+      },
+      {},
+      now,
+      db
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.value.sessionToken).toBeUndefined()
+    expect(result.value.session.id).toBe(existingSession.session.id)
+    const grants = await db
+      .selectFrom('session_membership_authentications')
+      .select(['membership_id'])
+      .where('session_id', '=', existingSession.session.id)
+      .execute()
+    expect(grants).toEqual([{ membership_id: membershipB.id }])
+  })
+
+  it('既存SessionとCredentialのUserが異なる場合は拒否してGrantを作らない', async () => {
+    const sessionOwner = await createLocalMembership({
+      organizationName: 'Session Organization',
+      organizationSlug: 'session-organization',
+      legacyEmail: 'session-owner@example.test',
+      loginEmail: 'session-login@example.test',
+      password: 'session-password',
+    })
+    await createLocalMembership({
+      organizationName: 'Target Organization',
+      organizationSlug: 'target-organization',
+      legacyEmail: 'target-owner@example.test',
+      loginEmail: 'target-login@example.test',
+      password: 'target-password',
+    })
+    const session = await createSession({ userId: sessionOwner.user.id, now }, db)
+
+    const result = await loginToOrganizationWithLocalCredential(
+      'target-organization',
+      session.token,
+      {
+        login_email: 'target-login@example.test',
+        password: 'target-password',
+        return_to: '/orgs/target-organization',
+      },
+      {},
+      now,
+      db
+    )
+
+    expect(result).toEqual({
+      ok: false,
+      error: { type: 'AUTH_IDENTITY_USER_MISMATCH' },
+    })
+    await expect(
+      db.selectFrom('session_membership_authentications').selectAll().execute()
+    ).resolves.toEqual([])
+  })
+
+  it('失敗回数とlockoutはCredential単位で更新する', async () => {
+    const fixture = await createLocalMembership({
+      organizationName: 'Lock Organization',
+      organizationSlug: 'lock-organization',
+      legacyEmail: 'lock@example.test',
+      loginEmail: 'lock-login@example.test',
+      password: 'correct-password',
+    })
+    await db
+      .updateTable('organization_local_credentials')
+      .set({ failed_login_attempts: 4 })
+      .where('id', '=', fixture.credential.id)
+      .execute()
+
+    const result = await loginToOrganizationWithLocalCredential(
+      'lock-organization',
+      undefined,
+      {
+        login_email: 'lock-login@example.test',
+        password: 'wrong-password',
+        return_to: '/orgs/lock-organization',
+      },
+      {},
+      now,
+      db
+    )
+
+    expect(result).toEqual({ ok: false, error: { type: 'AUTH_CREDENTIAL_LOCKED' } })
+    const credential = await db
+      .selectFrom('organization_local_credentials')
+      .selectAll()
+      .where('id', '=', fixture.credential.id)
+      .executeTakeFirstOrThrow()
+    expect(credential.failed_login_attempts).toBe(5)
+    expect(credential.locked_until).toEqual(new Date('2026-08-11T10:15:00.000Z'))
+  })
+
+  it('Organization policyでLocal認証が無効ならCredentialを使用しない', async () => {
+    const fixture = await createLocalMembership({
+      organizationName: 'OIDC Organization',
+      organizationSlug: 'oidc-organization',
+      legacyEmail: 'oidc@example.test',
+      loginEmail: 'oidc-login@example.test',
+      password: 'local-password',
+    })
+    await db
+      .updateTable('organization_auth_settings')
+      .set({ local_auth_enabled: false, oidc_auth_enabled: true })
+      .where('organization_id', '=', fixture.organization.id)
+      .execute()
+
+    const result = await loginToOrganizationWithLocalCredential(
+      'oidc-organization',
+      undefined,
+      {
+        login_email: 'oidc-login@example.test',
+        password: 'local-password',
+        return_to: '/orgs/oidc-organization',
+      },
+      {},
+      now,
+      db
+    )
+
+    expect(result).toEqual({ ok: false, error: { type: 'AUTH_METHOD_NOT_ALLOWED' } })
+  })
+})


### PR DESCRIPTION
# issue番号

- #219

# 変更内容(写真か動画も一緒に)

- Organizationと正規化したlogin emailでMembership単位Local Credentialを認証
- Organization auth policyでLocal認証の利用可否を判定
- 既存SessionのUser一致を確認し、対象Membership Grantのみ作成・更新
- Credential単位の失敗回数とlockout、認証eventを追加
- Organization Local login APIとroute testを追加

# 影響範囲(あれば)

- KaedeのOrganization Local認証とrequest actor middleware
- Profile、OIDC、Invite、Mio、migration/backfillは変更なし

## Tests

- ESLint
- tsc --noEmit
- Unit: 79 files / 440 tests passed
- Database: 26 files / 220 tests passed