### PR TITLE
複数Organization認証の既存データを移行

### DIFF
--- a/apps/kaede/package.json
+++ b/apps/kaede/package.json
@@ -16,7 +16,8 @@
     "format": "prettier --write .",
     "typecheck": "tsc --noEmit",
     "storage-prefix-migration": "tsx src/cli/storage-prefix-migration.ts",
-    "floor-map-dimension-backfill": "tsx src/cli/floor-map-dimension-backfill.ts"
+    "floor-map-dimension-backfill": "tsx src/cli/floor-map-dimension-backfill.ts",
+    "multi-org-auth-backfill": "tsx src/cli/multi-org-auth-backfill.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1045.0",

--- a/apps/kaede/src/cli/multi-org-auth-backfill.test.ts
+++ b/apps/kaede/src/cli/multi-org-auth-backfill.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { parseOptions } from './multi-org-auth-backfill.js'
+
+describe('multi-org-auth-backfill options', () => {
+  it('uses a bounded default batch size', () => {
+    expect(parseOptions(['backfill-core'])).toEqual({
+      batchSize: 500,
+      command: 'backfill-core',
+    })
+  })
+
+  it('accepts an explicit batch size', () => {
+    expect(parseOptions(['backfill-auth', '--batch-size', '25'])).toEqual({
+      batchSize: 25,
+      command: 'backfill-auth',
+    })
+  })
+
+  it.each(['0', '-1', '1.5', '10001', 'not-a-number'])('rejects invalid batch size %s', (value) => {
+    expect(() => parseOptions(['verify', '--batch-size', value])).toThrow('usage:')
+  })
+})

--- a/apps/kaede/src/cli/multi-org-auth-backfill.ts
+++ b/apps/kaede/src/cli/multi-org-auth-backfill.ts
@@ -1,0 +1,84 @@
+import {
+  backfillMultiOrgAuthCore,
+  backfillMultiOrgAuthCredentials,
+  getMultiOrgAuthPreflightReport,
+  validateMultiOrgAuthExpandConstraints,
+  verifyMultiOrgAuthCoreBackfill,
+} from '../services/migrations/multi-org-auth-backfill.js'
+
+interface Options {
+  batchSize: number
+  command: 'preflight' | 'backfill-core' | 'backfill-auth' | 'verify' | 'validate'
+}
+
+const usage = (): never => {
+  throw new Error(
+    'usage: multi-org-auth-backfill <preflight|backfill-core|backfill-auth|verify|validate> [--batch-size POSITIVE_INTEGER]'
+  )
+}
+
+export const parseOptions = (argv: string[]): Options => {
+  const command = argv.shift()
+  if (
+    command !== 'preflight' &&
+    command !== 'backfill-core' &&
+    command !== 'backfill-auth' &&
+    command !== 'verify' &&
+    command !== 'validate'
+  ) {
+    usage()
+  }
+
+  let batchSize = 500
+  while (argv.length > 0) {
+    const flag = argv.shift()
+    if (flag !== '--batch-size') usage()
+    const value = argv.shift() ?? usage()
+    batchSize = Number(value)
+    if (!Number.isSafeInteger(batchSize) || batchSize <= 0 || batchSize > 10_000) usage()
+  }
+
+  return { batchSize, command: command as Options['command'] }
+}
+
+export const main = async (argv = process.argv.slice(2)) => {
+  const options = parseOptions([...argv])
+
+  if (options.command === 'preflight') {
+    const report = await getMultiOrgAuthPreflightReport()
+    process.stdout.write(`${JSON.stringify(report)}\n`)
+    if (report.blocking) throw new Error('multi-organization auth preflight has blocking issues')
+    return
+  }
+
+  if (options.command === 'backfill-core') {
+    const result = await backfillMultiOrgAuthCore(options.batchSize)
+    process.stdout.write(`${JSON.stringify(result)}\n`)
+    return
+  }
+
+  if (options.command === 'backfill-auth') {
+    const result = await backfillMultiOrgAuthCredentials(options.batchSize)
+    process.stdout.write(`${JSON.stringify(result)}\n`)
+    return
+  }
+
+  if (options.command === 'verify') {
+    const result = await verifyMultiOrgAuthCoreBackfill()
+    process.stdout.write(`${JSON.stringify(result)}\n`)
+    if (Object.values(result).some((count) => count > 0)) {
+      throw new Error('multi-organization auth core backfill is incomplete')
+    }
+    return
+  }
+
+  await validateMultiOrgAuthExpandConstraints()
+  process.stdout.write(`${JSON.stringify({ validated: true })}\n`)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error: unknown) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+    process.exitCode = 1
+  })
+}

