### PR TITLE
feat(kaede): add single-use organization invites

### DIFF
--- a/apps/kaede/src/routes/organization-invites/error.ts
+++ b/apps/kaede/src/routes/organization-invites/error.ts
@@ -1,0 +1,47 @@
+import type { OrganizationInviteError } from '../../usecases/organization-invites/index.js'
+
+export const toOrganizationInviteErrorResponse = (error: OrganizationInviteError) => {
+  switch (error.type) {
+    case 'AUTH_DASHBOARD_FORBIDDEN':
+    case 'AUTH_ORGANIZATION_FORBIDDEN':
+    case 'AUTH_METHOD_NOT_ALLOWED':
+    case 'INVITE_MEMBERSHIP_SUSPENDED':
+    case 'AUTH_USER_DISABLED':
+      return {
+        status: 403 as const,
+        body: { error_code: error.type, error_message: 'operation is not allowed' },
+      }
+    case 'AUTH_SESSION_EXPIRED':
+    case 'AUTH_SESSION_REVOKED':
+      return {
+        status: 401 as const,
+        body: { error_code: error.type, error_message: 'session is not valid' },
+      }
+    case 'INVITE_NOT_FOUND':
+    case 'INVITE_INVALID':
+      return {
+        status: 404 as const,
+        body: { error_code: error.type, error_message: 'invite is not available' },
+      }
+    case 'INVITE_EXPIRED':
+      return {
+        status: 422 as const,
+        body: { error_code: error.type, error_message: 'invite expired' },
+      }
+    case 'INVITE_ALREADY_REDEEMED':
+    case 'INVITE_ALREADY_REVOKED':
+    case 'INVITE_ALREADY_MEMBER':
+    case 'LOCAL_LOGIN_EMAIL_CONFLICT':
+    case 'MEMBERSHIP_PROFILE_UNAVAILABLE':
+      return {
+        status: 409 as const,
+        body: { error_code: error.type, error_message: 'invite conflicts with current state' },
+      }
+    case 'INVITE_NEW_USER_PROFILE_REQUIRED':
+    case 'INVITE_EXISTING_USER_PROFILE_NOT_ALLOWED':
+      return {
+        status: 400 as const,
+        body: { error_code: error.type, error_message: 'invalid invite registration payload' },
+      }
+  }
+}

--- a/apps/kaede/src/routes/organization-invites/index.ts
+++ b/apps/kaede/src/routes/organization-invites/index.ts
@@ -1,0 +1,5 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { registerPublicOrganizationInviteRoutes } from './public.js'
+
+export const organizationInvitesRoutes = new OpenAPIHono()
+registerPublicOrganizationInviteRoutes(organizationInvitesRoutes)

--- a/apps/kaede/src/routes/organization-invites/public.test.ts
+++ b/apps/kaede/src/routes/organization-invites/public.test.ts
@@ -1,0 +1,120 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { resetRuntimeConfigForTests } from '../../config/runtime.js'
+
+const usecases = vi.hoisted(() => ({
+  acceptOrganizationInviteWithLocalCredential: vi.fn(),
+  verifyOrganizationInvite: vi.fn(),
+}))
+vi.mock('../../usecases/organization-invites/index.js', () => usecases)
+
+import { organizationInvitesRoutes } from './index.js'
+
+const app = () => {
+  const instance = new OpenAPIHono()
+  instance.route('/api/invites', organizationInvitesRoutes)
+  return instance
+}
+
+describe('public organization invite routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.APP_ENV = 'local'
+    resetRuntimeConfigForTests()
+  })
+
+  afterEach(() => {
+    Reflect.deleteProperty(process.env, 'APP_ENV')
+    resetRuntimeConfigForTests()
+  })
+
+  it('verifyはInvite情報をno-storeで返す', async () => {
+    usecases.verifyOrganizationInvite.mockResolvedValue({
+      ok: true,
+      value: {
+        organization: { name: 'Example' },
+        role: 'member',
+        expires_at: '2026-08-18T10:00:00.000Z',
+        authentication_methods: { local: true, oidc: true },
+      },
+    })
+    const response = await app().request('/api/invites/verify', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ token: 'plain-token' }),
+    })
+    expect(response.status).toBe(200)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    await expect(response.json()).resolves.toMatchObject({ role: 'member' })
+  })
+
+  it('新規Local受領ではSession cookieを発行しtokenをresponse bodyへ含めない', async () => {
+    usecases.acceptOrganizationInviteWithLocalCredential.mockResolvedValue({
+      ok: true,
+      value: {
+        sessionToken: 'new-session-token',
+        session: { expires_at: '2026-08-18T10:00:00.000Z' },
+        membership: {
+          id: '22222222-2222-4222-8222-222222222222',
+          organization_id: '11111111-1111-4111-8111-111111111111',
+          role: 'member',
+          status: 'active',
+        },
+        grant: {
+          auth_method: 'local',
+          authenticated_at: '2026-08-11T10:00:00.000Z',
+          expires_at: '2026-08-11T11:00:00.000Z',
+        },
+      },
+    })
+    const response = await app().request('/api/invites/auth/local', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        token: 'plain-token',
+        login_email: 'member@example.test',
+        password: 'password',
+        contact_email: 'contact@example.test',
+        profile: { display_name: 'Member', locale: 'ja-JP', timezone: 'Asia/Tokyo' },
+      }),
+    })
+    expect(response.status).toBe(200)
+    expect(response.headers.get('set-cookie')).toContain('okarin_session=new-session-token')
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    expect(JSON.stringify(await response.json())).not.toContain('new-session-token')
+  })
+
+  it.each([
+    ['INVITE_INVALID', 404],
+    ['INVITE_ALREADY_REDEEMED', 409],
+    ['INVITE_EXPIRED', 422],
+  ])('verifyの%sをHTTP %iで返す', async (type, status) => {
+    usecases.verifyOrganizationInvite.mockResolvedValue({ ok: false, error: { type } })
+    const response = await app().request('/api/invites/verify', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ token: 'plain-token' }),
+    })
+    expect(response.status).toBe(status)
+  })
+
+  it.each([
+    ['locale', { display_name: 'Member', locale: 'not_a_locale', timezone: 'Asia/Tokyo' }],
+    ['timezone', { display_name: 'Member', locale: 'ja-JP', timezone: 'Mars/Olympus' }],
+  ])('無効な%sをUseCaseへ渡さない', async (_field, profile) => {
+    const response = await app().request('/api/invites/auth/local', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        token: 'plain-token',
+        login_email: ' member@example.test ',
+        password: 'password',
+        contact_email: ' contact@example.test ',
+        profile,
+      }),
+    })
+
+    expect(response.status).toBe(400)
+    expect(usecases.acceptOrganizationInviteWithLocalCredential).not.toHaveBeenCalled()
+  })
+})

