### PR TITLE
Add membership profile APIs

### DIFF
--- a/apps/kaede/src/routes/index.ts
+++ b/apps/kaede/src/routes/index.ts
@@ -11,6 +11,7 @@ import { pedestriansRoutes } from './pedestrians/index.js'
 import { platformRoutes } from './platform/index.js'
 import { recordingsRoutes } from './recordings/index.js'
 import { trajectoriesRoutes } from './trajectories/index.js'
+import { usersRoutes } from './users/index.js'
 
 export const registerApiRoutes = (app: OpenAPIHono) => {
   const api = new OpenAPIHono()
@@ -27,6 +28,7 @@ export const registerApiRoutes = (app: OpenAPIHono) => {
   api.route('/platform', platformRoutes)
   api.route('/recordings', recordingsRoutes)
   api.route('/trajectories', trajectoriesRoutes)
+  api.route('/users', usersRoutes)
 
   app.route('/api', api)
 }

--- a/apps/kaede/src/routes/organizations/create-organization-user.test.ts
+++ b/apps/kaede/src/routes/organizations/create-organization-user.test.ts
@@ -155,8 +155,8 @@ describe('POST /api/organizations/:organizationId/users', () => {
           pedestrian_id: '33333333-3333-4333-8333-333333333333',
           organization_id: '11111111-1111-4111-8111-111111111111',
           display_name: 'Pedestrian A',
-          height: 170.5,
-          stride_length: 72,
+          height: 1.705,
+          stride_length: 0.72,
           attributes: {
             team: 'A',
           },
@@ -182,8 +182,8 @@ describe('POST /api/organizations/:organizationId/users', () => {
           create_pedestrian: true,
           pedestrian: {
             display_name: 'Pedestrian A',
-            height: 170.5,
-            stride_length: 72,
+            height: 1.705,
+            stride_length: 0.72,
             attributes: {
               team: 'A',
             },
@@ -210,8 +210,8 @@ describe('POST /api/organizations/:organizationId/users', () => {
         create_pedestrian: true,
         pedestrian: {
           display_name: 'Pedestrian A',
-          height: 170.5,
-          stride_length: 72,
+          height: 1.705,
+          stride_length: 0.72,
           attributes: {
             team: 'A',
           },

--- a/apps/kaede/src/routes/organizations/index.ts
+++ b/apps/kaede/src/routes/organizations/index.ts
@@ -16,6 +16,7 @@ import { registerListOrganizationRecordingsRoute } from './list-organization-rec
 import { registerListOrganizationTrajectoriesRoute } from './list-organization-trajectories.js'
 import { registerListOrganizationUsersRoute } from './list-organization-users.js'
 import { registerListOrganizationsRoute } from './list-organizations.js'
+import { registerOrganizationMemberProfileRoutes } from './member-profiles.js'
 
 export const organizationsRoutes = new OpenAPIHono()
 
@@ -36,3 +37,4 @@ registerCreateOrganizationUserActivationLinkRoute(organizationsRoutes)
 registerCreateOrganizationMembershipRoute(organizationsRoutes)
 registerCreateStayHeatmapRoute(organizationsRoutes)
 registerAnalysisRunRoutes(organizationsRoutes)
+registerOrganizationMemberProfileRoutes(organizationsRoutes)

--- a/apps/kaede/src/routes/organizations/member-profiles.test.ts
+++ b/apps/kaede/src/routes/organizations/member-profiles.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import { createRouteTestApp } from '../create-route-test-app.js'
+import { registerOrganizationMemberProfileRoutes } from './member-profiles.js'
+
+const mocks = vi.hoisted(() => ({
+  getMyOrganizationMemberProfile: vi.fn(),
+  updateMyOrganizationMemberProfile: vi.fn(),
+  updateOrganizationMemberProfile: vi.fn(),
+}))
+
+vi.mock('../../usecases/profiles/index.js', () => mocks)
+
+const organizationId = '11111111-1111-4111-8111-111111111111'
+const membershipId = '22222222-2222-4222-8222-222222222222'
+const actor: RequestActor = {
+  type: 'user',
+  user_id: '33333333-3333-4333-8333-333333333333',
+  email: 'manager@example.com',
+  global_role: 'none',
+  account_state: 'active',
+  memberships: [{ organization_id: organizationId, organization_name: 'Example', role: 'manager' }],
+}
+
+const profile = {
+  organization_id: organizationId,
+  membership_id: membershipId,
+  global: { display_name: 'Alice' },
+  override: { display_name: null, height_meters: 1.705, stride_length_meters: 0.72 },
+  effective: { display_name: 'Alice', display_name_source: 'global' },
+  updated_at: '2026-08-11T00:00:00.000Z',
+}
+
+describe('organization member profile routes', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('本人の共通・override・実効Profileを返す', async () => {
+    mocks.getMyOrganizationMemberProfile.mockResolvedValue({ ok: true, value: profile })
+    const app = createRouteTestApp('/organizations', registerOrganizationMemberProfileRoutes, {
+      actor,
+    })
+
+    const response = await app.request(`/api/organizations/${organizationId}/members/me/profile`)
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual(profile)
+    expect(mocks.getMyOrganizationMemberProfile).toHaveBeenCalledWith(actor, organizationId)
+  })
+
+  it('managerによる第三者更新をmembership IDで処理する', async () => {
+    mocks.updateOrganizationMemberProfile.mockResolvedValue({
+      ok: true,
+      value: {
+        ...profile,
+        override: { ...profile.override, display_name: 'Managed' },
+        effective: { display_name: 'Managed', display_name_source: 'organization_override' },
+        update_context: { kind: 'forced', actor_role: 'manager' },
+      },
+    })
+    const app = createRouteTestApp('/organizations', registerOrganizationMemberProfileRoutes, {
+      actor,
+    })
+
+    const response = await app.request(
+      `/api/organizations/${organizationId}/members/${membershipId}/profile`,
+      {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ display_name: 'Managed' }),
+      }
+    )
+
+    expect(response.status).toBe(200)
+    expect(mocks.updateOrganizationMemberProfile).toHaveBeenCalledWith(
+      actor,
+      organizationId,
+      membershipId,
+      { display_name: 'Managed' }
+    )
+  })
+
+  it('height_metersが3mを超えるrequestを400で拒否する', async () => {
+    const app = createRouteTestApp('/organizations', registerOrganizationMemberProfileRoutes, {
+      actor,
+    })
+
+    const response = await app.request(`/api/organizations/${organizationId}/members/me/profile`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ height_meters: 170.5 }),
+    })
+
+    expect(response.status).toBe(400)
+    expect(mocks.updateMyOrganizationMemberProfile).not.toHaveBeenCalled()
+  })
+})

--- a/apps/kaede/src/routes/organizations/member-profiles.ts
+++ b/apps/kaede/src/routes/organizations/member-profiles.ts
@@ -1,0 +1,151 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { requireRequestActor } from '../../middleware/request-actor-context.js'
+import type { RequestActorContext } from '../../middleware/request-actor-context.js'
+import { errorResponseSchema } from '../../schemas/common.js'
+import {
+  organizationMemberProfileParamsSchema,
+  organizationMemberProfileSchema,
+  organizationMemberProfileUpdateResponseSchema,
+  organizationProfileParamsSchema,
+  updateOrganizationMemberProfileRequestSchema,
+} from '../../schemas/profiles.js'
+import {
+  getMyOrganizationMemberProfile,
+  updateMyOrganizationMemberProfile,
+  updateOrganizationMemberProfile,
+} from '../../usecases/profiles/index.js'
+import { toProfileErrorResponse } from '../profiles/error.js'
+
+const errorResponses = {
+  401: {
+    description: 'login required',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  403: {
+    description: 'permission denied or membership inactive',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  404: {
+    description: 'membership not found',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  409: {
+    description: 'membership migration is incomplete',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+} as const
+
+export const registerOrganizationMemberProfileRoutes = (app: OpenAPIHono) => {
+  const getMyRoute = createRoute({
+    method: 'get',
+    path: '/{organizationId}/members/me/profile',
+    tags: ['Organization Member Profiles'],
+    description: 'Organization共通値、override値、実効Profileを取得する',
+    request: { params: organizationProfileParamsSchema },
+    responses: {
+      200: {
+        description: 'organization member profile',
+        content: { 'application/json': { schema: organizationMemberProfileSchema } },
+      },
+      401: errorResponses[401],
+      403: errorResponses[403],
+      404: errorResponses[404],
+      409: errorResponses[409],
+    },
+  })
+
+  app.openapi(getMyRoute, async (c) => {
+    const { organizationId } = c.req.valid('param')
+    const result = await getMyOrganizationMemberProfile(
+      requireRequestActor(c as RequestActorContext),
+      organizationId
+    )
+    if (!result.ok) {
+      const error = toProfileErrorResponse(result.error)
+      return c.json(error.body, error.status)
+    }
+    return c.json(result.value, 200)
+  })
+
+  const patchMyRoute = createRoute({
+    method: 'patch',
+    path: '/{organizationId}/members/me/profile',
+    tags: ['Organization Member Profiles'],
+    description: '本人がOrganization内Profileを部分更新する。身長・歩幅の単位はメートル',
+    request: {
+      params: organizationProfileParamsSchema,
+      body: {
+        required: true,
+        content: { 'application/json': { schema: updateOrganizationMemberProfileRequestSchema } },
+      },
+    },
+    responses: {
+      200: {
+        description: 'updated organization member profile',
+        content: {
+          'application/json': { schema: organizationMemberProfileUpdateResponseSchema },
+        },
+      },
+      401: errorResponses[401],
+      403: errorResponses[403],
+      404: errorResponses[404],
+      409: errorResponses[409],
+    },
+  })
+
+  app.openapi(patchMyRoute, async (c) => {
+    const { organizationId } = c.req.valid('param')
+    const result = await updateMyOrganizationMemberProfile(
+      requireRequestActor(c as RequestActorContext),
+      organizationId,
+      c.req.valid('json')
+    )
+    if (!result.ok) {
+      const error = toProfileErrorResponse(result.error)
+      return c.json(error.body, error.status)
+    }
+    return c.json(result.value, 200)
+  })
+
+  const patchMemberRoute = createRoute({
+    method: 'patch',
+    path: '/{organizationId}/members/{membershipId}/profile',
+    tags: ['Organization Member Profiles'],
+    description: 'manager/ownerが管理対象MembershipのProfileを部分更新する',
+    request: {
+      params: organizationMemberProfileParamsSchema,
+      body: {
+        required: true,
+        content: { 'application/json': { schema: updateOrganizationMemberProfileRequestSchema } },
+      },
+    },
+    responses: {
+      200: {
+        description: 'forcibly updated organization member profile',
+        content: {
+          'application/json': { schema: organizationMemberProfileUpdateResponseSchema },
+        },
+      },
+      401: errorResponses[401],
+      403: errorResponses[403],
+      404: errorResponses[404],
+      409: errorResponses[409],
+    },
+  })
+
+  app.openapi(patchMemberRoute, async (c) => {
+    const { organizationId, membershipId } = c.req.valid('param')
+    const result = await updateOrganizationMemberProfile(
+      requireRequestActor(c as RequestActorContext),
+      organizationId,
+      membershipId,
+      c.req.valid('json')
+    )
+    if (!result.ok) {
+      const error = toProfileErrorResponse(result.error)
+      return c.json(error.body, error.status)
+    }
+    return c.json(result.value, 200)
+  })
+}

--- a/apps/kaede/src/routes/profiles/error.ts
+++ b/apps/kaede/src/routes/profiles/error.ts
@@ -1,0 +1,33 @@
+import type { ProfileError } from '../../usecases/profiles/index.js'
+import { toAuthorizationErrorResponse } from '../authorization-error.js'
+
+export const toProfileErrorResponse = (error: ProfileError) => {
+  switch (error.type) {
+    case 'AUTH_DASHBOARD_FORBIDDEN':
+    case 'AUTH_ORGANIZATION_FORBIDDEN':
+      return toAuthorizationErrorResponse(error)
+    case 'USER_NOT_FOUND':
+      return {
+        body: { error_code: error.type, error_message: 'user not found' },
+        status: 404 as const,
+      }
+    case 'MEMBERSHIP_NOT_FOUND':
+      return {
+        body: { error_code: error.type, error_message: 'membership not found' },
+        status: 404 as const,
+      }
+    case 'MEMBERSHIP_NOT_ACTIVE':
+      return {
+        body: { error_code: error.type, error_message: 'membership is not active' },
+        status: 403 as const,
+      }
+    case 'MEMBERSHIP_PROFILE_UNAVAILABLE':
+      return {
+        body: {
+          error_code: error.type,
+          error_message: 'membership profile is not available during migration',
+        },
+        status: 409 as const,
+      }
+  }
+}

--- a/apps/kaede/src/routes/users/index.ts
+++ b/apps/kaede/src/routes/users/index.ts
@@ -1,0 +1,7 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import type { RequestActorHonoEnv } from '../../middleware/request-actor-context.js'
+import { registerUserProfileRoutes } from './profile.js'
+
+export const usersRoutes = new OpenAPIHono<RequestActorHonoEnv>()
+
+registerUserProfileRoutes(usersRoutes)

--- a/apps/kaede/src/routes/users/profile.test.ts
+++ b/apps/kaede/src/routes/users/profile.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import { createRouteTestApp } from '../create-route-test-app.js'
+import { registerUserProfileRoutes } from './profile.js'
+
+const mocks = vi.hoisted(() => ({
+  getMyUserProfile: vi.fn(),
+  updateMyUserProfile: vi.fn(),
+}))
+
+vi.mock('../../usecases/profiles/index.js', () => mocks)
+
+const actor: RequestActor = {
+  type: 'user',
+  user_id: '11111111-1111-4111-8111-111111111111',
+  email: 'user@example.com',
+  global_role: 'none',
+  account_state: 'active',
+  memberships: [],
+}
+
+const responseProfile = {
+  user_id: '11111111-1111-4111-8111-111111111111',
+  display_name: 'Alice',
+  locale: 'ja-JP',
+  timezone: 'Asia/Tokyo',
+  updated_at: '2026-08-11T00:00:00.000Z',
+}
+
+describe('/api/users/me/profile', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('共通Profileを取得する', async () => {
+    mocks.getMyUserProfile.mockResolvedValue({ ok: true, value: responseProfile })
+    const app = createRouteTestApp('/users', registerUserProfileRoutes, { actor })
+
+    const response = await app.request('/api/users/me/profile')
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual(responseProfile)
+    expect(mocks.getMyUserProfile).toHaveBeenCalledWith(actor)
+  })
+
+  it('指定fieldだけをPATCHへ渡す', async () => {
+    mocks.updateMyUserProfile.mockResolvedValue({
+      ok: true,
+      value: { ...responseProfile, locale: 'en-US' },
+    })
+    const app = createRouteTestApp('/users', registerUserProfileRoutes, { actor })
+
+    const response = await app.request('/api/users/me/profile', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ locale: 'en-US' }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(mocks.updateMyUserProfile).toHaveBeenCalledWith(actor, { locale: 'en-US' })
+  })
+
+  it('空PATCHを400で拒否する', async () => {
+    const app = createRouteTestApp('/users', registerUserProfileRoutes, { actor })
+
+    const response = await app.request('/api/users/me/profile', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+
+    expect(response.status).toBe(400)
+    expect(mocks.updateMyUserProfile).not.toHaveBeenCalled()
+  })
+})

--- a/apps/kaede/src/routes/users/profile.ts
+++ b/apps/kaede/src/routes/users/profile.ts
@@ -1,0 +1,84 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { requireRequestActor } from '../../middleware/request-actor-context.js'
+import type { RequestActorHonoEnv } from '../../middleware/request-actor-context.js'
+import { errorResponseSchema } from '../../schemas/common.js'
+import { updateUserProfileRequestSchema, userProfileSchema } from '../../schemas/profiles.js'
+import { getMyUserProfile, updateMyUserProfile } from '../../usecases/profiles/index.js'
+import { toProfileErrorResponse } from '../profiles/error.js'
+
+export const registerUserProfileRoutes = (app: OpenAPIHono<RequestActorHonoEnv>) => {
+  const getRoute = createRoute({
+    method: 'get',
+    path: '/me/profile',
+    tags: ['Users'],
+    description: 'ログインUserのOrganization共通Profileを取得する',
+    responses: {
+      200: {
+        description: 'user profile',
+        content: { 'application/json': { schema: userProfileSchema } },
+      },
+      401: {
+        description: 'login required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      403: {
+        description: 'permission denied',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      404: {
+        description: 'user not found',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+    },
+  })
+
+  app.openapi(getRoute, async (c) => {
+    const result = await getMyUserProfile(requireRequestActor(c))
+    if (!result.ok) {
+      const error = toProfileErrorResponse(result.error)
+      return c.json(error.body, error.status as 403 | 404)
+    }
+    return c.json(result.value, 200)
+  })
+
+  const patchRoute = createRoute({
+    method: 'patch',
+    path: '/me/profile',
+    tags: ['Users'],
+    description: 'ログインUserのOrganization共通Profileを部分更新する',
+    request: {
+      body: {
+        required: true,
+        content: { 'application/json': { schema: updateUserProfileRequestSchema } },
+      },
+    },
+    responses: {
+      200: {
+        description: 'updated user profile',
+        content: { 'application/json': { schema: userProfileSchema } },
+      },
+      401: {
+        description: 'login required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      403: {
+        description: 'permission denied',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      404: {
+        description: 'user not found',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+    },
+  })
+
+  app.openapi(patchRoute, async (c) => {
+    const result = await updateMyUserProfile(requireRequestActor(c), c.req.valid('json'))
+    if (!result.ok) {
+      const error = toProfileErrorResponse(result.error)
+      return c.json(error.body, error.status as 403 | 404)
+    }
+    return c.json(result.value, 200)
+  })
+}

--- a/apps/kaede/src/schemas/profiles.ts
+++ b/apps/kaede/src/schemas/profiles.ts
@@ -1,0 +1,121 @@
+import { z } from '@hono/zod-openapi'
+import { isoDatetimeSchema, uuidSchema } from './common.js'
+
+const displayNameSchema = z.string().trim().min(1).max(255)
+
+const localeSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(64)
+  .refine((value) => {
+    try {
+      new Intl.Locale(value)
+      return true
+    } catch {
+      return false
+    }
+  }, 'locale must be a valid BCP 47 language tag')
+
+const timezoneSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(255)
+  .refine((value) => {
+    try {
+      new Intl.DateTimeFormat('en-US', { timeZone: value })
+      return true
+    } catch {
+      return false
+    }
+  }, 'timezone must be a valid IANA time zone')
+
+const heightMetersSchema = z.number().positive().max(3).nullable().openapi({
+  description: 'Organization内プロフィールで使用する身長（メートル）',
+  example: 1.705,
+})
+
+const strideLengthMetersSchema = z.number().positive().max(3).nullable().openapi({
+  description: 'Organization内プロフィールで使用する歩幅（メートル）',
+  example: 0.72,
+})
+
+export const userProfileSchema = z
+  .object({
+    user_id: uuidSchema,
+    display_name: displayNameSchema,
+    locale: localeSchema,
+    timezone: timezoneSchema,
+    updated_at: isoDatetimeSchema,
+  })
+  .openapi('UserProfile')
+
+export const updateUserProfileRequestSchema = z
+  .object({
+    display_name: displayNameSchema.optional(),
+    locale: localeSchema.optional(),
+    timezone: timezoneSchema.optional(),
+  })
+  .refine((payload) => Object.keys(payload).length > 0, 'at least one field is required')
+  .openapi('UpdateUserProfileRequest')
+
+export const organizationMemberProfileSchema = z
+  .object({
+    organization_id: uuidSchema,
+    membership_id: uuidSchema,
+    global: z.object({
+      display_name: displayNameSchema,
+    }),
+    override: z.object({
+      display_name: displayNameSchema.nullable(),
+      height_meters: heightMetersSchema,
+      stride_length_meters: strideLengthMetersSchema,
+    }),
+    effective: z.object({
+      display_name: displayNameSchema,
+      display_name_source: z.enum(['global', 'organization_override']),
+    }),
+    updated_at: isoDatetimeSchema.nullable(),
+  })
+  .openapi('OrganizationMemberProfile')
+
+export const organizationMemberProfileUpdateResponseSchema = organizationMemberProfileSchema
+  .extend({
+    update_context: z.discriminatedUnion('kind', [
+      z.object({ kind: z.literal('self') }),
+      z.object({
+        kind: z.literal('forced'),
+        actor_role: z.enum(['manager', 'owner', 'global_admin']),
+      }),
+    ]),
+  })
+  .openapi('OrganizationMemberProfileUpdateResponse')
+
+export const updateOrganizationMemberProfileRequestSchema = z
+  .object({
+    display_name: displayNameSchema.nullable().optional(),
+    height_meters: heightMetersSchema.optional(),
+    stride_length_meters: strideLengthMetersSchema.optional(),
+  })
+  .refine((payload) => Object.keys(payload).length > 0, 'at least one field is required')
+  .openapi('UpdateOrganizationMemberProfileRequest')
+
+export const organizationMemberProfileParamsSchema = z.object({
+  organizationId: uuidSchema,
+  membershipId: uuidSchema,
+})
+
+export const organizationProfileParamsSchema = z.object({
+  organizationId: uuidSchema,
+})
+
+export type UserProfileResponse = z.infer<typeof userProfileSchema>
+export type UpdateUserProfileRequest = z.infer<typeof updateUserProfileRequestSchema>
+export type OrganizationMemberProfileResponse = z.infer<typeof organizationMemberProfileSchema>
+export type OrganizationMemberProfileUpdateResponse = z.infer<
+  typeof organizationMemberProfileUpdateResponseSchema
+>
+export type UpdateOrganizationMemberProfileRequest = z.infer<
+  typeof updateOrganizationMemberProfileRequestSchema
+>

--- a/apps/kaede/src/services/profiles/index.ts
+++ b/apps/kaede/src/services/profiles/index.ts
@@ -1,0 +1,16 @@
+export {
+  findMemberProfileContextById,
+  findMemberProfileContextByUser,
+  findUserProfileContext,
+  insertAuditEvent,
+  upsertOrganizationMemberProfile,
+  upsertUserProfile,
+} from './profile-repository.js'
+export type {
+  MemberProfileContext,
+  OrganizationMemberProfile,
+  OrganizationMemberProfileUpdate,
+  UserProfile,
+  UserProfileContext,
+  UserProfileUpdate,
+} from './profile-repository.js'

--- a/apps/kaede/src/services/profiles/profile-repository.ts
+++ b/apps/kaede/src/services/profiles/profile-repository.ts
@@ -1,0 +1,135 @@
+import type { Insertable, Selectable, Updateable } from 'kysely'
+import type { AuditEvents, OrganizationMemberProfiles, UserProfiles } from '../db/generated.js'
+import { db } from '../db/index.js'
+import type { DbExecutor } from '../executor.js'
+
+export type UserProfile = Selectable<UserProfiles>
+export type UserProfileUpdate = Updateable<UserProfiles>
+export type OrganizationMemberProfile = Selectable<OrganizationMemberProfiles>
+export type OrganizationMemberProfileUpdate = Updateable<OrganizationMemberProfiles>
+
+export interface UserProfileContext {
+  user_id: string
+  legacy_display_name: string
+  legacy_updated_at: Date
+  display_name: string | null
+  locale: string | null
+  timezone: string | null
+  profile_updated_at: Date | null
+}
+
+export interface MemberProfileContext extends UserProfileContext {
+  membership_id: string | null
+  organization_id: string
+  membership_user_id: string
+  role: string
+  status: string | null
+  override_display_name: string | null
+  height_meters: string | null
+  stride_length_meters: string | null
+  member_profile_updated_at: Date | null
+}
+
+const userProfileContextQuery = (executor: DbExecutor) =>
+  executor
+    .selectFrom('users as user')
+    .leftJoin('user_profiles as profile', 'profile.user_id', 'user.id')
+    .select([
+      'user.id as user_id',
+      'user.display_name as legacy_display_name',
+      'user.updated_at as legacy_updated_at',
+      'profile.display_name as display_name',
+      'profile.locale as locale',
+      'profile.timezone as timezone',
+      'profile.updated_at as profile_updated_at',
+    ])
+
+export const findUserProfileContext = async (
+  userId: string,
+  executor: DbExecutor = db
+): Promise<UserProfileContext | undefined> => {
+  return userProfileContextQuery(executor).where('user.id', '=', userId).executeTakeFirst()
+}
+
+const memberProfileContextQuery = (executor: DbExecutor) =>
+  executor
+    .selectFrom('organization_memberships as membership')
+    .innerJoin('users as user', 'user.id', 'membership.user_id')
+    .leftJoin('user_profiles as user_profile', 'user_profile.user_id', 'user.id')
+    .leftJoin('organization_member_profiles as member_profile', (join) =>
+      join.onRef('member_profile.membership_id', '=', 'membership.id')
+    )
+    .select([
+      'membership.id as membership_id',
+      'membership.organization_id as organization_id',
+      'membership.user_id as membership_user_id',
+      'membership.role as role',
+      'membership.status as status',
+      'user.id as user_id',
+      'user.display_name as legacy_display_name',
+      'user.updated_at as legacy_updated_at',
+      'user_profile.display_name as display_name',
+      'user_profile.locale as locale',
+      'user_profile.timezone as timezone',
+      'user_profile.updated_at as profile_updated_at',
+      'member_profile.display_name as override_display_name',
+      'member_profile.height_meters as height_meters',
+      'member_profile.stride_length_meters as stride_length_meters',
+      'member_profile.updated_at as member_profile_updated_at',
+    ])
+
+export const findMemberProfileContextByUser = async (
+  organizationId: string,
+  userId: string,
+  executor: DbExecutor = db
+): Promise<MemberProfileContext | undefined> => {
+  return memberProfileContextQuery(executor)
+    .where('membership.organization_id', '=', organizationId)
+    .where('membership.user_id', '=', userId)
+    .where('membership.status', 'in', ['active', 'suspended'])
+    .executeTakeFirst()
+}
+
+export const findMemberProfileContextById = async (
+  organizationId: string,
+  membershipId: string,
+  executor: DbExecutor = db
+): Promise<MemberProfileContext | undefined> => {
+  return memberProfileContextQuery(executor)
+    .where('membership.organization_id', '=', organizationId)
+    .where('membership.id', '=', membershipId)
+    .executeTakeFirst()
+}
+
+export const upsertUserProfile = async (
+  profile: Insertable<UserProfiles>,
+  update: UserProfileUpdate,
+  executor: DbExecutor = db
+): Promise<UserProfile> => {
+  return executor
+    .insertInto('user_profiles')
+    .values(profile)
+    .onConflict((conflict) => conflict.column('user_id').doUpdateSet(update))
+    .returningAll()
+    .executeTakeFirstOrThrow()
+}
+
+export const upsertOrganizationMemberProfile = async (
+  profile: Insertable<OrganizationMemberProfiles>,
+  update: OrganizationMemberProfileUpdate,
+  executor: DbExecutor = db
+): Promise<OrganizationMemberProfile> => {
+  return executor
+    .insertInto('organization_member_profiles')
+    .values(profile)
+    .onConflict((conflict) => conflict.column('membership_id').doUpdateSet(update))
+    .returningAll()
+    .executeTakeFirstOrThrow()
+}
+
+export const insertAuditEvent = async (
+  event: Insertable<AuditEvents>,
+  executor: DbExecutor = db
+) => {
+  await executor.insertInto('audit_events').values(event).execute()
+}

--- a/apps/kaede/src/usecases/profiles/index.test.ts
+++ b/apps/kaede/src/usecases/profiles/index.test.ts
@@ -1,0 +1,264 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import type { DbExecutor } from '../../services/executor.js'
+
+const mocks = vi.hoisted(() => ({
+  findMemberProfileContextById: vi.fn(),
+  findMemberProfileContextByUser: vi.fn(),
+  findUserProfileContext: vi.fn(),
+  insertAuditEvent: vi.fn(),
+  upsertOrganizationMemberProfile: vi.fn(),
+  upsertUserProfile: vi.fn(),
+}))
+
+vi.mock('../../services/profiles/index.js', () => mocks)
+vi.mock('../../services/db/index.js', () => ({ db: {} }))
+
+import {
+  getMyOrganizationMemberProfile,
+  getMyUserProfile,
+  updateMyOrganizationMemberProfile,
+  updateOrganizationMemberProfile,
+} from './index.js'
+
+const executor = {} as DbExecutor
+const organizationId = '11111111-1111-4111-8111-111111111111'
+const actorMembershipId = '22222222-2222-4222-8222-222222222222'
+const targetMembershipId = '33333333-3333-4333-8333-333333333333'
+const actorUserId = '44444444-4444-4444-8444-444444444444'
+const targetUserId = '55555555-5555-4555-8555-555555555555'
+
+const userActor = (
+  role: 'member' | 'manager' | 'owner' = 'member',
+  globalRole: 'none' | 'admin' = 'none'
+): RequestActor => ({
+  type: 'user',
+  user_id: actorUserId,
+  email: 'actor@example.com',
+  global_role: globalRole,
+  account_state: 'active',
+  memberships: [
+    {
+      organization_id: organizationId,
+      organization_name: 'Example',
+      role,
+    },
+  ],
+})
+
+const memberContext = ({
+  membershipId = targetMembershipId,
+  userId = targetUserId,
+  role = 'member',
+  status = 'active',
+  overrideDisplayName = null,
+}: {
+  membershipId?: string | null
+  userId?: string
+  role?: string
+  status?: string | null
+  overrideDisplayName?: string | null
+} = {}) => ({
+  membership_id: membershipId,
+  organization_id: organizationId,
+  membership_user_id: userId,
+  role,
+  status,
+  user_id: userId,
+  legacy_display_name: 'Legacy Name',
+  display_name: 'Global Name',
+  locale: 'ja-JP',
+  timezone: 'Asia/Tokyo',
+  profile_updated_at: new Date('2026-08-11T00:00:00.000Z'),
+  override_display_name: overrideDisplayName,
+  height_meters: '1.705',
+  stride_length_meters: '0.720',
+  member_profile_updated_at: new Date('2026-08-11T00:00:00.000Z'),
+})
+
+describe('profile usecases', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('User Profile未作成時はlegacy display nameとdefault preferenceへfallbackする', async () => {
+    mocks.findUserProfileContext.mockResolvedValue({
+      user_id: actorUserId,
+      legacy_display_name: 'Legacy Name',
+      legacy_updated_at: new Date('2026-08-10T00:00:00.000Z'),
+      display_name: null,
+      locale: null,
+      timezone: null,
+      profile_updated_at: null,
+    })
+
+    await expect(getMyUserProfile(userActor(), executor)).resolves.toEqual({
+      ok: true,
+      value: {
+        user_id: actorUserId,
+        display_name: 'Legacy Name',
+        locale: 'ja-JP',
+        timezone: 'Asia/Tokyo',
+        updated_at: '2026-08-10T00:00:00.000Z',
+      },
+    })
+  })
+
+  it('Organization overrideがNULLなら共通display nameを実効値にする', async () => {
+    mocks.findMemberProfileContextByUser.mockResolvedValue(
+      memberContext({ membershipId: actorMembershipId, userId: actorUserId })
+    )
+
+    const result = await getMyOrganizationMemberProfile(userActor(), organizationId, executor)
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        global: { display_name: 'Global Name' },
+        override: { display_name: null, height_meters: 1.705, stride_length_meters: 0.72 },
+        effective: { display_name: 'Global Name', display_name_source: 'global' },
+      },
+    })
+  })
+
+  it('本人更新はoverrideを解除でき、Audit Eventを作成しない', async () => {
+    const current = memberContext({
+      membershipId: actorMembershipId,
+      userId: actorUserId,
+      overrideDisplayName: 'Override Name',
+    })
+    mocks.findMemberProfileContextByUser.mockResolvedValue(current)
+    mocks.findMemberProfileContextById.mockResolvedValue({
+      ...current,
+      override_display_name: null,
+    })
+    mocks.upsertOrganizationMemberProfile.mockResolvedValue({})
+
+    const result = await updateMyOrganizationMemberProfile(
+      userActor(),
+      organizationId,
+      { display_name: null },
+      executor
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        effective: { display_name: 'Global Name', display_name_source: 'global' },
+        update_context: { kind: 'self' },
+      },
+    })
+    expect(mocks.insertAuditEvent).not.toHaveBeenCalled()
+  })
+
+  it('active managerは同じOrganizationのmember Profileを変更しAuditへ記録する', async () => {
+    const target = memberContext()
+    const actorMembership = memberContext({
+      membershipId: actorMembershipId,
+      userId: actorUserId,
+      role: 'manager',
+    })
+    mocks.findMemberProfileContextById
+      .mockResolvedValueOnce(target)
+      .mockResolvedValueOnce({ ...target, override_display_name: 'Managed Name' })
+    mocks.findMemberProfileContextByUser.mockResolvedValue(actorMembership)
+    mocks.upsertOrganizationMemberProfile.mockResolvedValue({})
+
+    const result = await updateOrganizationMemberProfile(
+      userActor('manager'),
+      organizationId,
+      targetMembershipId,
+      { display_name: 'Managed Name' },
+      executor
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: { update_context: { kind: 'forced', actor_role: 'manager' } },
+    })
+    expect(mocks.insertAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actor_user_id: actorUserId,
+        actor_membership_id: actorMembershipId,
+        organization_id: organizationId,
+        target_type: 'member_profile',
+        target_id: targetMembershipId,
+        changed_fields: ['display_name'],
+      }),
+      executor
+    )
+  })
+
+  it('managerはmanager/owner Profileを変更できない', async () => {
+    mocks.findMemberProfileContextById.mockResolvedValue(memberContext({ role: 'manager' }))
+    mocks.findMemberProfileContextByUser.mockResolvedValue(
+      memberContext({
+        membershipId: actorMembershipId,
+        userId: actorUserId,
+        role: 'manager',
+      })
+    )
+
+    await expect(
+      updateOrganizationMemberProfile(
+        userActor('manager'),
+        organizationId,
+        targetMembershipId,
+        { display_name: 'Denied' },
+        executor
+      )
+    ).resolves.toEqual({ ok: false, error: { type: 'AUTH_DASHBOARD_FORBIDDEN' } })
+    expect(mocks.upsertOrganizationMemberProfile).not.toHaveBeenCalled()
+    expect(mocks.insertAuditEvent).not.toHaveBeenCalled()
+  })
+
+  it('inactive actor Membershipでは第三者Profileを変更できない', async () => {
+    mocks.findMemberProfileContextById.mockResolvedValue(memberContext())
+    mocks.findMemberProfileContextByUser.mockResolvedValue(
+      memberContext({
+        membershipId: actorMembershipId,
+        userId: actorUserId,
+        role: 'owner',
+        status: 'suspended',
+      })
+    )
+
+    const result = await updateOrganizationMemberProfile(
+      userActor('owner'),
+      organizationId,
+      targetMembershipId,
+      { height_meters: 1.8 },
+      executor
+    )
+
+    expect(result).toEqual({ ok: false, error: { type: 'AUTH_DASHBOARD_FORBIDDEN' } })
+  })
+
+  it('ownerはowner Profileを変更できる', async () => {
+    const target = memberContext({ role: 'owner' })
+    mocks.findMemberProfileContextById
+      .mockResolvedValueOnce(target)
+      .mockResolvedValueOnce({ ...target, height_meters: '1.800' })
+    mocks.findMemberProfileContextByUser.mockResolvedValue(
+      memberContext({
+        membershipId: actorMembershipId,
+        userId: actorUserId,
+        role: 'owner',
+      })
+    )
+    mocks.upsertOrganizationMemberProfile.mockResolvedValue({})
+
+    const result = await updateOrganizationMemberProfile(
+      userActor('owner'),
+      organizationId,
+      targetMembershipId,
+      { height_meters: 1.8 },
+      executor
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: { update_context: { kind: 'forced', actor_role: 'owner' } },
+    })
+  })
+})

--- a/apps/kaede/src/usecases/profiles/index.ts
+++ b/apps/kaede/src/usecases/profiles/index.ts
@@ -1,0 +1,333 @@
+import type { Kysely } from 'kysely'
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import type {
+  OrganizationMemberProfileResponse,
+  OrganizationMemberProfileUpdateResponse,
+  UpdateOrganizationMemberProfileRequest,
+  UpdateUserProfileRequest,
+  UserProfileResponse,
+} from '../../schemas/profiles.js'
+import { db } from '../../services/db/index.js'
+import type { DB, Json } from '../../services/db/index.js'
+import type { DbExecutor } from '../../services/executor.js'
+import {
+  findMemberProfileContextById,
+  findMemberProfileContextByUser,
+  findUserProfileContext,
+  insertAuditEvent,
+  upsertOrganizationMemberProfile,
+  upsertUserProfile,
+} from '../../services/profiles/index.js'
+import type { MemberProfileContext, UserProfileContext } from '../../services/profiles/index.js'
+import type { AuthorizationError } from '../authorization.js'
+
+const defaultLocale = 'ja-JP'
+const defaultTimezone = 'Asia/Tokyo'
+
+export type ProfileError =
+  | AuthorizationError
+  | { type: 'USER_NOT_FOUND' }
+  | { type: 'MEMBERSHIP_NOT_FOUND' }
+  | { type: 'MEMBERSHIP_NOT_ACTIVE' }
+  | { type: 'MEMBERSHIP_PROFILE_UNAVAILABLE' }
+
+type ProfileResult<T> = { ok: true; value: T } | { ok: false; error: ProfileError }
+
+const runInTransaction = async <T>(
+  executor: DbExecutor | undefined,
+  callback: (trx: DbExecutor) => Promise<T>
+): Promise<T> => {
+  const baseExecutor = executor ?? db
+
+  if ('transaction' in baseExecutor) {
+    return (baseExecutor as Kysely<DB>).transaction().execute((trx) => callback(trx))
+  }
+
+  return callback(baseExecutor)
+}
+
+const requireUserActor = (
+  actor: RequestActor
+):
+  | { ok: true; actor: Extract<RequestActor, { type: 'user' }> }
+  | { ok: false; error: ProfileError } => {
+  if (actor.type === 'service_client') {
+    return { ok: false, error: { type: 'AUTH_DASHBOARD_FORBIDDEN' } }
+  }
+
+  return { ok: true, actor }
+}
+
+const toUserProfileResponse = (context: UserProfileContext): UserProfileResponse => ({
+  user_id: context.user_id,
+  display_name: context.display_name ?? context.legacy_display_name,
+  locale: context.locale ?? defaultLocale,
+  timezone: context.timezone ?? defaultTimezone,
+  updated_at: (context.profile_updated_at ?? context.legacy_updated_at).toISOString(),
+})
+
+const toMemberProfileResponse = (
+  context: MemberProfileContext
+): OrganizationMemberProfileResponse => {
+  if (!context.membership_id) {
+    throw new Error('membership id is not available')
+  }
+
+  const globalDisplayName = context.display_name ?? context.legacy_display_name
+
+  return {
+    organization_id: context.organization_id,
+    membership_id: context.membership_id,
+    global: {
+      display_name: globalDisplayName,
+    },
+    override: {
+      display_name: context.override_display_name,
+      height_meters: context.height_meters === null ? null : Number(context.height_meters),
+      stride_length_meters:
+        context.stride_length_meters === null ? null : Number(context.stride_length_meters),
+    },
+    effective: {
+      display_name: context.override_display_name ?? globalDisplayName,
+      display_name_source:
+        context.override_display_name === null ? 'global' : 'organization_override',
+    },
+    updated_at: context.member_profile_updated_at?.toISOString() ?? null,
+  }
+}
+
+const checkActiveMembership = (
+  membership: MemberProfileContext | undefined
+):
+  | { ok: true; membership: MemberProfileContext & { membership_id: string } }
+  | {
+      ok: false
+      error: ProfileError
+    } => {
+  if (!membership) {
+    return { ok: false, error: { type: 'MEMBERSHIP_NOT_FOUND' } }
+  }
+
+  if (membership.status !== 'active') {
+    return { ok: false, error: { type: 'MEMBERSHIP_NOT_ACTIVE' } }
+  }
+
+  if (!membership.membership_id) {
+    return { ok: false, error: { type: 'MEMBERSHIP_PROFILE_UNAVAILABLE' } }
+  }
+
+  return {
+    ok: true,
+    membership: membership as MemberProfileContext & { membership_id: string },
+  }
+}
+
+export const getMyUserProfile = async (
+  actor: RequestActor,
+  executor?: DbExecutor
+): Promise<ProfileResult<UserProfileResponse>> => {
+  const authenticated = requireUserActor(actor)
+  if (!authenticated.ok) return authenticated
+
+  const profile = await findUserProfileContext(authenticated.actor.user_id, executor)
+
+  if (!profile) {
+    return { ok: false, error: { type: 'USER_NOT_FOUND' } }
+  }
+
+  return { ok: true, value: toUserProfileResponse(profile) }
+}
+
+export const updateMyUserProfile = async (
+  actor: RequestActor,
+  payload: UpdateUserProfileRequest,
+  executor?: DbExecutor
+): Promise<ProfileResult<UserProfileResponse>> => {
+  const authenticated = requireUserActor(actor)
+  if (!authenticated.ok) return authenticated
+
+  return runInTransaction(executor, async (trx) => {
+    const current = await findUserProfileContext(authenticated.actor.user_id, trx)
+    if (!current) return { ok: false, error: { type: 'USER_NOT_FOUND' } }
+
+    const next = {
+      display_name: payload.display_name ?? current.display_name ?? current.legacy_display_name,
+      locale: payload.locale ?? current.locale ?? defaultLocale,
+      timezone: payload.timezone ?? current.timezone ?? defaultTimezone,
+    }
+
+    const profile = await upsertUserProfile(
+      { user_id: authenticated.actor.user_id, ...next },
+      next,
+      trx
+    )
+
+    return {
+      ok: true,
+      value: {
+        user_id: profile.user_id,
+        display_name: profile.display_name,
+        locale: profile.locale,
+        timezone: profile.timezone,
+        updated_at: profile.updated_at.toISOString(),
+      },
+    }
+  })
+}
+
+export const getMyOrganizationMemberProfile = async (
+  actor: RequestActor,
+  organizationId: string,
+  executor?: DbExecutor
+): Promise<ProfileResult<OrganizationMemberProfileResponse>> => {
+  const authenticated = requireUserActor(actor)
+  if (!authenticated.ok) return authenticated
+
+  const membership = checkActiveMembership(
+    await findMemberProfileContextByUser(organizationId, authenticated.actor.user_id, executor)
+  )
+  if (!membership.ok) return membership
+
+  return { ok: true, value: toMemberProfileResponse(membership.membership) }
+}
+
+const updateMemberProfile = async (
+  current: MemberProfileContext & { membership_id: string },
+  payload: UpdateOrganizationMemberProfileRequest,
+  executor: DbExecutor
+) => {
+  const next = {
+    display_name:
+      payload.display_name === undefined ? current.override_display_name : payload.display_name,
+    height_meters:
+      payload.height_meters === undefined ? current.height_meters : payload.height_meters,
+    stride_length_meters:
+      payload.stride_length_meters === undefined
+        ? current.stride_length_meters
+        : payload.stride_length_meters,
+  }
+
+  await upsertOrganizationMemberProfile(
+    { membership_id: current.membership_id, ...next },
+    next,
+    executor
+  )
+
+  const refreshed = await findMemberProfileContextById(
+    current.organization_id,
+    current.membership_id,
+    executor
+  )
+
+  if (!refreshed) throw new Error('updated membership profile was not found')
+  return { next, refreshed }
+}
+
+export const updateMyOrganizationMemberProfile = async (
+  actor: RequestActor,
+  organizationId: string,
+  payload: UpdateOrganizationMemberProfileRequest,
+  executor?: DbExecutor
+): Promise<ProfileResult<OrganizationMemberProfileUpdateResponse>> => {
+  const authenticated = requireUserActor(actor)
+  if (!authenticated.ok) return authenticated
+
+  return runInTransaction(executor, async (trx) => {
+    const membership = checkActiveMembership(
+      await findMemberProfileContextByUser(organizationId, authenticated.actor.user_id, trx)
+    )
+    if (!membership.ok) return membership
+
+    const { refreshed } = await updateMemberProfile(membership.membership, payload, trx)
+    return {
+      ok: true,
+      value: { ...toMemberProfileResponse(refreshed), update_context: { kind: 'self' } },
+    }
+  })
+}
+
+const thirdPartyActorRole = (
+  actor: Extract<RequestActor, { type: 'user' }>,
+  actorMembership: MemberProfileContext | undefined,
+  target: MemberProfileContext
+): 'manager' | 'owner' | 'global_admin' | undefined => {
+  if (actor.global_role === 'admin') return 'global_admin'
+  if (actorMembership?.status !== 'active' || !actorMembership.membership_id) return undefined
+  if (actorMembership.role === 'owner') return 'owner'
+  if (actorMembership.role === 'manager' && target.role === 'member') return 'manager'
+  return undefined
+}
+
+export const updateOrganizationMemberProfile = async (
+  actor: RequestActor,
+  organizationId: string,
+  membershipId: string,
+  payload: UpdateOrganizationMemberProfileRequest,
+  executor?: DbExecutor
+): Promise<ProfileResult<OrganizationMemberProfileUpdateResponse>> => {
+  const authenticated = requireUserActor(actor)
+  if (!authenticated.ok) return authenticated
+
+  return runInTransaction(executor, async (trx) => {
+    const target = checkActiveMembership(
+      await findMemberProfileContextById(organizationId, membershipId, trx)
+    )
+    if (!target.ok) return target
+
+    const actorMembership = await findMemberProfileContextByUser(
+      organizationId,
+      authenticated.actor.user_id,
+      trx
+    )
+    const actorRole = thirdPartyActorRole(authenticated.actor, actorMembership, target.membership)
+
+    if (!actorRole) {
+      return { ok: false, error: { type: 'AUTH_DASHBOARD_FORBIDDEN' } }
+    }
+
+    const before = {
+      display_name: target.membership.override_display_name,
+      height_meters:
+        target.membership.height_meters === null ? null : Number(target.membership.height_meters),
+      stride_length_meters:
+        target.membership.stride_length_meters === null
+          ? null
+          : Number(target.membership.stride_length_meters),
+    }
+    const { next, refreshed } = await updateMemberProfile(target.membership, payload, trx)
+    const after = {
+      display_name: next.display_name,
+      height_meters: next.height_meters === null ? null : Number(next.height_meters),
+      stride_length_meters:
+        next.stride_length_meters === null ? null : Number(next.stride_length_meters),
+    }
+    const changedFields = (Object.keys(after) as (keyof typeof after)[]).filter(
+      (field) => before[field] !== after[field]
+    )
+
+    if (changedFields.length > 0) {
+      await insertAuditEvent(
+        {
+          actor_user_id: authenticated.actor.user_id,
+          actor_membership_id: actorMembership?.membership_id ?? null,
+          organization_id: organizationId,
+          target_type: 'member_profile',
+          target_id: membershipId,
+          action: 'update',
+          changed_fields: changedFields,
+          before_values: before as Json,
+          after_values: { ...after, actor_role: actorRole } as Json,
+        },
+        trx
+      )
+    }
+
+    return {
+      ok: true,
+      value: {
+        ...toMemberProfileResponse(refreshed),
+        update_context: { kind: 'forced', actor_role: actorRole },
+      },
+    }
+  })
+}

--- a/apps/kaede/tests/services/organizations/organizations.test.ts
+++ b/apps/kaede/tests/services/organizations/organizations.test.ts
@@ -1282,8 +1282,8 @@ describe('organizations usecase', () => {
         create_pedestrian: true,
         pedestrian: {
           display_name: 'Pedestrian A',
-          height: 170.5,
-          stride_length: 72,
+          height: 1.705,
+          stride_length: 0.72,
           attributes: {
             team: 'A',
           },
@@ -1301,8 +1301,8 @@ describe('organizations usecase', () => {
         pedestrian: {
           organization_id: organization.id,
           display_name: 'Pedestrian A',
-          height: 170.5,
-          stride_length: 72,
+          height: 1.705,
+          stride_length: 0.72,
           attributes: {
             team: 'A',
           },

--- a/apps/kaede/tests/services/profiles/profiles.test.ts
+++ b/apps/kaede/tests/services/profiles/profiles.test.ts
@@ -1,0 +1,219 @@
+import { sql } from 'kysely'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import type { RequestActor } from '../../../src/middleware/request-actor-context.js'
+import { createDb } from '../../../src/services/db/client.js'
+import { findMemberProfileContextByUser } from '../../../src/services/profiles/index.js'
+import {
+  getMyOrganizationMemberProfile,
+  updateOrganizationMemberProfile,
+} from '../../../src/usecases/profiles/index.js'
+import { resetDatabase } from '../../db/helpers.js'
+
+const db = createDb()
+
+const createUser = async (email: string, displayName: string) =>
+  db
+    .insertInto('users')
+    .values({
+      email,
+      display_name: displayName,
+      password_hash: null,
+      global_role: 'none',
+      status: 'active',
+      password_changed_at: null,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+describe('profile usecases with database', () => {
+  beforeEach(async () => resetDatabase(db))
+  afterAll(async () => db.destroy())
+
+  it('override未設定時はUser Profileへfallbackする', async () => {
+    const user = await createUser('self-profile@example.com', 'Legacy')
+    const organization = await db
+      .insertInto('organizations')
+      .values({ name: 'Profile Organization' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const membership = await db
+      .insertInto('organization_memberships')
+      .values({ organization_id: organization.id, user_id: user.id, role: 'member' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    await db
+      .insertInto('user_profiles')
+      .values({
+        user_id: user.id,
+        display_name: 'Global Profile',
+        locale: 'ja-JP',
+        timezone: 'Asia/Tokyo',
+      })
+      .execute()
+
+    const actor: RequestActor = {
+      type: 'user',
+      user_id: user.id,
+      email: user.email,
+      global_role: 'none',
+      account_state: 'active',
+      memberships: [
+        { organization_id: organization.id, organization_name: organization.name, role: 'member' },
+      ],
+    }
+
+    const result = await getMyOrganizationMemberProfile(actor, organization.id)
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        membership_id: membership.id,
+        global: { display_name: 'Global Profile' },
+        override: { display_name: null, height_meters: null, stride_length_meters: null },
+        effective: { display_name: 'Global Profile', display_name_source: 'global' },
+      },
+    })
+  })
+
+  it('managerによるmember Profile変更とAudit Eventを同時に保存する', async () => {
+    const manager = await createUser('profile-manager@example.com', 'Manager')
+    const member = await createUser('profile-member@example.com', 'Member')
+    const organization = await db
+      .insertInto('organizations')
+      .values({ name: 'Managed Profile Organization' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const managerMembership = await db
+      .insertInto('organization_memberships')
+      .values({ organization_id: organization.id, user_id: manager.id, role: 'manager' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const memberMembership = await db
+      .insertInto('organization_memberships')
+      .values({ organization_id: organization.id, user_id: member.id, role: 'member' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    if (!managerMembership.id || !memberMembership.id) {
+      throw new Error('membership ids must be populated')
+    }
+    await db
+      .insertInto('user_profiles')
+      .values([
+        {
+          user_id: manager.id,
+          display_name: 'Manager',
+          locale: 'ja-JP',
+          timezone: 'Asia/Tokyo',
+        },
+        {
+          user_id: member.id,
+          display_name: 'Member',
+          locale: 'ja-JP',
+          timezone: 'Asia/Tokyo',
+        },
+      ])
+      .execute()
+
+    const actor: RequestActor = {
+      type: 'user',
+      user_id: manager.id,
+      email: manager.email,
+      global_role: 'none',
+      account_state: 'active',
+      memberships: [
+        {
+          organization_id: organization.id,
+          organization_name: organization.name,
+          role: 'manager',
+        },
+      ],
+    }
+
+    const result = await updateOrganizationMemberProfile(
+      actor,
+      organization.id,
+      memberMembership.id,
+      { display_name: 'Managed Member', height_meters: 1.705, stride_length_meters: 0.72 }
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        effective: {
+          display_name: 'Managed Member',
+          display_name_source: 'organization_override',
+        },
+        update_context: { kind: 'forced', actor_role: 'manager' },
+      },
+    })
+
+    const storedProfile = await db
+      .selectFrom('organization_member_profiles')
+      .selectAll()
+      .where('membership_id', '=', memberMembership.id)
+      .executeTakeFirstOrThrow()
+    expect(storedProfile.display_name).toBe('Managed Member')
+    expect(Number(storedProfile.height_meters)).toBe(1.705)
+    expect(Number(storedProfile.stride_length_meters)).toBe(0.72)
+
+    const audit = await db
+      .selectFrom('audit_events')
+      .selectAll()
+      .where('target_id', '=', memberMembership.id)
+      .executeTakeFirstOrThrow()
+    expect(audit.actor_membership_id).toBe(managerMembership.id)
+    expect(audit.changed_fields).toEqual(['display_name', 'height_meters', 'stride_length_meters'])
+  })
+
+  it('再参加でleftとactive Membershipが併存するときcurrent Membershipを選ぶ', async () => {
+    const user = await createUser('rejoined-profile@example.com', 'Rejoined Member')
+    const organization = await db
+      .insertInto('organizations')
+      .values({ name: 'Rejoined Profile Organization' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    await db
+      .transaction()
+      .execute(async (trx) => {
+        await sql`ALTER TABLE organization_memberships DROP CONSTRAINT organization_memberships_pkey`.execute(
+          trx
+        )
+
+        const leftMembership = await trx
+          .insertInto('organization_memberships')
+          .values({
+            organization_id: organization.id,
+            user_id: user.id,
+            role: 'member',
+            status: 'left',
+            left_at: new Date('2026-08-10T00:00:00.000Z'),
+          })
+          .returningAll()
+          .executeTakeFirstOrThrow()
+        const activeMembership = await trx
+          .insertInto('organization_memberships')
+          .values({
+            organization_id: organization.id,
+            user_id: user.id,
+            role: 'member',
+            status: 'active',
+          })
+          .returningAll()
+          .executeTakeFirstOrThrow()
+
+        const selected = await findMemberProfileContextByUser(organization.id, user.id, trx)
+
+        expect(selected?.membership_id).toBe(activeMembership.id)
+        expect(selected?.membership_id).not.toBe(leftMembership.id)
+        expect(selected?.status).toBe('active')
+
+        throw new Error('rollback rejoined membership test')
+      })
+      .catch((error: unknown) => {
+        if (!(error instanceof Error) || error.message !== 'rollback rejoined membership test') {
+          throw error
+        }
+      })
+  })
+})


### PR DESCRIPTION
# issue番号

#219

# 変更内容(写真か動画も一緒に)

- User共通ProfileとOrganization Member Profileの取得・更新APIを追加
- manager/ownerによる管理対象Profile更新とAudit記録を追加
- 表示名overrideのfallbackと身長・歩幅のメートル単位契約を追加

# 影響範囲(あれば)

- KaedeのProfile API、認可、OpenAPI schema、関連テスト