--- a/apps/kaede/src/cli/multi-org-auth-backfill.ts
+++ b/apps/kaede/src/cli/multi-org-auth-backfill.ts
@@ -1,11 +1,3 @@
-import {
-  backfillMultiOrgAuthCore,
-  backfillMultiOrgAuthCredentials,
-  getMultiOrgAuthPreflightReport,
-  validateMultiOrgAuthExpandConstraints,
-  verifyMultiOrgAuthCoreBackfill,
-} from '../services/migrations/multi-org-auth-backfill.js'
-
 interface Options {
   batchSize: number
   command: 'preflight' | 'backfill-core' | 'backfill-auth' | 'verify' | 'validate'
@@ -43,6 +35,13 @@ export const parseOptions = (argv: string[]): Options => {
 
 export const main = async (argv = process.argv.slice(2)) => {
   const options = parseOptions([...argv])
+  const {
+    backfillMultiOrgAuthCore,
+    backfillMultiOrgAuthCredentials,
+    getMultiOrgAuthPreflightReport,
+    validateMultiOrgAuthExpandConstraints,
+    verifyMultiOrgAuthCoreBackfill,
+  } = await import('../services/migrations/multi-org-auth-backfill.js')
 
   if (options.command === 'preflight') {
     const report = await getMultiOrgAuthPreflightReport()

--- a/apps/kaede/src/services/migrations/multi-org-auth-backfill.ts
+++ b/apps/kaede/src/services/migrations/multi-org-auth-backfill.ts
@@ -1,0 +1,813 @@
+import { sql } from 'kysely'
+import type { RawBuilder } from 'kysely'
+import { db } from '../db/index.js'
+import type { DbExecutor } from '../executor.js'
+
+export const canonicalGoogleIssuer = 'https://accounts.google.com'
+
+export type PreflightScope = 'core' | 'auth' | 'measurements' | 'legacy'
+
+export interface PreflightIssue {
+  blocking: boolean
+  code: string
+  count: number
+  description: string
+  scope: PreflightScope
+  samples: string[]
+}
+
+export interface PreflightReport {
+  blocking: boolean
+  issues: PreflightIssue[]
+  measurements: MeasurementClassification
+}
+
+export interface MeasurementClassification {
+  already_m: number
+  converted_cm: number
+  invalid: number
+}
+
+export interface BackfillResult {
+  auth_settings_unchanged: number
+  contact_emails: number
+  invite_creators: number
+  local_credentials: number
+  measurement_values_already_m: number
+  measurement_values_converted_cm: number
+  memberships: number
+  member_profiles: number
+  oidc_identities: number
+  oidc_links: number
+  organizations: number
+  pedestrian_memberships: number
+  user_profiles: number
+}
+
+const emptyResult = (): BackfillResult => ({
+  auth_settings_unchanged: 0,
+  contact_emails: 0,
+  invite_creators: 0,
+  local_credentials: 0,
+  measurement_values_already_m: 0,
+  measurement_values_converted_cm: 0,
+  memberships: 0,
+  member_profiles: 0,
+  oidc_identities: 0,
+  oidc_links: 0,
+  organizations: 0,
+  pedestrian_memberships: 0,
+  user_profiles: 0,
+})
+
+const getIssue = async (
+  executor: DbExecutor,
+  issue: Omit<PreflightIssue, 'count' | 'samples'>,
+  query: RawBuilder<{ sample: string }>
+): Promise<PreflightIssue | undefined> => {
+  const result = await sql<{ sample: string; total_count: number }>`
+    SELECT sample, (count(*) OVER ())::integer AS total_count
+    FROM (${query}) AS issue
+    LIMIT 20
+  `.execute(executor)
+  if (result.rows.length === 0) return undefined
+
+  return {
+    ...issue,
+    count: result.rows[0]?.total_count ?? 0,
+    samples: result.rows.map((row) => row.sample),
+  }
+}
+
+export const getMultiOrgAuthPreflightReport = async (
+  executor: DbExecutor = db
+): Promise<PreflightReport> => {
+  const [candidates, measurementRows] = await Promise.all([
+    Promise.all([
+      getIssue(
+        executor,
+        {
+          blocking: true,
+          code: 'LOCAL_LOGIN_EMAIL_COLLISION',
+          description:
+            'The same normalized legacy login email belongs to multiple users in one organization.',
+          scope: 'auth',
+        },
+        sql<{ sample: string }>`
+        SELECT organization_id::text || ':' || lower(btrim(u.email)) AS sample
+        FROM organization_memberships AS m
+        JOIN users AS u ON u.id = m.user_id
+        WHERE u.password_hash IS NOT NULL
+          AND COALESCE(m.status, 'active') IN ('active', 'suspended')
+        GROUP BY organization_id, lower(btrim(u.email))
+        HAVING count(*) > 1
+      `
+      ),
+      getIssue(
+        executor,
+        {
+          blocking: true,
+          code: 'MISSING_ORGANIZATION_AUTH_POLICY',
+          description:
+            'Organization authentication policy is an operator decision and cannot be inferred from global runtime flags.',
+          scope: 'auth',
+        },
+        sql<{ sample: string }>`
+        SELECT o.id::text AS sample
+        FROM organizations AS o
+        LEFT JOIN organization_auth_settings AS settings
+          ON settings.organization_id = o.id
+        WHERE settings.organization_id IS NULL
+        ORDER BY o.id
+      `
+      ),
+      getIssue(
+        executor,
+        {
+          blocking: true,
+          code: 'OIDC_PROVIDER_MAPPING_MISSING_OR_AMBIGUOUS',
+          description:
+            'An OIDC-enabled organization with a legacy Google user must have exactly one enabled canonical Google provider.',
+          scope: 'auth',
+        },
+        sql<{ sample: string }>`
+        SELECT DISTINCT m.organization_id::text AS sample
+        FROM organization_memberships AS m
+        JOIN auth_identities AS legacy
+          ON legacy.user_id = m.user_id
+         AND legacy.provider = 'google'
+        JOIN organization_auth_settings AS settings
+          ON settings.organization_id = m.organization_id
+         AND settings.oidc_auth_enabled
+        LEFT JOIN organization_oidc_providers AS provider
+          ON provider.organization_id = m.organization_id
+         AND provider.enabled
+         AND provider.issuer = ${canonicalGoogleIssuer}
+        WHERE COALESCE(m.status, 'active') IN ('active', 'suspended')
+        GROUP BY m.organization_id, m.user_id
+        HAVING count(provider.id) <> 1
+      `
+      ),
+      getIssue(
+        executor,
+        {
+          blocking: true,
+          code: 'OIDC_IDENTITY_OWNER_CONFLICT',
+          description: 'A canonical issuer and subject pair resolves to more than one user.',
+          scope: 'auth',
+        },
+        sql<{ sample: string }>`
+        WITH identities AS (
+          SELECT ${canonicalGoogleIssuer}::text AS issuer, provider_subject AS subject, user_id
+          FROM auth_identities
+          WHERE provider = 'google'
+          UNION ALL
+          SELECT issuer, subject, user_id
+          FROM oidc_identities
+        )
+        SELECT issuer || ':' || subject AS sample
+        FROM identities
+        GROUP BY issuer, subject
+        HAVING count(DISTINCT user_id) > 1
+      `
+      ),
+      getIssue(
+        executor,
+        {
+          blocking: true,
+          code: 'PEDESTRIAN_MEMBERSHIP_NOT_FOUND',
+          description: 'A pedestrian user and organization do not resolve to a membership.',
+          scope: 'core',
+        },
+        sql<{ sample: string }>`
+        SELECT p.id::text AS sample
+        FROM pedestrians AS p
+        LEFT JOIN organization_memberships AS m
+          ON m.organization_id = p.organization_id
+         AND m.user_id = p.user_id
+         AND COALESCE(m.status, 'active') IN ('active', 'suspended')
+        WHERE p.user_id IS NOT NULL
+          AND m.user_id IS NULL
+        ORDER BY p.id
+      `
+      ),
+      getIssue(
+        executor,
+        {
+          blocking: true,
+          code: 'PEDESTRIAN_MEASUREMENT_OUT_OF_RANGE',
+          description:
+            'Legacy measurements must be greater than 0 and at most 300 before meter normalization.',
+          scope: 'measurements',
+        },
+        sql<{ sample: string }>`
+        SELECT p.id::text || ':height=' || p.height::text AS sample
+        FROM pedestrians AS p
+        WHERE p.height IS NOT NULL
+          AND (
+            NOT (p.height > 0 AND p.height <= 300)
+            OR round((CASE WHEN p.height <= 3 THEN p.height ELSE p.height / 100 END)::numeric, 3)
+              <= 0
+          )
+        UNION ALL
+        SELECT p.id::text || ':stride_length=' || p.stride_length::text AS sample
+        FROM pedestrians AS p
+        WHERE p.stride_length IS NOT NULL
+          AND (
+            NOT (p.stride_length > 0 AND p.stride_length <= 300)
+            OR round((CASE
+                WHEN p.stride_length <= 3 THEN p.stride_length
+                ELSE p.stride_length / 100
+              END)::numeric, 3) <= 0
+          )
+      `
+      ),
+      getIssue(
+        executor,
+        {
+          blocking: true,
+          code: 'INVITE_CREATOR_MEMBERSHIP_NOT_FOUND',
+          description:
+            'A legacy invite creator does not have a current membership in the organization.',
+          scope: 'core',
+        },
+        sql<{ sample: string }>`
+        SELECT invite.id::text AS sample
+        FROM organization_invites AS invite
+        LEFT JOIN organization_memberships AS m
+          ON m.organization_id = invite.organization_id
+         AND m.user_id = invite.created_by_user_id
+         AND COALESCE(m.status, 'active') IN ('active', 'suspended')
+        WHERE invite.created_by_membership_id IS NULL
+          AND m.user_id IS NULL
+        ORDER BY invite.id
+      `
+      ),
+      getIssue(
+        executor,
+        {
+          blocking: true,
+          code: 'LEGACY_MULTI_USE_INVITE',
+          description:
+            'Multi-use or already-used legacy invites require an operator migration decision.',
+          scope: 'legacy',
+        },
+        sql<{ sample: string }>`
+        SELECT id::text AS sample
+        FROM organization_invites
+        WHERE max_uses <> 1 OR used_count <> 0
+        ORDER BY id
+      `
+      ),
+      getIssue(
+        executor,
+        {
+          blocking: false,
+          code: 'PENDING_ACTIVATION_USER',
+          description: 'Pending activation users must be handled by the cutover plan.',
+          scope: 'legacy',
+        },
+        sql<{ sample: string }>`
+        SELECT id::text AS sample
+        FROM users
+        WHERE status = 'pending_activation'
+        ORDER BY id
+      `
+      ),
+    ]),
+    sql<MeasurementClassification>`
+      SELECT
+        (
+          count(*) FILTER (WHERE height > 0 AND height <= 3 AND round(height::numeric, 3) > 0)
+          + count(*) FILTER (
+              WHERE stride_length > 0
+                AND stride_length <= 3
+                AND round(stride_length::numeric, 3) > 0
+            )
+        )::integer AS already_m,
+        (
+          count(*) FILTER (
+              WHERE height > 3 AND height <= 300 AND round((height / 100)::numeric, 3) > 0
+            )
+          + count(*) FILTER (
+              WHERE stride_length > 3
+                AND stride_length <= 300
+                AND round((stride_length / 100)::numeric, 3) > 0
+            )
+        )::integer AS converted_cm,
+        (
+          count(*) FILTER (
+              WHERE height IS NOT NULL
+                AND (
+                  NOT (height > 0 AND height <= 300)
+                  OR round((CASE WHEN height <= 3 THEN height ELSE height / 100 END)::numeric, 3)
+                    <= 0
+                )
+            )
+          + count(*) FILTER (
+              WHERE stride_length IS NOT NULL
+                AND (
+                  NOT (stride_length > 0 AND stride_length <= 300)
+                  OR round((CASE
+                      WHEN stride_length <= 3 THEN stride_length
+                      ELSE stride_length / 100
+                    END)::numeric, 3) <= 0
+                )
+            )
+        )::integer AS invalid
+      FROM pedestrians
+    `.execute(executor),
+  ])
+
+  const issues = candidates.filter((issue): issue is PreflightIssue => issue !== undefined)
+  return {
+    blocking: issues.some((issue) => issue.blocking),
+    issues,
+    measurements: measurementRows.rows[0] ?? { already_m: 0, converted_cm: 0, invalid: 0 },
+  }
+}
+
+const runBatches = async (runBatch: () => Promise<number>): Promise<number> => {
+  let total = 0
+  for (;;) {
+    const updated = await runBatch()
+    total += updated
+    if (updated === 0) return total
+  }
+}
+
+export const backfillMultiOrgAuthCore = async (
+  batchSize: number,
+  executor: DbExecutor = db
+): Promise<BackfillResult> => {
+  const result = emptyResult()
+  const preflight = await getMultiOrgAuthPreflightReport(executor)
+  const blockers = preflight.issues.filter(
+    (issue) =>
+      issue.blocking &&
+      (issue.scope === 'core' || issue.scope === 'measurements' || issue.scope === 'legacy')
+  )
+  if (blockers.length > 0) {
+    throw new Error(`core backfill blocked: ${blockers.map((issue) => issue.code).join(', ')}`)
+  }
+
+  result.organizations = await runBatches(async () => {
+    const rows = await sql<{ id: string }>`
+      WITH target AS (
+        SELECT id FROM organizations WHERE status IS NULL ORDER BY id LIMIT ${batchSize}
+      )
+      UPDATE organizations AS o
+      SET status = 'active'
+      FROM target
+      WHERE o.id = target.id
+      RETURNING o.id
+    `.execute(executor)
+    return rows.rows.length
+  })
+
+  result.memberships = await runBatches(async () => {
+    const rows = await sql<{ id: string }>`
+      WITH target AS (
+        SELECT organization_id, user_id
+        FROM organization_memberships
+        WHERE id IS NULL OR status IS NULL OR joined_at IS NULL
+        ORDER BY organization_id, user_id
+        LIMIT ${batchSize}
+        FOR UPDATE SKIP LOCKED
+      )
+      UPDATE organization_memberships AS m
+      SET
+        id = COALESCE(m.id, gen_random_uuid()),
+        status = COALESCE(m.status, 'active'),
+        joined_at = COALESCE(m.joined_at, m.created_at)
+      FROM target
+      WHERE m.organization_id = target.organization_id
+        AND m.user_id = target.user_id
+      RETURNING m.id
+    `.execute(executor)
+    return rows.rows.length
+  })
+
+  result.contact_emails = await runBatches(async () => {
+    const rows = await sql<{ id: string }>`
+      WITH target AS (
+        SELECT id FROM users WHERE contact_email IS NULL ORDER BY id LIMIT ${batchSize}
+      )
+      UPDATE users AS u
+      SET
+        contact_email = u.email,
+        normalized_contact_email = lower(btrim(u.email))
+      FROM target
+      WHERE u.id = target.id
+      RETURNING u.id
+    `.execute(executor)
+    return rows.rows.length
+  })
+
+  result.user_profiles = await runBatches(async () => {
+    const rows = await sql<{ user_id: string }>`
+      INSERT INTO user_profiles (user_id, display_name)
+      SELECT u.id, u.display_name
+      FROM users AS u
+      LEFT JOIN user_profiles AS profile ON profile.user_id = u.id
+      WHERE profile.user_id IS NULL
+      ORDER BY u.id
+      LIMIT ${batchSize}
+      ON CONFLICT (user_id) DO NOTHING
+      RETURNING user_id
+    `.execute(executor)
+    return rows.rows.length
+  })
+
+  result.pedestrian_memberships = await runBatches(async () => {
+    const rows = await sql<{ id: string }>`
+      WITH target AS (
+        SELECT p.id, m.id AS membership_id
+        FROM pedestrians AS p
+        JOIN organization_memberships AS m
+          ON m.organization_id = p.organization_id
+         AND m.user_id = p.user_id
+         AND m.status IN ('active', 'suspended')
+        WHERE p.membership_id IS NULL
+        ORDER BY p.id
+        LIMIT ${batchSize}
+      )
+      UPDATE pedestrians AS p
+      SET membership_id = target.membership_id
+      FROM target
+      WHERE p.id = target.id
+      RETURNING p.id
+    `.execute(executor)
+    return rows.rows.length
+  })
+
+  result.member_profiles = await runBatches(async () => {
+    const rows = await sql<{ membership_id: string }>`
+      INSERT INTO organization_member_profiles (membership_id, display_name)
+      SELECT
+        m.id,
+        CASE
+          WHEN p.display_name IS DISTINCT FROM u.display_name THEN p.display_name
+          ELSE NULL
+        END
+      FROM organization_memberships AS m
+      JOIN users AS u ON u.id = m.user_id
+      LEFT JOIN pedestrians AS p ON p.membership_id = m.id
+      LEFT JOIN organization_member_profiles AS profile ON profile.membership_id = m.id
+      WHERE m.id IS NOT NULL
+        AND profile.membership_id IS NULL
+      ORDER BY m.id
+      LIMIT ${batchSize}
+      ON CONFLICT (membership_id) DO NOTHING
+      RETURNING membership_id
+    `.execute(executor)
+    return rows.rows.length
+  })
+
+  for (;;) {
+    const rows = await sql<{
+      height_already_m: boolean
+      height_converted_cm: boolean
+      stride_already_m: boolean
+      stride_converted_cm: boolean
+    }>`
+      WITH target AS (
+        SELECT
+          p.membership_id,
+          p.height,
+          p.stride_length,
+          profile.height_meters IS NULL AND p.height IS NOT NULL AS height_needs_backfill,
+          profile.stride_length_meters IS NULL AND p.stride_length IS NOT NULL
+            AS stride_needs_backfill
+        FROM pedestrians AS p
+        JOIN organization_member_profiles AS profile
+          ON profile.membership_id = p.membership_id
+        WHERE
+          (profile.height_meters IS NULL AND p.height IS NOT NULL)
+          OR (profile.stride_length_meters IS NULL AND p.stride_length IS NOT NULL)
+        ORDER BY p.membership_id
+        LIMIT ${batchSize}
+        FOR UPDATE OF p SKIP LOCKED
+      )
+      UPDATE organization_member_profiles AS profile
+      SET
+        height_meters = CASE
+          WHEN profile.height_meters IS NOT NULL OR target.height IS NULL
+            THEN profile.height_meters
+          WHEN target.height <= 3 THEN round(target.height::numeric, 3)
+          ELSE round((target.height / 100)::numeric, 3)
+        END,
+        stride_length_meters = CASE
+          WHEN profile.stride_length_meters IS NOT NULL OR target.stride_length IS NULL
+            THEN profile.stride_length_meters
+          WHEN target.stride_length <= 3 THEN round(target.stride_length::numeric, 3)
+          ELSE round((target.stride_length / 100)::numeric, 3)
+        END
+      FROM target
+      WHERE profile.membership_id = target.membership_id
+      RETURNING
+        target.height_needs_backfill AND target.height <= 3 AS height_already_m,
+        target.height_needs_backfill AND target.height > 3 AS height_converted_cm,
+        target.stride_needs_backfill AND target.stride_length <= 3 AS stride_already_m,
+        target.stride_needs_backfill AND target.stride_length > 3 AS stride_converted_cm
+    `.execute(executor)
+
+    if (rows.rows.length === 0) break
+    for (const row of rows.rows) {
+      if (row.height_already_m) result.measurement_values_already_m += 1
+      if (row.height_converted_cm) result.measurement_values_converted_cm += 1
+      if (row.stride_already_m) result.measurement_values_already_m += 1
+      if (row.stride_converted_cm) result.measurement_values_converted_cm += 1
+    }
+  }
+
+  result.invite_creators = await runBatches(async () => {
+    const rows = await sql<{ id: string }>`
+      WITH target AS (
+        SELECT invite.id, m.id AS membership_id
+        FROM organization_invites AS invite
+        JOIN organization_memberships AS m
+          ON m.organization_id = invite.organization_id
+         AND m.user_id = invite.created_by_user_id
+         AND m.status IN ('active', 'suspended')
+        WHERE invite.created_by_membership_id IS NULL
+        ORDER BY invite.id
+        LIMIT ${batchSize}
+      )
+      UPDATE organization_invites AS invite
+      SET created_by_membership_id = target.membership_id
+      FROM target
+      WHERE invite.id = target.id
+      RETURNING invite.id
+    `.execute(executor)
+    return rows.rows.length
+  })
+
+  return result
+}
+
+export const backfillMultiOrgAuthCredentials = async (
+  batchSize: number,
+  executor: DbExecutor = db
+): Promise<BackfillResult> => {
+  const result = emptyResult()
+  const coreVerification = await verifyMultiOrgAuthCoreBackfill(executor)
+  if (Object.values(coreVerification).some((count) => count > 0)) {
+    throw new Error('authentication backfill requires completed core backfill')
+  }
+  const report = await getMultiOrgAuthPreflightReport(executor)
+  const blockers = report.issues.filter((issue) => issue.blocking && issue.scope === 'auth')
+  if (blockers.length > 0) {
+    throw new Error(
+      `authentication backfill blocked: ${blockers.map((issue) => issue.code).join(', ')}`
+    )
+  }
+
+  result.auth_settings_unchanged = await sql<{ count: number }>`
+    SELECT count(*)::integer AS count FROM organization_auth_settings
+  `
+    .execute(executor)
+    .then((rows) => rows.rows[0]?.count ?? 0)
+
+  result.local_credentials = await runBatches(async () => {
+    const rows = await sql<{ id: string }>`
+      INSERT INTO organization_local_credentials (
+        membership_id,
+        organization_id,
+        login_email,
+        normalized_login_email,
+        password_hash,
+        password_changed_at,
+        failed_login_attempts,
+        locked_until
+      )
+      SELECT
+        m.id,
+        m.organization_id,
+        u.email,
+        lower(btrim(u.email)),
+        u.password_hash,
+        COALESCE(u.password_changed_at, u.created_at),
+        u.failed_login_attempts,
+        u.locked_until
+      FROM organization_memberships AS m
+      JOIN users AS u ON u.id = m.user_id
+      JOIN organization_auth_settings AS settings
+        ON settings.organization_id = m.organization_id
+       AND settings.local_auth_enabled
+      LEFT JOIN organization_local_credentials AS credential
+        ON credential.membership_id = m.id
+      WHERE m.id IS NOT NULL
+        AND m.status IN ('active', 'suspended')
+        AND u.password_hash IS NOT NULL
+        AND credential.id IS NULL
+      ORDER BY m.id
+      LIMIT ${batchSize}
+      ON CONFLICT (membership_id) DO NOTHING
+      RETURNING id
+    `.execute(executor)
+    return rows.rows.length
+  })
+
+  result.oidc_identities = await runBatches(async () => {
+    const rows = await sql<{ id: string }>`
+      INSERT INTO oidc_identities (
+        user_id,
+        issuer,
+        subject,
+        last_claimed_email,
+        last_claimed_email_verified
+      )
+      SELECT
+        legacy.user_id,
+        ${canonicalGoogleIssuer},
+        legacy.provider_subject,
+        legacy.email,
+        legacy.email_verified
+      FROM auth_identities AS legacy
+      LEFT JOIN oidc_identities AS identity
+        ON identity.issuer = ${canonicalGoogleIssuer}
+       AND identity.subject = legacy.provider_subject
+      WHERE legacy.provider = 'google'
+        AND identity.id IS NULL
+      ORDER BY legacy.id
+      LIMIT ${batchSize}
+      ON CONFLICT (issuer, subject) DO NOTHING
+      RETURNING id
+    `.execute(executor)
+    return rows.rows.length
+  })
+
+  result.oidc_links = await runBatches(async () => {
+    const rows = await sql<{ id: string }>`
+      INSERT INTO organization_member_oidc_identities (
+        membership_id,
+        organization_id,
+        user_id,
+        organization_oidc_provider_id,
+        oidc_identity_id
+      )
+      SELECT
+        m.id,
+        m.organization_id,
+        m.user_id,
+        provider.id,
+        identity.id
+      FROM organization_memberships AS m
+      JOIN organization_auth_settings AS settings
+        ON settings.organization_id = m.organization_id
+       AND settings.oidc_auth_enabled
+      JOIN oidc_identities AS identity
+        ON identity.user_id = m.user_id
+       AND identity.issuer = ${canonicalGoogleIssuer}
+      JOIN organization_oidc_providers AS provider
+        ON provider.organization_id = m.organization_id
+       AND provider.enabled
+       AND provider.issuer = ${canonicalGoogleIssuer}
+      LEFT JOIN organization_member_oidc_identities AS link
+        ON link.membership_id = m.id
+       AND link.organization_oidc_provider_id = provider.id
+       AND link.oidc_identity_id = identity.id
+      WHERE m.id IS NOT NULL
+        AND m.status IN ('active', 'suspended')
+        AND link.id IS NULL
+      ORDER BY m.id
+      LIMIT ${batchSize}
+      ON CONFLICT (
+        membership_id,
+        organization_oidc_provider_id,
+        oidc_identity_id
+      ) DO NOTHING
+      RETURNING id
+    `.execute(executor)
+    return rows.rows.length
+  })
+
+  return result
+}
+
+export interface VerificationResult {
+  pending_contact_emails: number
+  pending_invite_creators: number
+  pending_member_profiles: number
+  pending_memberships: number
+  pending_organization_statuses: number
+  pending_pedestrian_memberships: number
+  pending_profile_measurements: number
+  pending_user_profiles: number
+}
+
+export const verifyMultiOrgAuthCoreBackfill = async (
+  executor: DbExecutor = db
+): Promise<VerificationResult> => {
+  const rows = await sql<VerificationResult>`
+    SELECT
+      (SELECT count(*) FROM organizations WHERE status IS NULL)::integer
+        AS pending_organization_statuses,
+      (SELECT count(*) FROM organization_memberships
+        WHERE id IS NULL OR status IS NULL OR joined_at IS NULL)::integer
+        AS pending_memberships,
+      (SELECT count(*) FROM users WHERE contact_email IS NULL)::integer
+        AS pending_contact_emails,
+      (SELECT count(*) FROM users AS u LEFT JOIN user_profiles AS p ON p.user_id = u.id
+        WHERE p.user_id IS NULL)::integer AS pending_user_profiles,
+      (SELECT count(*) FROM pedestrians
+        WHERE user_id IS NOT NULL AND membership_id IS NULL)::integer
+        AS pending_pedestrian_memberships,
+      (SELECT count(*) FROM organization_memberships AS m
+        LEFT JOIN organization_member_profiles AS profile ON profile.membership_id = m.id
+        WHERE m.id IS NOT NULL AND profile.membership_id IS NULL)::integer
+        AS pending_member_profiles,
+      (SELECT count(*) FROM pedestrians AS p
+        JOIN organization_member_profiles AS profile ON profile.membership_id = p.membership_id
+        WHERE (p.height IS NOT NULL AND profile.height_meters IS NULL)
+           OR (p.stride_length IS NOT NULL AND profile.stride_length_meters IS NULL))::integer
+        AS pending_profile_measurements,
+      (SELECT count(*) FROM organization_invites
+        WHERE created_by_membership_id IS NULL)::integer AS pending_invite_creators
+  `.execute(executor)
+  return (
+    rows.rows[0] ?? {
+      pending_contact_emails: 0,
+      pending_invite_creators: 0,
+      pending_member_profiles: 0,
+      pending_memberships: 0,
+      pending_organization_statuses: 0,
+      pending_pedestrian_memberships: 0,
+      pending_profile_measurements: 0,
+      pending_user_profiles: 0,
+    }
+  )
+}
+
+export const validateMultiOrgAuthExpandConstraints = async (
+  executor: DbExecutor = db
+): Promise<void> => {
+  const verification = await verifyMultiOrgAuthCoreBackfill(executor)
+  if (Object.values(verification).some((count) => count > 0)) {
+    throw new Error(`constraint validation blocked: ${JSON.stringify(verification)}`)
+  }
+
+  await sql
+    .raw(
+      `
+    SET LOCAL lock_timeout = '5s';
+
+    ALTER TABLE users VALIDATE CONSTRAINT users_contact_email_state_chk;
+    ALTER TABLE organizations VALIDATE CONSTRAINT organizations_status_chk;
+    ALTER TABLE organization_memberships
+      VALIDATE CONSTRAINT organization_memberships_status_chk;
+    ALTER TABLE organization_memberships
+      VALIDATE CONSTRAINT organization_memberships_left_at_chk;
+    ALTER TABLE pedestrians
+      VALIDATE CONSTRAINT pedestrians_membership_organization_fkey;
+    ALTER TABLE organization_invites
+      VALIDATE CONSTRAINT organization_invites_creator_org_fkey;
+    ALTER TABLE organization_invites
+      VALIDATE CONSTRAINT organization_invites_redeemed_membership_org_fkey;
+    ALTER TABLE organization_invites
+      VALIDATE CONSTRAINT organization_invites_redemption_state_chk;
+    ALTER TABLE organization_invites
+      VALIDATE CONSTRAINT organization_invites_revoked_redeemed_chk;
+    ALTER TABLE organization_invites
+      VALIDATE CONSTRAINT organization_invites_role_chk;
+
+    ALTER TABLE organizations
+      ADD CONSTRAINT organizations_status_not_null_backfill_chk
+      CHECK (status IS NOT NULL) NOT VALID;
+    ALTER TABLE organization_memberships
+      ADD CONSTRAINT organization_memberships_id_not_null_backfill_chk
+      CHECK (id IS NOT NULL) NOT VALID;
+    ALTER TABLE organization_memberships
+      ADD CONSTRAINT organization_memberships_status_not_null_backfill_chk
+      CHECK (status IS NOT NULL) NOT VALID;
+    ALTER TABLE organization_memberships
+      ADD CONSTRAINT organization_memberships_joined_at_not_null_backfill_chk
+      CHECK (joined_at IS NOT NULL) NOT VALID;
+
+    ALTER TABLE organizations
+      VALIDATE CONSTRAINT organizations_status_not_null_backfill_chk;
+    ALTER TABLE organization_memberships
+      VALIDATE CONSTRAINT organization_memberships_id_not_null_backfill_chk;
+    ALTER TABLE organization_memberships
+      VALIDATE CONSTRAINT organization_memberships_status_not_null_backfill_chk;
+    ALTER TABLE organization_memberships
+      VALIDATE CONSTRAINT organization_memberships_joined_at_not_null_backfill_chk;
+
+    ALTER TABLE organizations ALTER COLUMN status SET NOT NULL;
+    ALTER TABLE organization_memberships ALTER COLUMN id SET NOT NULL;
+    ALTER TABLE organization_memberships ALTER COLUMN status SET NOT NULL;
+    ALTER TABLE organization_memberships ALTER COLUMN joined_at SET NOT NULL;
+
+    ALTER TABLE organizations
+      DROP CONSTRAINT organizations_status_not_null_backfill_chk;
+    ALTER TABLE organization_memberships
+      DROP CONSTRAINT organization_memberships_id_not_null_backfill_chk;
+    ALTER TABLE organization_memberships
+      DROP CONSTRAINT organization_memberships_status_not_null_backfill_chk;
+    ALTER TABLE organization_memberships
+      DROP CONSTRAINT organization_memberships_joined_at_not_null_backfill_chk;
+  `
+    )
+    .execute(executor)
+}

--- a/apps/kaede/tests/services/db/multi-org-auth-backfill.test.ts
+++ b/apps/kaede/tests/services/db/multi-org-auth-backfill.test.ts
@@ -1,0 +1,335 @@
+import { sql } from 'kysely'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { createDb } from '../../../src/services/db/client.js'
+import {
+  backfillMultiOrgAuthCore,
+  backfillMultiOrgAuthCredentials,
+  canonicalGoogleIssuer,
+  getMultiOrgAuthPreflightReport,
+  validateMultiOrgAuthExpandConstraints,
+  verifyMultiOrgAuthCoreBackfill,
+} from '../../../src/services/migrations/multi-org-auth-backfill.js'
+import { resetDatabase } from '../../db/helpers.js'
+
+const db = createDb()
+const passwordHash = '$argon2id$v=19$m=65536,t=3,p=4$ZHVtbXk$legacy-password-hash'
+
+const createLegacyUserAndMembership = async (suffix: string) => {
+  const user = await db
+    .insertInto('users')
+    .values({
+      display_name: `User ${suffix}`,
+      email: `${suffix}@example.com`,
+      global_role: 'none',
+      password_hash: passwordHash,
+      status: 'active',
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const organization = await db
+    .insertInto('organizations')
+    .values({ name: `Organization ${suffix}` })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const membership = await db
+    .insertInto('organization_memberships')
+    .values({ organization_id: organization.id, role: 'owner', user_id: user.id })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+  await sql`
+    UPDATE organization_memberships
+    SET id = NULL, status = NULL, joined_at = NULL
+    WHERE organization_id = ${organization.id} AND user_id = ${user.id}
+  `.execute(db)
+  await sql`UPDATE organizations SET status = NULL WHERE id = ${organization.id}`.execute(db)
+
+  return { membership, organization, user }
+}
+
+describe('multi organization auth backfill', () => {
+  beforeEach(async () => {
+    await resetDatabase(db)
+  })
+
+  afterAll(async () => {
+    await db.destroy()
+  })
+
+  it('backfills the safe core fields in batches and is idempotent', async () => {
+    const { organization, user } = await createLegacyUserAndMembership('core')
+    const pedestrian = await db
+      .insertInto('pedestrians')
+      .values({
+        display_name: 'Organization Persona',
+        organization_id: organization.id,
+        user_id: user.id,
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    await db
+      .insertInto('organization_invites')
+      .values({
+        created_by_user_id: user.id,
+        email: 'invitee@example.com',
+        expires_at: new Date('2026-08-20T00:00:00.000Z'),
+        organization_id: organization.id,
+        role: 'member',
+        token_hash: 'legacy-token',
+      })
+      .execute()
+
+    const first = await backfillMultiOrgAuthCore(1, db)
+    const second = await backfillMultiOrgAuthCore(1, db)
+    const verification = await verifyMultiOrgAuthCoreBackfill(db)
+
+    expect(first).toMatchObject({
+      contact_emails: 1,
+      invite_creators: 1,
+      memberships: 1,
+      member_profiles: 1,
+      organizations: 1,
+      pedestrian_memberships: 1,
+      user_profiles: 1,
+    })
+    expect(Object.values(second).every((count) => count === 0)).toBe(true)
+    expect(Object.values(verification).every((count) => count === 0)).toBe(true)
+
+    const migratedPedestrian = await db
+      .selectFrom('pedestrians')
+      .select('membership_id')
+      .where('id', '=', pedestrian.id)
+      .executeTakeFirstOrThrow()
+    if (!migratedPedestrian.membership_id) throw new Error('membership was not backfilled')
+    const memberProfile = await db
+      .selectFrom('organization_member_profiles')
+      .selectAll()
+      .where('membership_id', '=', migratedPedestrian.membership_id)
+      .executeTakeFirstOrThrow()
+    expect(memberProfile.display_name).toBe('Organization Persona')
+    expect(memberProfile.height_meters).toBeNull()
+    expect(memberProfile.stride_length_meters).toBeNull()
+  })
+
+  it('normalizes meter and centimeter measurements and reports their classifications', async () => {
+    const { organization, user } = await createLegacyUserAndMembership('measurements')
+    await db
+      .insertInto('pedestrians')
+      .values({
+        display_name: 'Measured User',
+        height: 170,
+        organization_id: organization.id,
+        stride_length: 0.7,
+        user_id: user.id,
+      })
+      .execute()
+
+    const report = await getMultiOrgAuthPreflightReport(db)
+    expect(report.measurements).toEqual({ already_m: 1, converted_cm: 1, invalid: 0 })
+
+    const result = await backfillMultiOrgAuthCore(10, db)
+    const profile = await db
+      .selectFrom('organization_member_profiles')
+      .select(['height_meters', 'stride_length_meters'])
+      .executeTakeFirstOrThrow()
+    expect(profile).toEqual({ height_meters: '1.700', stride_length_meters: '0.700' })
+    expect(result.measurement_values_already_m).toBe(1)
+    expect(result.measurement_values_converted_cm).toBe(1)
+  })
+
+  it('blocks values that cannot be represented safely after normalization', async () => {
+    const { organization, user } = await createLegacyUserAndMembership('invalid-measurement')
+    await db
+      .insertInto('pedestrians')
+      .values({
+        display_name: 'Invalid Measurement',
+        height: 0.0001,
+        organization_id: organization.id,
+        stride_length: 301,
+        user_id: user.id,
+      })
+      .execute()
+
+    const report = await getMultiOrgAuthPreflightReport(db)
+    expect(report.measurements.invalid).toBe(2)
+    await expect(backfillMultiOrgAuthCore(10, db)).rejects.toThrow(
+      'PEDESTRIAN_MEASUREMENT_OUT_OF_RANGE'
+    )
+  })
+
+  it('returns an exact issue count with at most twenty samples', async () => {
+    const { organization } = await createLegacyUserAndMembership('bounded-samples')
+    await db
+      .insertInto('pedestrians')
+      .values(
+        Array.from({ length: 25 }, (_, index) => ({
+          display_name: `Invalid ${index}`,
+          height: 301,
+          organization_id: organization.id,
+        }))
+      )
+      .execute()
+
+    const report = await getMultiOrgAuthPreflightReport(db)
+    const issue = report.issues.find(
+      (candidate) => candidate.code === 'PEDESTRIAN_MEASUREMENT_OUT_OF_RANGE'
+    )
+    expect(issue?.count).toBe(25)
+    expect(issue?.samples).toHaveLength(20)
+  })
+
+  it('stops core backfill before writing when a blocking legacy issue exists', async () => {
+    const { organization, user } = await createLegacyUserAndMembership('legacy-blocker')
+    await db
+      .insertInto('organization_invites')
+      .values({
+        created_by_user_id: user.id,
+        email: 'legacy-multi-use@example.com',
+        expires_at: new Date('2026-08-20T00:00:00.000Z'),
+        max_uses: 2,
+        organization_id: organization.id,
+        role: 'member',
+        token_hash: 'legacy-multi-use-token',
+      })
+      .execute()
+
+    await expect(backfillMultiOrgAuthCore(10, db)).rejects.toThrow('LEGACY_MULTI_USE_INVITE')
+    const unchanged = await db
+      .selectFrom('organization_memberships')
+      .select(['id', 'joined_at', 'status'])
+      .where('organization_id', '=', organization.id)
+      .where('user_id', '=', user.id)
+      .executeTakeFirstOrThrow()
+    expect(unchanged).toEqual({ id: null, joined_at: null, status: null })
+  })
+
+  it('stops auth backfill on normalized login email collision', async () => {
+    const first = await createLegacyUserAndMembership('collision-first')
+    const secondUser = await db
+      .insertInto('users')
+      .values({
+        display_name: 'Collision Second',
+        email: 'COLLISION-FIRST@example.com',
+        global_role: 'none',
+        password_hash: passwordHash,
+        status: 'active',
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    await db
+      .insertInto('organization_memberships')
+      .values({
+        organization_id: first.organization.id,
+        role: 'member',
+        user_id: secondUser.id,
+      })
+      .execute()
+    await db
+      .insertInto('organization_auth_settings')
+      .values({
+        local_auth_enabled: true,
+        membership_grant_ttl_seconds: 3600,
+        oidc_auth_enabled: false,
+        organization_id: first.organization.id,
+        reauthentication_interval_seconds: 1800,
+      })
+      .execute()
+    await backfillMultiOrgAuthCore(10, db)
+
+    await expect(backfillMultiOrgAuthCredentials(10, db)).rejects.toThrow(
+      'LOCAL_LOGIN_EMAIL_COLLISION'
+    )
+    expect(await db.selectFrom('organization_local_credentials').selectAll().execute()).toEqual([])
+  })
+
+  it('backfills local credentials and canonical Google identities only after explicit policy/provider setup', async () => {
+    const { organization, user } = await createLegacyUserAndMembership('auth')
+    await backfillMultiOrgAuthCore(10, db)
+    await db
+      .insertInto('organization_auth_settings')
+      .values({
+        local_auth_enabled: true,
+        membership_grant_ttl_seconds: 3600,
+        oidc_auth_enabled: true,
+        organization_id: organization.id,
+        reauthentication_interval_seconds: 1800,
+      })
+      .execute()
+    await db
+      .insertInto('organization_oidc_providers')
+      .values({
+        client_id: 'legacy-google-client',
+        issuer: canonicalGoogleIssuer,
+        name: 'Google',
+        organization_id: organization.id,
+        scopes: ['openid'],
+      })
+      .execute()
+    await db
+      .insertInto('auth_identities')
+      .values({
+        email: user.email,
+        email_verified: true,
+        provider: 'google',
+        provider_subject: 'legacy-google-subject',
+        user_id: user.id,
+      })
+      .execute()
+
+    const first = await backfillMultiOrgAuthCredentials(1, db)
+    const second = await backfillMultiOrgAuthCredentials(1, db)
+
+    expect(first).toMatchObject({
+      auth_settings_unchanged: 1,
+      local_credentials: 1,
+      oidc_identities: 1,
+      oidc_links: 1,
+    })
+    expect(second).toMatchObject({
+      auth_settings_unchanged: 1,
+      local_credentials: 0,
+      oidc_identities: 0,
+      oidc_links: 0,
+    })
+    await expect(
+      db
+        .selectFrom('oidc_identities')
+        .select(['issuer', 'subject', 'user_id'])
+        .executeTakeFirstOrThrow()
+    ).resolves.toEqual({
+      issuer: canonicalGoogleIssuer,
+      subject: 'legacy-google-subject',
+      user_id: user.id,
+    })
+  })
+
+  it('validates expand constraints and promotes required columns only after core verification', async () => {
+    await db
+      .transaction()
+      .execute(async (trx) => {
+        await createLegacyUserAndMembership('validate')
+        await backfillMultiOrgAuthCore(10, trx)
+        await validateMultiOrgAuthExpandConstraints(trx)
+
+        const columns = await sql<{ attname: string; attnotnull: boolean }>`
+          SELECT attribute.attname, attribute.attnotnull
+          FROM pg_attribute AS attribute
+          WHERE attribute.attrelid = 'organization_memberships'::regclass
+            AND attribute.attname IN ('id', 'status', 'joined_at')
+          ORDER BY attribute.attname
+        `.execute(trx)
+        expect(columns.rows).toEqual([
+          { attname: 'id', attnotnull: true },
+          { attname: 'joined_at', attnotnull: true },
+          { attname: 'status', attnotnull: true },
+        ])
+
+        throw new Error('rollback constraint promotion test')
+      })
+      .catch((error: unknown) => {
+        if (!(error instanceof Error) || error.message !== 'rollback constraint promotion test') {
+          throw error
+        }
+      })
+  })
+})

--- a/db/multi-organization-auth-backfill.md
+++ b/db/multi-organization-auth-backfill.md
@@ -1,0 +1,93 @@
+# Multi-Organization Auth Backfill Runbook
+
+この手順は、multi-organization authのExpand schema適用後に既存データを移行するためのものです。
+旧column/API/sessionはこの手順では削除・切替しません。
+
+## 安全原則
+
+- 本番と同等のsnapshotで事前リハーサルする。
+- `preflight` のblocking issueを手動で解消し、データを推測で修正しない。
+- backfillはbatch実行し、再実行可能であることを確認する。
+- Organizationの認証方式はglobal runtime設定から推測しない。各Organizationについて明示的に決定する。
+- 既存Sessionのrevoke、auth cutover、旧column削除、Membership PK切替は後続PRで行う。
+
+## 測定値の正規化
+
+`pedestrians.height` と `pedestrians.stride_length` は次の規則でmeterへ統一する。
+
+| 既存値                      | 判定       | 保存値                             |
+| --------------------------- | ---------- | ---------------------------------- |
+| `NULL`                      | 未設定     | `NULL`                             |
+| `0 < value <= 3`            | 既にmeter  | 小数第3位へ丸める                  |
+| `3 < value <= 300`          | centimeter | `value / 100`後、小数第3位へ丸める |
+| 上記以外、または丸め後に`0` | 不正       | blocking issue。自動修正しない     |
+
+`preflight` は `already_m / converted_cm / invalid` の値数を返す。`backfill-core`も実際に書き込んだ
+`measurement_values_already_m / measurement_values_converted_cm`を返す。
+
+## 実行コマンド
+
+Kaede directoryで実行する。
+
+```sh
+pnpm multi-org-auth-backfill preflight
+pnpm multi-org-auth-backfill backfill-core --batch-size 500
+pnpm multi-org-auth-backfill verify
+```
+
+`backfill-core`の対象は次の通り。
+
+- Organization status
+- Membership UUID/status/joined_at（`joined_at`は旧Membershipの`created_at`を使用）
+- User contact emailと共通Profile
+- PedestrianとMembershipの関連
+- Organization member profile（表示名override、meterへ正規化した身長・歩幅）
+- Invite creator Membership
+
+## 認証設定とCredential移行
+
+先に各Organizationの`organization_auth_settings`を運用者が明示的に登録する。OIDCを有効にする場合は、
+そのOrganizationにcanonical issuer `https://accounts.google.com`を持つ有効なProviderを1件登録する。
+作成者のemail domainやglobal環境変数からpolicy/hosted domainを自動設定しない。
+
+設定後に再度preflightを実行する。
+
+```sh
+pnpm multi-org-auth-backfill preflight
+pnpm multi-org-auth-backfill backfill-auth --batch-size 500
+```
+
+`backfill-auth`は次を行う。
+
+- Local auth有効Organizationだけ、現在Membershipとlegacy passwordからLocal Credentialを作る。
+- login emailは`lower(btrim(email))`で正規化し、Organization内collisionがあれば全auth backfillを停止する。
+- legacy Google Identityをcanonical `issuer + subject`へ移す。emailはIdentity keyにしない。
+- OIDC auth有効かつGoogle Providerが一意に決まるOrganizationだけMembership Linkを作る。
+
+認証policy不足、Providerの不足/複数候補、Identity owner conflictがある場合は何も自動修正せず停止する。
+
+## Constraint validation
+
+core verifyが全て0になった後だけ実行する。
+
+```sh
+pnpm multi-org-auth-backfill validate
+```
+
+これはExpandで`NOT VALID`として追加した、今回のbackfillで安全に検証できるconstraintを`VALIDATE`し、
+Organization statusとMembership UUID/status/joined_atを`NOT NULL`へ昇格する。
+NOT NULL昇格では短い`lock_timeout`と一時的な`NOT VALID` CHECKの事前検証を利用し、長時間のlockと再scanを避ける。
+Membershipの旧`(organization_id, user_id)` PKと同じ意味になるcurrent Membership partial unique indexはこのPRでは追加しない。
+現行Repositoryが同制約をupsert conflict targetとして使っているため、UUID PKへの切替はRepository互換対応と同じPRで行う。
+
+## blocking issueの扱い
+
+- `LOCAL_LOGIN_EMAIL_COLLISION`: 対象のlogin emailを運用判断で変更してから再実行する。
+- `MISSING_ORGANIZATION_AUTH_POLICY`: OrganizationごとのLocal/OIDC policyを明示する。
+- `OIDC_PROVIDER_MAPPING_MISSING_OR_AMBIGUOUS`: Providerを一意に確定する。
+- `OIDC_IDENTITY_OWNER_CONFLICT`: account linkを自動統合せず、本人確認を伴う別手順で解消する。
+- `PEDESTRIAN_MEMBERSHIP_NOT_FOUND`: Membershipとの対応を確認する。
+- `PEDESTRIAN_MEASUREMENT_OUT_OF_RANGE`: 元データの単位・値を確認して修正する。
+- `INVITE_CREATOR_MEMBERSHIP_NOT_FOUND`: 発行者Membershipを確認する。
+- `LEGACY_MULTI_USE_INVITE`: 権限を持つmanager/ownerが新しいsingle-use Inviteを発行する。
+- `PENDING_ACTIVATION_USER`: cutover前にactivation状態を運用判断する。


### PR DESCRIPTION
## Issue

- #219

## 概要

- 既存Membership/Profile/Pedestrian/Inviteを再実行可能なバッチで移行
- Local CredentialとGoogle OIDC Identity/Linkを明示Policyに基づいて移行
- 身長・歩幅をメートルへ統一し、衝突・不整合は書込み前に停止
- Preflight、Verify、制約昇格、運用Runbookを追加

## 確認内容

- Lint / TypeScript: PASS
- Unit tests: 7 PASS
- Database tests: 221 PASS
- git diff --check: PASS

既存認証の切替・旧column削除・Membership PK切替は行いません。