--- a/apps/kaede/src/routes/organization-invites/public.ts
+++ b/apps/kaede/src/routes/organization-invites/public.ts
@@ -1,0 +1,127 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { errorResponseSchema } from '../../schemas/common.js'
+import {
+  acceptLocalOrganizationInviteRequestSchema,
+  acceptLocalOrganizationInviteResponseSchema,
+  verifyOrganizationInviteRequestSchema,
+  verifyOrganizationInviteResponseSchema,
+} from '../../schemas/organization-invites.js'
+import {
+  acceptOrganizationInviteWithLocalCredential,
+  verifyOrganizationInvite,
+} from '../../usecases/organization-invites/index.js'
+import { getSessionTokenFromCookie, setSessionCookie } from '../auth/cookie.js'
+import { toOrganizationInviteErrorResponse } from './error.js'
+
+const errors = {
+  400: {
+    description: 'invalid registration payload',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  401: {
+    description: 'invalid session',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  403: {
+    description: 'authentication method or membership is not allowed',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  404: {
+    description: 'invite not found',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  409: {
+    description: 'invite conflicts with current state',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  422: {
+    description: 'invite expired',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+} as const
+
+export const registerPublicOrganizationInviteRoutes = (app: OpenAPIHono) => {
+  const verifyRoute = createRoute({
+    method: 'post',
+    path: '/verify',
+    tags: ['Organization Invites'],
+    request: {
+      body: { content: { 'application/json': { schema: verifyOrganizationInviteRequestSchema } } },
+    },
+    responses: {
+      200: {
+        description: 'invite is available',
+        content: { 'application/json': { schema: verifyOrganizationInviteResponseSchema } },
+      },
+      404: errors[404],
+      409: errors[409],
+      422: errors[422],
+    },
+  })
+  app.openapi(verifyRoute, async (c) => {
+    const result = await verifyOrganizationInvite(c.req.valid('json').token)
+    if (!result.ok) {
+      switch (result.error.type) {
+        case 'INVITE_INVALID':
+          return c.json(
+            { error_code: result.error.type, error_message: 'invite is not available' },
+            404
+          )
+        case 'INVITE_ALREADY_REDEEMED':
+          return c.json(
+            { error_code: result.error.type, error_message: 'invite was already redeemed' },
+            409
+          )
+        case 'INVITE_EXPIRED':
+          return c.json({ error_code: result.error.type, error_message: 'invite expired' }, 422)
+      }
+    }
+    c.header('Cache-Control', 'no-store')
+    return c.json(result.value, 200)
+  })
+
+  const localRoute = createRoute({
+    method: 'post',
+    path: '/auth/local',
+    tags: ['Organization Invites'],
+    request: {
+      body: {
+        content: { 'application/json': { schema: acceptLocalOrganizationInviteRequestSchema } },
+      },
+    },
+    responses: {
+      200: {
+        description: 'invite accepted',
+        content: { 'application/json': { schema: acceptLocalOrganizationInviteResponseSchema } },
+      },
+      400: errors[400],
+      401: errors[401],
+      403: errors[403],
+      404: errors[404],
+      409: errors[409],
+      422: errors[422],
+    },
+  })
+  app.openapi(localRoute, async (c) => {
+    const result = await acceptOrganizationInviteWithLocalCredential(
+      getSessionTokenFromCookie(c),
+      c.req.valid('json'),
+      { requestId: c.req.header('x-request-id'), userAgent: c.req.header('user-agent') }
+    )
+    if (!result.ok) {
+      const error = toOrganizationInviteErrorResponse(result.error)
+      return c.json(error.body, error.status)
+    }
+    if (result.value.sessionToken) setSessionCookie(c, result.value.sessionToken)
+    c.header('Cache-Control', 'no-store')
+    return c.json(
+      {
+        session: result.value.session,
+        membership: result.value.membership,
+        grant: result.value.grant,
+      },
+      200
+    )
+  })
+}

--- a/apps/kaede/src/routes/organizations/index.ts
+++ b/apps/kaede/src/routes/organizations/index.ts
@@ -9,6 +9,7 @@ import { registerCreateOrganizationRoute } from './create-organization.js'
 import { registerCreateStayHeatmapRoute } from './create-stay-heatmap.js'
 import { registerGetOrganizationUserRoute } from './get-organization-user.js'
 import { registerGetOrganizationRoute } from './get-organization.js'
+import { registerOrganizationInviteRoutes } from './invites.js'
 import { registerListOrganizationBuildingFloorsRoute } from './list-organization-building-floors.js'
 import { registerListOrganizationBuildingsRoute } from './list-organization-buildings.js'
 import { registerListOrganizationFloorsRoute } from './list-organization-floors.js'
@@ -40,3 +41,4 @@ registerCreateStayHeatmapRoute(organizationsRoutes)
 registerAnalysisRunRoutes(organizationsRoutes)
 registerOrganizationMemberProfileRoutes(organizationsRoutes)
 registerOrganizationOidcProviderRoutes(organizationsRoutes)
+registerOrganizationInviteRoutes(organizationsRoutes)

--- a/apps/kaede/src/routes/organizations/invites.ts
+++ b/apps/kaede/src/routes/organizations/invites.ts
@@ -1,0 +1,155 @@
+import { createRoute, z } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { requireRequestActor } from '../../middleware/request-actor-context.js'
+import type { RequestActorContext } from '../../middleware/request-actor-context.js'
+import { errorResponseSchema } from '../../schemas/common.js'
+import {
+  createOrganizationInviteRequestSchema,
+  organizationInviteParamsSchema,
+  organizationInvitesParamsSchema,
+  organizationInvitesResponseSchema,
+  organizationInviteTokenResponseSchema,
+} from '../../schemas/organization-invites.js'
+import {
+  getOrganizationInvites,
+  issueOrganizationInvite,
+  reissueInvite,
+  revokeInvite,
+} from '../../usecases/organization-invites/index.js'
+import { toOrganizationInviteErrorResponse } from '../organization-invites/error.js'
+
+const errorResponses = {
+  400: {
+    description: 'invalid request',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  401: {
+    description: 'login required',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  403: {
+    description: 'permission denied',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  404: {
+    description: 'invite not found',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  409: {
+    description: 'invite conflicts with current state',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+} as const
+
+/* OpenAPIHono keeps each handler's status union at the call site; this shared mapper intentionally erases it. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const respondError = (c: any, error: Parameters<typeof toOrganizationInviteErrorResponse>[0]) => {
+  const response = toOrganizationInviteErrorResponse(error)
+  return c.json(response.body, response.status)
+}
+
+export const registerOrganizationInviteRoutes = (app: OpenAPIHono) => {
+  const listRoute = createRoute({
+    method: 'get',
+    path: '/{organizationId}/invites',
+    tags: ['Organization Invites'],
+    request: { params: organizationInvitesParamsSchema },
+    responses: {
+      200: {
+        description: 'invites',
+        content: { 'application/json': { schema: organizationInvitesResponseSchema } },
+      },
+      401: errorResponses[401],
+      403: errorResponses[403],
+    },
+  })
+  app.openapi(listRoute, async (c) => {
+    const result = await getOrganizationInvites(
+      requireRequestActor(c as RequestActorContext),
+      c.req.valid('param').organizationId
+    )
+    return result.ok ? c.json(result.value, 200) : respondError(c, result.error)
+  })
+
+  const issueRoute = createRoute({
+    method: 'post',
+    path: '/{organizationId}/invites',
+    tags: ['Organization Invites'],
+    request: {
+      params: organizationInvitesParamsSchema,
+      body: { content: { 'application/json': { schema: createOrganizationInviteRequestSchema } } },
+    },
+    responses: {
+      201: {
+        description: 'plain token is returned once',
+        content: { 'application/json': { schema: organizationInviteTokenResponseSchema } },
+      },
+      401: errorResponses[401],
+      403: errorResponses[403],
+    },
+  })
+  app.openapi(issueRoute, async (c) => {
+    const result = await issueOrganizationInvite(
+      requireRequestActor(c as RequestActorContext),
+      c.req.valid('param').organizationId,
+      c.req.valid('json')
+    )
+    if (!result.ok) return respondError(c, result.error)
+    c.header('Cache-Control', 'no-store')
+    return c.json(result.value, 201)
+  })
+
+  const revokeRoute = createRoute({
+    method: 'post',
+    path: '/{organizationId}/invites/{inviteId}/revoke',
+    tags: ['Organization Invites'],
+    request: { params: organizationInviteParamsSchema },
+    responses: {
+      200: {
+        description: 'revoked',
+        content: { 'application/json': { schema: z.object({ revoked: z.literal(true) }) } },
+      },
+      401: errorResponses[401],
+      403: errorResponses[403],
+      404: errorResponses[404],
+      409: errorResponses[409],
+    },
+  })
+  app.openapi(revokeRoute, async (c) => {
+    const p = c.req.valid('param')
+    const result = await revokeInvite(
+      requireRequestActor(c as RequestActorContext),
+      p.organizationId,
+      p.inviteId
+    )
+    return result.ok ? c.json(result.value, 200) : respondError(c, result.error)
+  })
+
+  const reissueRoute = createRoute({
+    method: 'post',
+    path: '/{organizationId}/invites/{inviteId}/reissue',
+    tags: ['Organization Invites'],
+    request: { params: organizationInviteParamsSchema },
+    responses: {
+      201: {
+        description: 'old invite revoked and new plain token returned once',
+        content: { 'application/json': { schema: organizationInviteTokenResponseSchema } },
+      },
+      401: errorResponses[401],
+      403: errorResponses[403],
+      404: errorResponses[404],
+      409: errorResponses[409],
+    },
+  })
+  app.openapi(reissueRoute, async (c) => {
+    const p = c.req.valid('param')
+    const result = await reissueInvite(
+      requireRequestActor(c as RequestActorContext),
+      p.organizationId,
+      p.inviteId
+    )
+    if (!result.ok) return respondError(c, result.error)
+    c.header('Cache-Control', 'no-store')
+    return c.json(result.value, 201)
+  })
+}

--- a/apps/kaede/src/schemas/organization-invites.test.ts
+++ b/apps/kaede/src/schemas/organization-invites.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { createOrganizationInviteRequestSchema } from './organization-invites.js'
+
+describe('organization invite schemas', () => {
+  it('owner roleのInviteを受け付けない', () => {
+    expect(createOrganizationInviteRequestSchema.safeParse({ role: 'owner' }).success).toBe(false)
+  })
+
+  it.each(['member', 'manager'])('%s roleのInviteを受け付ける', (role) => {
+    expect(createOrganizationInviteRequestSchema.safeParse({ role }).success).toBe(true)
+  })
+})

--- a/apps/kaede/src/schemas/organization-invites.ts
+++ b/apps/kaede/src/schemas/organization-invites.ts
@@ -1,0 +1,87 @@
+import { z } from '@hono/zod-openapi'
+import { isoDatetimeSchema, uuidSchema } from './common.js'
+import { displayNameSchema, localeSchema, timezoneSchema } from './profiles.js'
+
+export const inviteRoleSchema = z.enum(['member', 'manager'])
+export const inviteStatusSchema = z.enum(['active', 'redeemed', 'revoked', 'expired'])
+
+export const organizationInviteParamsSchema = z.object({
+  organizationId: uuidSchema,
+  inviteId: uuidSchema,
+})
+
+export const organizationInvitesParamsSchema = z.object({ organizationId: uuidSchema })
+
+export const createOrganizationInviteRequestSchema = z.object({ role: inviteRoleSchema })
+
+export const organizationInviteTokenResponseSchema = z
+  .object({
+    token: z.string().min(1),
+    expires_at: isoDatetimeSchema,
+  })
+  .openapi('OrganizationInviteTokenResponse')
+
+export const organizationInviteSchema = z.object({
+  id: uuidSchema,
+  role: inviteRoleSchema,
+  status: inviteStatusSchema,
+  expires_at: isoDatetimeSchema,
+  created_at: isoDatetimeSchema,
+})
+
+export const organizationInvitesResponseSchema = z
+  .object({ invites: z.array(organizationInviteSchema) })
+  .openapi('OrganizationInvitesResponse')
+
+export const verifyOrganizationInviteRequestSchema = z.object({
+  token: z.string().min(1).max(512),
+})
+
+export const verifyOrganizationInviteResponseSchema = z
+  .object({
+    organization: z.object({ name: z.string().min(1) }),
+    role: inviteRoleSchema,
+    expires_at: isoDatetimeSchema,
+    authentication_methods: z.object({
+      local: z.boolean(),
+      oidc: z.boolean(),
+    }),
+  })
+  .openapi('VerifyOrganizationInviteResponse')
+
+const newUserProfileSchema = z.object({
+  display_name: displayNameSchema,
+  locale: localeSchema,
+  timezone: timezoneSchema,
+})
+
+export const acceptLocalOrganizationInviteRequestSchema = z.object({
+  token: z.string().min(1).max(512),
+  login_email: z.string().trim().email().max(255),
+  password: z.string().min(8).max(100),
+  contact_email: z.string().trim().email().max(255).optional(),
+  profile: newUserProfileSchema.optional(),
+})
+
+export const acceptLocalOrganizationInviteResponseSchema = z
+  .object({
+    session: z.object({ expires_at: isoDatetimeSchema }),
+    membership: z.object({
+      id: uuidSchema,
+      organization_id: uuidSchema,
+      role: inviteRoleSchema,
+      status: z.literal('active'),
+    }),
+    grant: z.object({
+      auth_method: z.literal('local'),
+      authenticated_at: isoDatetimeSchema,
+      expires_at: isoDatetimeSchema,
+    }),
+  })
+  .openapi('AcceptLocalOrganizationInviteResponse')
+
+export type InviteRole = z.infer<typeof inviteRoleSchema>
+export type CreateOrganizationInviteRequest = z.infer<typeof createOrganizationInviteRequestSchema>
+export type AcceptLocalOrganizationInviteRequest = z.infer<
+  typeof acceptLocalOrganizationInviteRequestSchema
+>

--- a/apps/kaede/src/schemas/profiles.ts
+++ b/apps/kaede/src/schemas/profiles.ts
@@ -1,9 +1,9 @@
 import { z } from '@hono/zod-openapi'
 import { isoDatetimeSchema, uuidSchema } from './common.js'
 
-const displayNameSchema = z.string().trim().min(1).max(255)
+export const displayNameSchema = z.string().trim().min(1).max(255)
 
-const localeSchema = z
+export const localeSchema = z
   .string()
   .trim()
   .min(1)
@@ -17,7 +17,7 @@ const localeSchema = z
     }
   }, 'locale must be a valid BCP 47 language tag')
 
-const timezoneSchema = z
+export const timezoneSchema = z
   .string()
   .trim()
   .min(1)

--- a/apps/kaede/src/server.ts
+++ b/apps/kaede/src/server.ts
@@ -7,6 +7,7 @@ import { getRuntimeConfig } from './config/runtime.js'
 import { organizationAuthorizationMiddleware } from './middleware/organization-authorization.js'
 import { requestActorMiddleware } from './middleware/request-actor.js'
 import { registerApiRoutes } from './routes/index.js'
+import { organizationInvitesRoutes } from './routes/organization-invites/index.js'
 import { organizationLocalAuthRoutes } from './routes/organization-local-auth/index.js'
 import { organizationOidcAuthRoutes } from './routes/organization-oidc-auth/index.js'
 
@@ -38,6 +39,8 @@ export const createApp = () => {
   // Local loginはSessionなしでも利用でき、Sessionがある場合だけreauthenticateとして扱う。
   app.route('/api/organizations', organizationLocalAuthRoutes)
   app.route('/api/organizations', organizationOidcAuthRoutes)
+  // 招待確認・Local招待受領はSessionなしでも利用する。
+  app.route('/api/invites', organizationInvitesRoutes)
 
   app.onError((err, c) => {
     Sentry.captureException(err)

--- a/apps/kaede/src/services/organization-invites/index.ts
+++ b/apps/kaede/src/services/organization-invites/index.ts
@@ -1,0 +1,16 @@
+export {
+  consumeOrganizationInvite,
+  findActorMembership,
+  findActorMembershipForUpdate,
+  findEnabledLocalCredentialByEmail,
+  findInviteContextByTokenHash,
+  findInviteContextByTokenHashForUpdate,
+  findMembershipStateForInvite,
+  findOrganizationInviteForUpdate,
+  insertOrganizationInvite,
+  insertOrganizationLocalCredential,
+  insertOrganizationMembershipForInvite,
+  listOrganizationInvites,
+  revokeOrganizationInvite,
+} from './repository.js'
+export type { OrganizationInvite } from './repository.js'

--- a/apps/kaede/src/services/organization-invites/repository.ts
+++ b/apps/kaede/src/services/organization-invites/repository.ts
@@ -1,0 +1,211 @@
+import { sql } from 'kysely'
+import type { Insertable, Selectable } from 'kysely'
+import type {
+  OrganizationInvites,
+  OrganizationLocalCredentials,
+  OrganizationMemberships,
+} from '../db/generated.js'
+import { db } from '../db/index.js'
+import type { DbExecutor } from '../executor.js'
+
+export type OrganizationInvite = Selectable<OrganizationInvites>
+
+export const findActorMembershipForUpdate = async (
+  organizationId: string,
+  userId: string,
+  executor: DbExecutor
+) => {
+  return executor
+    .selectFrom('organization_memberships')
+    .selectAll()
+    .where('organization_id', '=', organizationId)
+    .where('user_id', '=', userId)
+    .where('status', 'in', ['active', 'suspended'])
+    .forUpdate()
+    .executeTakeFirst()
+}
+
+export const findActorMembership = async (
+  organizationId: string,
+  userId: string,
+  executor: DbExecutor = db
+) => {
+  return executor
+    .selectFrom('organization_memberships')
+    .selectAll()
+    .where('organization_id', '=', organizationId)
+    .where('user_id', '=', userId)
+    .where('status', 'in', ['active', 'suspended'])
+    .executeTakeFirst()
+}
+
+export const insertOrganizationInvite = async (
+  invite: Insertable<OrganizationInvites>,
+  executor: DbExecutor
+): Promise<OrganizationInvite> => {
+  return executor
+    .insertInto('organization_invites')
+    .values(invite)
+    .returningAll()
+    .executeTakeFirstOrThrow()
+}
+
+export const listOrganizationInvites = async (
+  organizationId: string,
+  roles: ('member' | 'manager')[],
+  executor: DbExecutor = db
+): Promise<OrganizationInvite[]> => {
+  return executor
+    .selectFrom('organization_invites')
+    .selectAll()
+    .where('organization_id', '=', organizationId)
+    .where('role', 'in', roles)
+    .orderBy('created_at', 'desc')
+    .execute()
+}
+
+export const findOrganizationInviteForUpdate = async (
+  organizationId: string,
+  inviteId: string,
+  executor: DbExecutor
+): Promise<OrganizationInvite | undefined> => {
+  return executor
+    .selectFrom('organization_invites')
+    .selectAll()
+    .where('organization_id', '=', organizationId)
+    .where('id', '=', inviteId)
+    .forUpdate()
+    .executeTakeFirst()
+}
+
+export const revokeOrganizationInvite = async (
+  inviteId: string,
+  revokedAt: Date,
+  executor: DbExecutor
+) => {
+  return executor
+    .updateTable('organization_invites')
+    .set({ revoked_at: revokedAt })
+    .where('id', '=', inviteId)
+    .where('redeemed_at', 'is', null)
+    .where('revoked_at', 'is', null)
+    .returningAll()
+    .executeTakeFirst()
+}
+
+const inviteContextQuery = (executor: DbExecutor) =>
+  executor
+    .selectFrom('organization_invites as invite')
+    .innerJoin('organizations as organization', 'organization.id', 'invite.organization_id')
+    .leftJoin(
+      'organization_auth_settings as auth_settings',
+      'auth_settings.organization_id',
+      'organization.id'
+    )
+    .select([
+      'invite.id as invite_id',
+      'invite.organization_id',
+      'invite.role',
+      'invite.expires_at',
+      'invite.revoked_at',
+      'invite.redeemed_at',
+      'organization.name as organization_name',
+      'organization.status as organization_status',
+      'auth_settings.local_auth_enabled',
+      'auth_settings.oidc_auth_enabled',
+      'auth_settings.policy_version',
+      'auth_settings.membership_grant_ttl_seconds',
+    ])
+
+export const findInviteContextByTokenHash = async (
+  tokenHash: string,
+  executor: DbExecutor = db
+) => {
+  return inviteContextQuery(executor).where('invite.token_hash', '=', tokenHash).executeTakeFirst()
+}
+
+export const findInviteContextByTokenHashForUpdate = async (
+  tokenHash: string,
+  executor: DbExecutor
+) => {
+  return inviteContextQuery(executor)
+    .where('invite.token_hash', '=', tokenHash)
+    .forUpdate('invite')
+    .executeTakeFirst()
+}
+
+export const findMembershipStateForInvite = async (
+  organizationId: string,
+  userId: string,
+  executor: DbExecutor
+) => {
+  return executor
+    .selectFrom('organization_memberships')
+    .selectAll()
+    .where('organization_id', '=', organizationId)
+    .where('user_id', '=', userId)
+    .orderBy(
+      sql<number>`CASE status WHEN 'active' THEN 0 WHEN 'suspended' THEN 1 ELSE 2 END`,
+      'asc'
+    )
+    .orderBy('joined_at', 'desc')
+    .forUpdate()
+    .executeTakeFirst()
+}
+
+export const findEnabledLocalCredentialByEmail = async (
+  organizationId: string,
+  normalizedLoginEmail: string,
+  executor: DbExecutor
+) => {
+  return executor
+    .selectFrom('organization_local_credentials')
+    .select(['id'])
+    .where('organization_id', '=', organizationId)
+    .where('normalized_login_email', '=', normalizedLoginEmail)
+    .where('enabled', '=', true)
+    .executeTakeFirst()
+}
+
+export const insertOrganizationMembershipForInvite = async (
+  membership: Insertable<OrganizationMemberships>,
+  executor: DbExecutor
+) => {
+  return executor
+    .insertInto('organization_memberships')
+    .values(membership)
+    .returningAll()
+    .executeTakeFirstOrThrow()
+}
+
+export const insertOrganizationLocalCredential = async (
+  credential: Insertable<OrganizationLocalCredentials>,
+  executor: DbExecutor
+) => {
+  return executor
+    .insertInto('organization_local_credentials')
+    .values(credential)
+    .returningAll()
+    .executeTakeFirstOrThrow()
+}
+
+export const consumeOrganizationInvite = async (
+  inviteId: string,
+  membershipId: string,
+  consumedAt: Date,
+  executor: DbExecutor
+) => {
+  return executor
+    .updateTable('organization_invites')
+    .set({
+      redeemed_at: consumedAt,
+      redeemed_membership_id: membershipId,
+      used_count: 1,
+    })
+    .where('id', '=', inviteId)
+    .where('redeemed_at', 'is', null)
+    .where('revoked_at', 'is', null)
+    .where('expires_at', '>', consumedAt)
+    .returningAll()
+    .executeTakeFirst()
+}

--- a/apps/kaede/src/usecases/organization-invites/index.test.ts
+++ b/apps/kaede/src/usecases/organization-invites/index.test.ts
@@ -1,0 +1,323 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import type { DbExecutor } from '../../services/executor.js'
+
+const auth = vi.hoisted(() => ({
+  createSession: vi.fn(),
+  findValidSessionByToken: vi.fn(),
+  generateActivationToken: vi.fn(),
+  hashActivationToken: vi.fn(),
+  hashPassword: vi.fn(),
+}))
+const invites = vi.hoisted(() => ({
+  consumeOrganizationInvite: vi.fn(),
+  findActorMembership: vi.fn(),
+  findActorMembershipForUpdate: vi.fn(),
+  findEnabledLocalCredentialByEmail: vi.fn(),
+  findInviteContextByTokenHash: vi.fn(),
+  findInviteContextByTokenHashForUpdate: vi.fn(),
+  findMembershipStateForInvite: vi.fn(),
+  findOrganizationInviteForUpdate: vi.fn(),
+  insertOrganizationInvite: vi.fn(),
+  insertOrganizationLocalCredential: vi.fn(),
+  insertOrganizationMembershipForInvite: vi.fn(),
+  listOrganizationInvites: vi.fn(),
+  revokeOrganizationInvite: vi.fn(),
+}))
+const local = vi.hoisted(() => ({
+  insertAuthenticationEvent: vi.fn(),
+  normalizeLocalLoginEmail: vi.fn((email: string) => email.trim().toLowerCase()),
+  upsertLocalMembershipGrant: vi.fn(),
+}))
+const profiles = vi.hoisted(() => ({
+  insertAuditEvent: vi.fn(),
+  upsertOrganizationMemberProfile: vi.fn(),
+  upsertUserProfile: vi.fn(),
+}))
+const users = vi.hoisted(() => ({ findUserById: vi.fn(), insertUser: vi.fn() }))
+
+vi.mock('../../services/auth/index.js', () => auth)
+vi.mock('../../services/organization-invites/index.js', () => invites)
+vi.mock('../../services/organization-local-auth/index.js', () => local)
+vi.mock('../../services/profiles/index.js', () => profiles)
+vi.mock('../../services/users/index.js', () => users)
+vi.mock('../../services/db/index.js', () => ({ db: {} }))
+
+import {
+  acceptOrganizationInviteWithLocalCredential,
+  issueOrganizationInvite,
+  reissueInvite,
+  verifyOrganizationInvite,
+} from './index.js'
+
+const executor = {} as DbExecutor
+const now = new Date('2026-08-11T10:00:00.000Z')
+const organizationId = '11111111-1111-4111-8111-111111111111'
+const actorUserId = '22222222-2222-4222-8222-222222222222'
+const actorMembershipId = '33333333-3333-4333-8333-333333333333'
+const inviteId = '44444444-4444-4444-8444-444444444444'
+
+const actor = (role: 'member' | 'manager' | 'owner'): RequestActor => ({
+  type: 'user',
+  user_id: actorUserId,
+  email: 'actor@example.test',
+  global_role: 'none',
+  account_state: 'active',
+  memberships: [{ organization_id: organizationId, organization_name: 'Org', role }],
+})
+
+const actorMembership = (role: string) => ({
+  id: actorMembershipId,
+  organization_id: organizationId,
+  user_id: actorUserId,
+  role,
+  status: 'active',
+  joined_at: now,
+  left_at: null,
+  created_at: now,
+  updated_at: now,
+})
+
+const inviteContext = (overrides: Record<string, unknown> = {}) => ({
+  invite_id: inviteId,
+  organization_id: organizationId,
+  role: 'member',
+  expires_at: new Date('2026-08-18T10:00:00.000Z'),
+  revoked_at: null,
+  redeemed_at: null,
+  organization_name: 'Example',
+  organization_status: 'active',
+  local_auth_enabled: true,
+  oidc_auth_enabled: true,
+  policy_version: 1,
+  membership_grant_ttl_seconds: 3600,
+  ...overrides,
+})
+
+describe('organization invite usecases', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    auth.generateActivationToken.mockReturnValue('plain-token')
+    auth.hashActivationToken.mockImplementation((token: string) => `hash:${token}`)
+    auth.hashPassword.mockResolvedValue('password-hash')
+    invites.findInviteContextByTokenHash.mockResolvedValue(inviteContext())
+    profiles.insertAuditEvent.mockResolvedValue(undefined)
+  })
+
+  it('managerはmember Inviteを発行でき、平文tokenではなくhashだけを保存する', async () => {
+    invites.findActorMembershipForUpdate.mockResolvedValue(actorMembership('manager'))
+    invites.insertOrganizationInvite.mockImplementation((value: object) =>
+      Promise.resolve({ ...value, id: inviteId, created_at: now, updated_at: now })
+    )
+
+    const result = await issueOrganizationInvite(
+      actor('manager'),
+      organizationId,
+      { role: 'member' },
+      now,
+      executor
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      value: { token: 'plain-token', expires_at: '2026-08-18T10:00:00.000Z' },
+    })
+    expect(invites.insertOrganizationInvite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token_hash: 'hash:plain-token',
+        max_uses: 1,
+        used_count: 0,
+        email: 'single-use-invite@invalid.local',
+      }),
+      executor
+    )
+    expect(JSON.stringify(invites.insertOrganizationInvite.mock.calls[0]?.[0])).not.toContain(
+      '"token":"plain-token"'
+    )
+  })
+
+  it('managerはmanager Inviteを発行できない', async () => {
+    invites.findActorMembershipForUpdate.mockResolvedValue(actorMembership('manager'))
+    await expect(
+      issueOrganizationInvite(actor('manager'), organizationId, { role: 'manager' }, now, executor)
+    ).resolves.toEqual({ ok: false, error: { type: 'AUTH_DASHBOARD_FORBIDDEN' } })
+    expect(invites.insertOrganizationInvite).not.toHaveBeenCalled()
+  })
+
+  it('ownerはmanager Inviteを発行できる', async () => {
+    invites.findActorMembershipForUpdate.mockResolvedValue(actorMembership('owner'))
+    invites.insertOrganizationInvite.mockImplementation((value: object) =>
+      Promise.resolve({ ...value, id: inviteId, created_at: now, updated_at: now })
+    )
+    await expect(
+      issueOrganizationInvite(actor('owner'), organizationId, { role: 'manager' }, now, executor)
+    ).resolves.toMatchObject({ ok: true })
+  })
+
+  it('再発行は旧Inviteをrevokeし、新しいInvite INSERTのtokenだけ返す', async () => {
+    invites.findOrganizationInviteForUpdate.mockResolvedValue({ ...inviteContext(), id: inviteId })
+    invites.findActorMembershipForUpdate.mockResolvedValue(actorMembership('owner'))
+    invites.revokeOrganizationInvite.mockResolvedValue({ id: inviteId })
+    const replacementId = '55555555-5555-4555-8555-555555555555'
+    invites.insertOrganizationInvite.mockImplementation((value: object) =>
+      Promise.resolve({ ...value, id: replacementId, created_at: now, updated_at: now })
+    )
+
+    const result = await reissueInvite(actor('owner'), organizationId, inviteId, now, executor)
+
+    expect(result).toMatchObject({ ok: true, value: { token: 'plain-token' } })
+    expect(invites.revokeOrganizationInvite).toHaveBeenCalledWith(inviteId, now, executor)
+    expect(invites.insertOrganizationInvite).toHaveBeenCalledOnce()
+  })
+
+  it('verifyは認証方式だけを返しtoken/hash/IDを露出しない', async () => {
+    invites.findInviteContextByTokenHash.mockResolvedValue(inviteContext())
+    const result = await verifyOrganizationInvite('plain-token', now, executor)
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        organization: { name: 'Example' },
+        role: 'member',
+        expires_at: '2026-08-18T10:00:00.000Z',
+        authentication_methods: { local: true, oidc: true },
+      },
+    })
+    expect(JSON.stringify(result)).not.toContain('plain-token')
+    expect(JSON.stringify(result)).not.toContain(inviteId)
+  })
+
+  it('legacy owner Inviteを無効として扱う', async () => {
+    invites.findInviteContextByTokenHash.mockResolvedValue(inviteContext({ role: 'owner' }))
+    await expect(verifyOrganizationInvite('plain-token', now, executor)).resolves.toEqual({
+      ok: false,
+      error: { type: 'INVITE_INVALID' },
+    })
+  })
+
+  it.each([
+    ['active', 'INVITE_ALREADY_MEMBER'],
+    ['suspended', 'INVITE_MEMBERSHIP_SUSPENDED'],
+  ] as const)('%s MembershipはInviteを消費せず先に拒否する', async (status, errorType) => {
+    invites.findInviteContextByTokenHashForUpdate.mockResolvedValue(inviteContext())
+    auth.findValidSessionByToken.mockResolvedValue({
+      ok: true,
+      session: { id: 'session-id', user_id: actorUserId, expires_at: new Date('2026-08-12') },
+    })
+    users.findUserById.mockResolvedValue({ id: actorUserId, status: 'active' })
+    invites.findMembershipStateForInvite.mockResolvedValue({ status })
+
+    const result = await acceptOrganizationInviteWithLocalCredential(
+      'session-token',
+      { token: 'plain-token', login_email: 'member@example.test', password: 'password' },
+      {},
+      now,
+      executor
+    )
+
+    expect(result).toEqual({ ok: false, error: { type: errorType } })
+    expect(invites.findEnabledLocalCredentialByEmail).not.toHaveBeenCalled()
+    expect(invites.consumeOrganizationInvite).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['invalid', undefined, 'INVITE_INVALID'],
+    [
+      'expired',
+      inviteContext({ expires_at: new Date('2026-08-11T09:59:59.000Z') }),
+      'INVITE_EXPIRED',
+    ],
+    ['local disabled', inviteContext({ local_auth_enabled: false }), 'AUTH_METHOD_NOT_ALLOWED'],
+  ])('%s InviteはArgon2計算前に拒否する', async (_label, context, errorType) => {
+    invites.findInviteContextByTokenHash.mockResolvedValue(context)
+
+    const result = await acceptOrganizationInviteWithLocalCredential(
+      undefined,
+      {
+        token: 'invalid-token',
+        login_email: 'member@example.test',
+        password: 'password',
+        contact_email: 'contact@example.test',
+        profile: { display_name: 'Member', locale: 'ja-JP', timezone: 'Asia/Tokyo' },
+      },
+      {},
+      now,
+      executor
+    )
+
+    expect(result).toEqual({ ok: false, error: { type: errorType } })
+    expect(auth.hashPassword).not.toHaveBeenCalled()
+    expect(invites.findInviteContextByTokenHashForUpdate).not.toHaveBeenCalled()
+  })
+
+  it('新規Local受領はUserからGrantまでを作りInviteを1回だけ消費する', async () => {
+    const membershipId = '66666666-6666-4666-8666-666666666666'
+    invites.findInviteContextByTokenHashForUpdate.mockResolvedValue(inviteContext())
+    invites.findMembershipStateForInvite.mockResolvedValue(undefined)
+    invites.findEnabledLocalCredentialByEmail.mockResolvedValue(undefined)
+    users.insertUser.mockResolvedValue({})
+    profiles.upsertUserProfile.mockResolvedValue({})
+    invites.insertOrganizationMembershipForInvite.mockImplementation((value: object) =>
+      Promise.resolve({ ...value, id: membershipId, created_at: now, updated_at: now })
+    )
+    profiles.upsertOrganizationMemberProfile.mockResolvedValue({})
+    invites.insertOrganizationLocalCredential.mockResolvedValue({ id: 'credential-id' })
+    invites.consumeOrganizationInvite.mockResolvedValue({ id: inviteId })
+    auth.createSession.mockResolvedValue({
+      token: 'new-session-token',
+      session: {
+        id: 'session-id',
+        user_id: actorUserId,
+        expires_at: new Date('2026-08-18T10:00:00.000Z'),
+      },
+    })
+    local.upsertLocalMembershipGrant.mockResolvedValue({
+      authenticated_at: now,
+      expires_at: new Date('2026-08-11T11:00:00.000Z'),
+    })
+
+    const result = await acceptOrganizationInviteWithLocalCredential(
+      undefined,
+      {
+        token: 'plain-token',
+        login_email: ' Member@Example.Test ',
+        password: 'password',
+        contact_email: 'contact@example.test',
+        profile: { display_name: 'Member', locale: 'ja-JP', timezone: 'Asia/Tokyo' },
+      },
+      {},
+      now,
+      executor
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        sessionToken: 'new-session-token',
+        membership: {
+          id: membershipId,
+          organization_id: organizationId,
+          role: 'member',
+          status: 'active',
+        },
+        grant: { auth_method: 'local' },
+      },
+    })
+    expect(invites.insertOrganizationLocalCredential).toHaveBeenCalledWith(
+      expect.objectContaining({
+        normalized_login_email: 'member@example.test',
+        password_hash: 'password-hash',
+      }),
+      executor
+    )
+    expect(invites.consumeOrganizationInvite).toHaveBeenCalledWith(
+      inviteId,
+      membershipId,
+      now,
+      executor
+    )
+    expect(local.insertAuthenticationEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ event_type: 'local_invite_accept', outcome: 'success' }),
+      executor
+    )
+  })
+})

--- a/apps/kaede/src/usecases/organization-invites/index.ts
+++ b/apps/kaede/src/usecases/organization-invites/index.ts
@@ -1,0 +1,581 @@
+import { randomUUID } from 'node:crypto'
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import type {
+  AcceptLocalOrganizationInviteRequest,
+  CreateOrganizationInviteRequest,
+  InviteRole,
+} from '../../schemas/organization-invites.js'
+import {
+  createSession,
+  findValidSessionByToken,
+  generateActivationToken,
+  hashActivationToken,
+  hashPassword,
+} from '../../services/auth/index.js'
+import type { Json } from '../../services/db/index.js'
+import { db } from '../../services/db/index.js'
+import type { DbExecutor } from '../../services/executor.js'
+import {
+  consumeOrganizationInvite,
+  findActorMembership,
+  findActorMembershipForUpdate,
+  findEnabledLocalCredentialByEmail,
+  findInviteContextByTokenHash,
+  findInviteContextByTokenHashForUpdate,
+  findMembershipStateForInvite,
+  findOrganizationInviteForUpdate,
+  insertOrganizationInvite,
+  insertOrganizationLocalCredential,
+  insertOrganizationMembershipForInvite,
+  listOrganizationInvites,
+  revokeOrganizationInvite,
+} from '../../services/organization-invites/index.js'
+import {
+  insertAuthenticationEvent,
+  normalizeLocalLoginEmail,
+  upsertLocalMembershipGrant,
+} from '../../services/organization-local-auth/index.js'
+import {
+  insertAuditEvent,
+  upsertOrganizationMemberProfile,
+  upsertUserProfile,
+} from '../../services/profiles/index.js'
+import { findUserById, insertUser } from '../../services/users/index.js'
+
+const INVITE_TTL_MS = 7 * 24 * 60 * 60 * 1000
+const LEGACY_INVITE_EMAIL = 'single-use-invite@invalid.local'
+
+export type OrganizationInviteError =
+  | { type: 'AUTH_DASHBOARD_FORBIDDEN' }
+  | { type: 'AUTH_ORGANIZATION_FORBIDDEN' }
+  | { type: 'INVITE_NOT_FOUND' }
+  | { type: 'INVITE_INVALID' }
+  | { type: 'INVITE_EXPIRED' }
+  | { type: 'INVITE_ALREADY_REDEEMED' }
+  | { type: 'INVITE_ALREADY_REVOKED' }
+  | { type: 'INVITE_ALREADY_MEMBER' }
+  | { type: 'INVITE_MEMBERSHIP_SUSPENDED' }
+  | { type: 'AUTH_METHOD_NOT_ALLOWED' }
+  | { type: 'LOCAL_LOGIN_EMAIL_CONFLICT' }
+  | { type: 'INVITE_NEW_USER_PROFILE_REQUIRED' }
+  | { type: 'INVITE_EXISTING_USER_PROFILE_NOT_ALLOWED' }
+  | { type: 'AUTH_SESSION_EXPIRED' }
+  | { type: 'AUTH_SESSION_REVOKED' }
+  | { type: 'AUTH_USER_DISABLED' }
+  | { type: 'MEMBERSHIP_PROFILE_UNAVAILABLE' }
+
+type Result<T> = { ok: true; value: T } | { ok: false; error: OrganizationInviteError }
+
+const runInTransaction = async <T>(
+  executor: DbExecutor | undefined,
+  callback: (trx: DbExecutor) => Promise<T>
+): Promise<T> => {
+  const baseExecutor = executor ?? db
+  return 'transaction' in baseExecutor
+    ? baseExecutor.transaction().execute((trx) => callback(trx))
+    : callback(baseExecutor)
+}
+
+const requireUser = (actor: RequestActor) =>
+  actor.type === 'user'
+    ? ({ ok: true, actor } as const)
+    : ({ ok: false, error: { type: 'AUTH_DASHBOARD_FORBIDDEN' } } as const)
+
+const permittedRoles = (role: string): InviteRole[] => {
+  if (role === 'owner') return ['member', 'manager']
+  if (role === 'manager') return ['member']
+  return []
+}
+
+const requireIssuer = async (
+  actor: RequestActor,
+  organizationId: string,
+  inviteRole: InviteRole | undefined,
+  executor: DbExecutor,
+  lock: boolean
+) => {
+  const user = requireUser(actor)
+  if (!user.ok) return user
+  const membership = lock
+    ? await findActorMembershipForUpdate(organizationId, user.actor.user_id, executor)
+    : await findActorMembership(organizationId, user.actor.user_id, executor)
+  if (!membership?.id || membership.status !== 'active') {
+    return { ok: false, error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' } } as const
+  }
+  const activeMembership = { ...membership, id: membership.id }
+  const allowed = permittedRoles(membership.role)
+  if (allowed.length === 0 || (inviteRole && !allowed.includes(inviteRole))) {
+    return { ok: false, error: { type: 'AUTH_DASHBOARD_FORBIDDEN' } } as const
+  }
+  return { ok: true, user: user.actor, membership: activeMembership, allowed } as const
+}
+
+const inviteStatus = (
+  invite: {
+    redeemed_at: Date | null
+    revoked_at: Date | null
+    expires_at: Date
+  },
+  now: Date
+) => {
+  if (invite.redeemed_at) return 'redeemed' as const
+  if (invite.revoked_at) return 'revoked' as const
+  if (invite.expires_at <= now) return 'expired' as const
+  return 'active' as const
+}
+
+const insertInvite = async (
+  organizationId: string,
+  role: InviteRole,
+  actorUserId: string,
+  actorMembershipId: string,
+  now: Date,
+  executor: DbExecutor
+) => {
+  const token = generateActivationToken()
+  const invite = await insertOrganizationInvite(
+    {
+      organization_id: organizationId,
+      token_hash: hashActivationToken(token),
+      role,
+      expires_at: new Date(now.getTime() + INVITE_TTL_MS),
+      revoked_at: null,
+      redeemed_at: null,
+      redeemed_membership_id: null,
+      created_by_membership_id: actorMembershipId,
+      created_by_user_id: actorUserId,
+      email: LEGACY_INVITE_EMAIL,
+      max_uses: 1,
+      used_count: 0,
+    },
+    executor
+  )
+  return { token, invite }
+}
+
+export const issueOrganizationInvite = async (
+  actor: RequestActor,
+  organizationId: string,
+  payload: CreateOrganizationInviteRequest,
+  now = new Date(),
+  executor?: DbExecutor
+): Promise<Result<{ token: string; expires_at: string }>> =>
+  runInTransaction(executor, async (trx) => {
+    const issuer = await requireIssuer(actor, organizationId, payload.role, trx, true)
+    if (!issuer.ok) return issuer
+    const created = await insertInvite(
+      organizationId,
+      payload.role,
+      issuer.user.user_id,
+      issuer.membership.id,
+      now,
+      trx
+    )
+    await insertAuditEvent(
+      {
+        actor_user_id: issuer.user.user_id,
+        actor_membership_id: issuer.membership.id,
+        organization_id: organizationId,
+        target_type: 'organization_invite',
+        target_id: created.invite.id,
+        action: 'issue',
+        changed_fields: ['role', 'expires_at'],
+        before_values: null,
+        after_values: {
+          role: payload.role,
+          expires_at: created.invite.expires_at.toISOString(),
+        } as Json,
+      },
+      trx
+    )
+    return {
+      ok: true,
+      value: { token: created.token, expires_at: created.invite.expires_at.toISOString() },
+    }
+  })
+
+export const getOrganizationInvites = async (
+  actor: RequestActor,
+  organizationId: string,
+  now = new Date(),
+  executor?: DbExecutor
+) => {
+  const issuer = await requireIssuer(actor, organizationId, undefined, executor ?? db, false)
+  if (!issuer.ok) return issuer
+  const invites = await listOrganizationInvites(organizationId, issuer.allowed, executor)
+  return {
+    ok: true,
+    value: {
+      invites: invites.map((invite) => ({
+        id: invite.id,
+        role: invite.role as InviteRole,
+        status: inviteStatus(invite, now),
+        expires_at: invite.expires_at.toISOString(),
+        created_at: invite.created_at.toISOString(),
+      })),
+    },
+  } as const
+}
+
+const lockedInviteForActor = async (
+  actor: RequestActor,
+  organizationId: string,
+  inviteId: string,
+  executor: DbExecutor
+) => {
+  const invite = await findOrganizationInviteForUpdate(organizationId, inviteId, executor)
+  if (!invite) return { ok: false, error: { type: 'INVITE_NOT_FOUND' } } as const
+  const issuer = await requireIssuer(
+    actor,
+    organizationId,
+    invite.role as InviteRole,
+    executor,
+    true
+  )
+  if (!issuer.ok) return issuer
+  return { ok: true, invite, issuer } as const
+}
+
+export const revokeInvite = async (
+  actor: RequestActor,
+  organizationId: string,
+  inviteId: string,
+  now = new Date(),
+  executor?: DbExecutor
+): Promise<Result<{ revoked: true }>> =>
+  runInTransaction(executor, async (trx) => {
+    const context = await lockedInviteForActor(actor, organizationId, inviteId, trx)
+    if (!context.ok) return context
+    if (context.invite.redeemed_at) return { ok: false, error: { type: 'INVITE_ALREADY_REDEEMED' } }
+    if (context.invite.revoked_at) return { ok: false, error: { type: 'INVITE_ALREADY_REVOKED' } }
+    const revoked = await revokeOrganizationInvite(inviteId, now, trx)
+    if (!revoked) return { ok: false, error: { type: 'INVITE_INVALID' } }
+    await insertAuditEvent(
+      {
+        actor_user_id: context.issuer.user.user_id,
+        actor_membership_id: context.issuer.membership.id,
+        organization_id: organizationId,
+        target_type: 'organization_invite',
+        target_id: inviteId,
+        action: 'revoke',
+        changed_fields: ['revoked_at'],
+        before_values: { revoked_at: null } as Json,
+        after_values: { revoked_at: now.toISOString() } as Json,
+      },
+      trx
+    )
+    return { ok: true, value: { revoked: true } }
+  })
+
+export const reissueInvite = async (
+  actor: RequestActor,
+  organizationId: string,
+  inviteId: string,
+  now = new Date(),
+  executor?: DbExecutor
+): Promise<Result<{ token: string; expires_at: string }>> =>
+  runInTransaction(executor, async (trx) => {
+    const context = await lockedInviteForActor(actor, organizationId, inviteId, trx)
+    if (!context.ok) return context
+    if (context.invite.redeemed_at) return { ok: false, error: { type: 'INVITE_ALREADY_REDEEMED' } }
+    if (context.invite.revoked_at) return { ok: false, error: { type: 'INVITE_ALREADY_REVOKED' } }
+    const revoked = await revokeOrganizationInvite(inviteId, now, trx)
+    if (!revoked) return { ok: false, error: { type: 'INVITE_INVALID' } }
+    const created = await insertInvite(
+      organizationId,
+      context.invite.role as InviteRole,
+      context.issuer.user.user_id,
+      context.issuer.membership.id,
+      now,
+      trx
+    )
+    await insertAuditEvent(
+      {
+        actor_user_id: context.issuer.user.user_id,
+        actor_membership_id: context.issuer.membership.id,
+        organization_id: organizationId,
+        target_type: 'organization_invite',
+        target_id: created.invite.id,
+        action: 'reissue',
+        changed_fields: ['revoked_at', 'replacement_invite_id'],
+        before_values: { invite_id: inviteId } as Json,
+        after_values: { invite_id: created.invite.id } as Json,
+      },
+      trx
+    )
+    return {
+      ok: true,
+      value: { token: created.token, expires_at: created.invite.expires_at.toISOString() },
+    }
+  })
+
+const validateInviteContext = (
+  context: Awaited<ReturnType<typeof findInviteContextByTokenHash>>,
+  now: Date
+) => {
+  if (
+    !context ||
+    context.revoked_at ||
+    context.organization_status !== 'active' ||
+    (context.role !== 'member' && context.role !== 'manager')
+  ) {
+    return { ok: false, error: { type: 'INVITE_INVALID' } } as const
+  }
+  if (context.redeemed_at) return { ok: false, error: { type: 'INVITE_ALREADY_REDEEMED' } } as const
+  if (context.expires_at <= now) return { ok: false, error: { type: 'INVITE_EXPIRED' } } as const
+  return { ok: true, context } as const
+}
+
+export const verifyOrganizationInvite = async (
+  token: string,
+  now = new Date(),
+  executor?: DbExecutor
+) => {
+  const valid = validateInviteContext(
+    await findInviteContextByTokenHash(hashActivationToken(token), executor),
+    now
+  )
+  if (!valid.ok) return valid
+  return {
+    ok: true,
+    value: {
+      organization: { name: valid.context.organization_name },
+      role: valid.context.role as InviteRole,
+      expires_at: valid.context.expires_at.toISOString(),
+      authentication_methods: {
+        local: valid.context.local_auth_enabled === true,
+        oidc: valid.context.oidc_auth_enabled === true,
+      },
+    },
+  } as const
+}
+
+const membershipConflict = (status: string | null) => {
+  if (status === 'active') return { type: 'INVITE_ALREADY_MEMBER' } as const
+  if (status === 'suspended') return { type: 'INVITE_MEMBERSHIP_SUSPENDED' } as const
+  return undefined
+}
+
+export interface InviteAcceptanceMetadata {
+  requestId?: string
+  userAgent?: string
+}
+
+export const acceptOrganizationInviteWithLocalCredential = async (
+  sessionToken: string | undefined,
+  payload: AcceptLocalOrganizationInviteRequest,
+  metadata: InviteAcceptanceMetadata = {},
+  now = new Date(),
+  executor?: DbExecutor
+): Promise<
+  Result<{
+    sessionToken?: string
+    session: { expires_at: string }
+    membership: { id: string; organization_id: string; role: InviteRole; status: 'active' }
+    grant: { auth_method: 'local'; authenticated_at: string; expires_at: string }
+  }>
+> => {
+  // Argon2は高コストなので、無効token/policyを軽量なreadで先に拒否する。
+  // 正しさはtransaction内のFOR UPDATE + 再検証で保証する。
+  const tokenHash = hashActivationToken(payload.token)
+  const prechecked = validateInviteContext(
+    await findInviteContextByTokenHash(tokenHash, executor),
+    now
+  )
+  if (!prechecked.ok) return prechecked
+  if (!prechecked.context.local_auth_enabled) {
+    return { ok: false, error: { type: 'AUTH_METHOD_NOT_ALLOWED' } }
+  }
+  const passwordHash = await hashPassword(payload.password)
+  return runInTransaction(executor, async (trx) => {
+    const valid = validateInviteContext(
+      await findInviteContextByTokenHashForUpdate(tokenHash, trx),
+      now
+    )
+    if (!valid.ok) return valid
+    if (!valid.context.local_auth_enabled)
+      return { ok: false, error: { type: 'AUTH_METHOD_NOT_ALLOWED' } }
+
+    let userId: string
+    let activeSession
+    let createdSessionToken: string | undefined
+    if (sessionToken) {
+      if (payload.contact_email !== undefined || payload.profile !== undefined) {
+        return { ok: false, error: { type: 'INVITE_EXISTING_USER_PROFILE_NOT_ALLOWED' } }
+      }
+      const foundSession = await findValidSessionByToken(sessionToken, now, trx)
+      if (!foundSession.ok) {
+        return {
+          ok: false,
+          error: {
+            type:
+              foundSession.error === 'SESSION_EXPIRED'
+                ? 'AUTH_SESSION_EXPIRED'
+                : 'AUTH_SESSION_REVOKED',
+          },
+        }
+      }
+      activeSession = foundSession.session
+      userId = activeSession.user_id
+      const user = await findUserById(userId, trx)
+      if (user?.status !== 'active') return { ok: false, error: { type: 'AUTH_USER_DISABLED' } }
+    } else {
+      if (!payload.contact_email || !payload.profile) {
+        return { ok: false, error: { type: 'INVITE_NEW_USER_PROFILE_REQUIRED' } }
+      }
+      userId = randomUUID()
+    }
+
+    const priorMembership = await findMembershipStateForInvite(
+      valid.context.organization_id,
+      userId,
+      trx
+    )
+    const conflict = membershipConflict(priorMembership?.status ?? null)
+    if (conflict) return { ok: false, error: conflict }
+
+    const normalizedLoginEmail = normalizeLocalLoginEmail(payload.login_email)
+    if (
+      await findEnabledLocalCredentialByEmail(
+        valid.context.organization_id,
+        normalizedLoginEmail,
+        trx
+      )
+    ) {
+      return { ok: false, error: { type: 'LOCAL_LOGIN_EMAIL_CONFLICT' } }
+    }
+
+    if (!sessionToken) {
+      const profile = payload.profile
+      const contactEmail = payload.contact_email
+      if (!profile || !contactEmail) {
+        return { ok: false, error: { type: 'INVITE_NEW_USER_PROFILE_REQUIRED' } }
+      }
+      const normalizedContactEmail = contactEmail.trim()
+      await insertUser(
+        {
+          id: userId,
+          email: `${userId}@invite.local.invalid`,
+          display_name: profile.display_name,
+          password_hash: null,
+          password_changed_at: null,
+          status: 'active',
+          global_role: 'none',
+          contact_email: normalizedContactEmail,
+          normalized_contact_email: normalizedContactEmail.toLowerCase(),
+          contact_email_verified_at: null,
+          locked_until: null,
+        },
+        trx
+      )
+      await upsertUserProfile(
+        {
+          user_id: userId,
+          display_name: profile.display_name,
+          locale: profile.locale,
+          timezone: profile.timezone,
+        },
+        profile,
+        trx
+      )
+    }
+
+    const membership = await insertOrganizationMembershipForInvite(
+      {
+        id: randomUUID(),
+        organization_id: valid.context.organization_id,
+        user_id: userId,
+        role: valid.context.role,
+        status: 'active',
+        joined_at: now,
+        left_at: null,
+      },
+      trx
+    )
+    if (!membership.id) return { ok: false, error: { type: 'MEMBERSHIP_PROFILE_UNAVAILABLE' } }
+    await upsertOrganizationMemberProfile(
+      {
+        membership_id: membership.id,
+        display_name: null,
+        height_meters: null,
+        stride_length_meters: null,
+      },
+      { display_name: null, height_meters: null, stride_length_meters: null },
+      trx
+    )
+    const credential = await insertOrganizationLocalCredential(
+      {
+        membership_id: membership.id,
+        organization_id: valid.context.organization_id,
+        login_email: payload.login_email.trim(),
+        normalized_login_email: normalizedLoginEmail,
+        password_hash: passwordHash,
+        password_changed_at: now,
+        failed_login_attempts: 0,
+        locked_until: null,
+        enabled: true,
+      },
+      trx
+    )
+    if (!(await consumeOrganizationInvite(valid.context.invite_id, membership.id, now, trx))) {
+      return { ok: false, error: { type: 'INVITE_INVALID' } }
+    }
+
+    if (!activeSession) {
+      const created = await createSession({ authMethod: 'password', userId, now }, trx)
+      activeSession = created.session
+      createdSessionToken = created.token
+    }
+    const grantExpiresAt = new Date(
+      now.getTime() + (valid.context.membership_grant_ttl_seconds ?? 0) * 1000
+    )
+    const grant = await upsertLocalMembershipGrant(
+      {
+        session_id: activeSession.id,
+        membership_id: membership.id,
+        user_id: userId,
+        auth_method: 'local',
+        policy_version: valid.context.policy_version ?? 1,
+        local_credential_id: credential.id,
+        member_oidc_identity_id: null,
+        authenticated_at: now,
+        expires_at: grantExpiresAt,
+        revoked_at: null,
+      },
+      trx
+    )
+    await insertAuthenticationEvent(
+      {
+        event_type: 'local_invite_accept',
+        outcome: 'success',
+        user_id: userId,
+        organization_id: valid.context.organization_id,
+        membership_id: membership.id,
+        session_id: activeSession.id,
+        auth_method: 'local',
+        credential_reference_id: credential.id,
+        request_id: metadata.requestId ?? null,
+        user_agent: metadata.userAgent ?? null,
+      },
+      trx
+    )
+    return {
+      ok: true,
+      value: {
+        sessionToken: createdSessionToken,
+        session: { expires_at: activeSession.expires_at.toISOString() },
+        membership: {
+          id: membership.id,
+          organization_id: membership.organization_id,
+          role: membership.role as InviteRole,
+          status: 'active',
+        },
+        grant: {
+          auth_method: 'local',
+          authenticated_at: grant.authenticated_at.toISOString(),
+          expires_at: grant.expires_at.toISOString(),
+        },
+      },
+    }
+  })
+}


### PR DESCRIPTION
Relates to #219

- Add single-use invite issue, list, revoke, and reissue APIs
- Add public invite verification and atomic local invite acceptance
- Enforce manager/owner role boundaries, token hashing, row locking, and no-store responses

Tests: `pnpm test`, `pnpm typecheck`, `pnpm lint`, `prettier --check .`

Note: left-member rejoin requires the membership lifecycle PR to replace the legacy organization/user primary key before final integration.