### PR TITLE
Add organization OIDC authentication

### DIFF
--- a/apps/kaede/src/routes/auth/auth.test.ts
+++ b/apps/kaede/src/routes/auth/auth.test.ts
@@ -14,6 +14,8 @@ const {
   getMeMock,
   loginMock,
   logoutMock,
+  completeOrganizationOidcMock,
+  isOrganizationOidcTransactionStateMock,
   requireActiveSessionUserMock,
   verifyActivationTokenMock,
 } = vi.hoisted(() => ({
@@ -24,8 +26,15 @@ const {
   getMeMock: vi.fn(),
   loginMock: vi.fn(),
   logoutMock: vi.fn(),
+  completeOrganizationOidcMock: vi.fn(),
+  isOrganizationOidcTransactionStateMock: vi.fn(),
   requireActiveSessionUserMock: vi.fn(),
   verifyActivationTokenMock: vi.fn(),
+}))
+
+vi.mock('../../usecases/organization-oidc-auth/index.js', () => ({
+  completeOrganizationOidc: completeOrganizationOidcMock,
+  isOrganizationOidcTransactionState: isOrganizationOidcTransactionStateMock,
 }))
 
 vi.mock('../../services/auth/index.js', () => ({
@@ -87,6 +96,7 @@ const userResponse = {
 describe('auth routes', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    isOrganizationOidcTransactionStateMock.mockResolvedValue(false)
     if (originalAppEnv === undefined) {
       Reflect.deleteProperty(process.env, 'APP_ENV')
     } else {
@@ -390,6 +400,82 @@ describe('auth routes', () => {
       },
       expect.any(Object)
     )
+  })
+
+  it('GET /api/auth/oidc/google/callback はOrganization transactionを新callbackへdispatchする', async () => {
+    process.env.OIDC_ENABLED = 'true'
+    process.env.OIDC_GOOGLE_CLIENT_ID = 'client-id'
+    process.env.OIDC_GOOGLE_CLIENT_SECRET = 'client-secret'
+    process.env.OIDC_GOOGLE_REDIRECT_URI = 'https://api.example.test/api/auth/oidc/google/callback'
+    process.env.OIDC_STATE_COOKIE_SECRET = 'state-cookie-secret'
+    process.env.FRONTEND_ORIGIN = 'https://app.example.test'
+    resetRuntimeConfigForTests()
+    isOrganizationOidcTransactionStateMock.mockResolvedValue(true)
+    completeOrganizationOidcMock.mockResolvedValue({
+      ok: true,
+      value: {
+        return_to: '/orgs/organization-a',
+        sessionToken: 'organization-session-token',
+      },
+    })
+
+    const app = createAuthTestApp()
+    const response = await app.request(
+      '/api/auth/oidc/google/callback?code=authorization-code&state=organization-state'
+    )
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toBe(
+      'https://app.example.test/auth/complete?result=success&return_to=%2Forgs%2Forganization-a'
+    )
+    expect(response.headers.get('set-cookie')).toContain(
+      'okarin_session=organization-session-token'
+    )
+    expect(completeOrganizationOidcMock).toHaveBeenCalledWith(
+      'authorization-code',
+      'organization-state',
+      expect.objectContaining({ sessionToken: undefined })
+    )
+    expect(completeGoogleOidcLoginMock).not.toHaveBeenCalled()
+    expect(completeGoogleOidcLinkMock).not.toHaveBeenCalled()
+  })
+
+  it('replayed Organization stateをlegacy callbackへfallbackしない', async () => {
+    process.env.OIDC_ENABLED = 'true'
+    process.env.OIDC_GOOGLE_CLIENT_ID = 'client-id'
+    process.env.OIDC_GOOGLE_CLIENT_SECRET = 'client-secret'
+    process.env.OIDC_GOOGLE_REDIRECT_URI = 'https://api.example.test/api/auth/oidc/google/callback'
+    process.env.OIDC_STATE_COOKIE_SECRET = 'state-cookie-secret'
+    process.env.FRONTEND_ORIGIN = 'https://app.example.test'
+    resetRuntimeConfigForTests()
+    isOrganizationOidcTransactionStateMock.mockResolvedValue(true)
+    completeOrganizationOidcMock.mockResolvedValue({
+      ok: false,
+      error: { type: 'OIDC_TRANSACTION_INVALID' },
+    })
+    const legacyStateCookie = serializeGoogleOidcStateCookie(
+      {
+        state: 'organization-state',
+        nonce: 'nonce-value',
+        codeVerifier: 'code-verifier',
+        expiresAt: '2099-06-17T00:10:00.000Z',
+        intent: 'login',
+      },
+      'state-cookie-secret'
+    )
+
+    const app = createAuthTestApp()
+    const response = await app.request(
+      '/api/auth/oidc/google/callback?code=authorization-code&state=organization-state',
+      { headers: { cookie: `okarin_oidc_google=${legacyStateCookie}` } }
+    )
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toBe(
+      'https://app.example.test/auth/complete?result=error&return_to=%2F&code=OIDC_TRANSACTION_INVALID'
+    )
+    expect(completeGoogleOidcLoginMock).not.toHaveBeenCalled()
+    expect(completeGoogleOidcLinkMock).not.toHaveBeenCalled()
   })
 
   it('GET /api/auth/me は cookie の session token で user を返す', async () => {

--- a/apps/kaede/src/routes/auth/oidc-google-callback.ts
+++ b/apps/kaede/src/routes/auth/oidc-google-callback.ts
@@ -1,8 +1,12 @@
 import { createRoute, z } from '@hono/zod-openapi'
 import type { OpenAPIHono } from '@hono/zod-openapi'
-import { getOidcRuntimeConfig } from '../../config/runtime.js'
+import { getAppRuntimeConfig, getOidcRuntimeConfig } from '../../config/runtime.js'
 import { GoogleOidcClient } from '../../services/auth/index.js'
 import { completeGoogleOidcLink, completeGoogleOidcLogin } from '../../usecases/auth/index.js'
+import {
+  completeOrganizationOidc,
+  isOrganizationOidcTransactionState,
+} from '../../usecases/organization-oidc-auth/index.js'
 import { getSessionTokenFromCookie, setSessionCookie } from './cookie.js'
 import { clearGoogleOidcStateCookie, getGoogleOidcStateCookie } from './oidc-cookie.js'
 
@@ -18,6 +22,20 @@ const withError = (url: string, errorCode: string) => {
   return url.startsWith('/')
     ? `${redirectUrl.pathname}${redirectUrl.search}`
     : redirectUrl.toString()
+}
+
+const organizationCompletionUrl = (
+  result: 'success' | 'error',
+  returnTo: string,
+  errorCode?: string
+) => {
+  const frontendOrigin = getAppRuntimeConfig().frontendOrigin
+  const url = new URL('/auth/complete', frontendOrigin ?? 'http://localhost')
+  url.searchParams.set('result', result)
+  url.searchParams.set('return_to', returnTo)
+  if (errorCode) url.searchParams.set('code', errorCode)
+
+  return frontendOrigin ? url.toString() : `${url.pathname}${url.search}`
 }
 
 export const registerGoogleOidcCallbackRoute = (app: OpenAPIHono) => {
@@ -40,11 +58,44 @@ export const registerGoogleOidcCallbackRoute = (app: OpenAPIHono) => {
     const config = getOidcRuntimeConfig()
     const query = c.req.valid('query')
     const failureRedirectUrl = config.loginFailureRedirectUrl
+    if (!config.enabled) {
+      clearGoogleOidcStateCookie(c)
+      return c.redirect(withError(failureRedirectUrl, query.error ?? 'oidc_disabled'), 302)
+    }
+
+    const organizationTransaction = query.state
+      ? await isOrganizationOidcTransactionState(query.state)
+      : false
+    const client = new GoogleOidcClient({
+      clientId: config.googleClientId,
+      clientSecret: config.googleClientSecret,
+      redirectUri: config.googleRedirectUri,
+    })
+    if (organizationTransaction) {
+      const result = await completeOrganizationOidc(
+        query.error ? undefined : query.code,
+        query.state,
+        {
+          client,
+          configuredClientId: config.googleClientId,
+          transactionSecret: config.stateCookieSecret,
+          sessionToken: getSessionTokenFromCookie(c),
+        }
+      )
+      if (!result.ok) {
+        return c.redirect(
+          organizationCompletionUrl('error', result.return_to ?? '/', result.error.type),
+          302
+        )
+      }
+      if (result.value.sessionToken) setSessionCookie(c, result.value.sessionToken)
+
+      return c.redirect(organizationCompletionUrl('success', result.value.return_to), 302)
+    }
 
     clearGoogleOidcStateCookie(c)
-
-    if (!config.enabled || query.error) {
-      return c.redirect(withError(failureRedirectUrl, query.error ?? 'oidc_disabled'), 302)
+    if (query.error) {
+      return c.redirect(withError(failureRedirectUrl, query.error), 302)
     }
 
     const stateCookie = getGoogleOidcStateCookie(c, config.stateCookieSecret)
@@ -53,11 +104,6 @@ export const registerGoogleOidcCallbackRoute = (app: OpenAPIHono) => {
       return c.redirect(withError(failureRedirectUrl, 'invalid_state'), 302)
     }
 
-    const client = new GoogleOidcClient({
-      clientId: config.googleClientId,
-      clientSecret: config.googleClientSecret,
-      redirectUri: config.googleRedirectUri,
-    })
     const params = {
       code: query.code,
       state: query.state,

--- a/apps/kaede/src/routes/organization-oidc-auth/index.ts
+++ b/apps/kaede/src/routes/organization-oidc-auth/index.ts
@@ -1,0 +1,6 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { registerOrganizationOidcStartRoute } from './start.js'
+
+export const organizationOidcAuthRoutes = new OpenAPIHono()
+
+registerOrganizationOidcStartRoute(organizationOidcAuthRoutes)

--- a/apps/kaede/src/routes/organization-oidc-auth/start.ts
+++ b/apps/kaede/src/routes/organization-oidc-auth/start.ts
@@ -1,0 +1,84 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { getOidcRuntimeConfig } from '../../config/runtime.js'
+import { errorResponseSchema } from '../../schemas/common.js'
+import {
+  organizationOidcStartParamsSchema,
+  organizationOidcStartRequestSchema,
+  organizationOidcStartResponseSchema,
+} from '../../schemas/organization-oidc-auth.js'
+import { GoogleOidcClient } from '../../services/auth/index.js'
+import { startOrganizationOidc } from '../../usecases/organization-oidc-auth/index.js'
+import { getSessionTokenFromCookie } from '../auth/cookie.js'
+
+const errorStatus = (type: string) => {
+  if (type === 'INVITE_INVALID' || type === 'OIDC_PROVIDER_NOT_FOUND') return 404 as const
+  if (type === 'AUTH_SESSION_REQUIRED' || type.includes('SESSION_')) return 401 as const
+  return 403 as const
+}
+
+export const registerOrganizationOidcStartRoute = (app: OpenAPIHono) => {
+  const route = createRoute({
+    method: 'post',
+    path: '/{organizationSlug}/auth/oidc/{providerId}/start',
+    tags: ['Organization Auth'],
+    request: {
+      params: organizationOidcStartParamsSchema,
+      body: { content: { 'application/json': { schema: organizationOidcStartRequestSchema } } },
+    },
+    responses: {
+      200: {
+        description: 'authorization transaction created',
+        content: { 'application/json': { schema: organizationOidcStartResponseSchema } },
+      },
+      401: {
+        description: 'session required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      403: {
+        description: 'OIDC not allowed',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      404: {
+        description: 'provider or invite not found',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+    },
+  })
+
+  app.openapi(route, async (c) => {
+    const config = getOidcRuntimeConfig()
+    if (!config.enabled) {
+      return c.json(
+        { error_code: 'AUTH_METHOD_NOT_ALLOWED', error_message: 'OIDC is disabled' },
+        403
+      )
+    }
+    const { organizationSlug, providerId } = c.req.valid('param')
+    const client = new GoogleOidcClient({
+      clientId: config.googleClientId,
+      clientSecret: config.googleClientSecret,
+      redirectUri: config.googleRedirectUri,
+    })
+    const result = await startOrganizationOidc(
+      organizationSlug,
+      providerId,
+      getSessionTokenFromCookie(c),
+      c.req.valid('json'),
+      {
+        client,
+        configuredClientId: config.googleClientId,
+        transactionSecret: config.stateCookieSecret,
+      }
+    )
+    if (!result.ok) {
+      const status = errorStatus(result.error.type)
+      return c.json(
+        { error_code: result.error.type, error_message: 'OIDC authorization could not start' },
+        status
+      )
+    }
+
+    return c.json(result.value, 200)
+  })
+}

--- a/apps/kaede/src/routes/organizations/index.ts
+++ b/apps/kaede/src/routes/organizations/index.ts
@@ -17,6 +17,7 @@ import { registerListOrganizationTrajectoriesRoute } from './list-organization-t
 import { registerListOrganizationUsersRoute } from './list-organization-users.js'
 import { registerListOrganizationsRoute } from './list-organizations.js'
 import { registerOrganizationMemberProfileRoutes } from './member-profiles.js'
+import { registerOrganizationOidcProviderRoutes } from './oidc-providers.js'
 
 export const organizationsRoutes = new OpenAPIHono()
 
@@ -38,3 +39,4 @@ registerCreateOrganizationMembershipRoute(organizationsRoutes)
 registerCreateStayHeatmapRoute(organizationsRoutes)
 registerAnalysisRunRoutes(organizationsRoutes)
 registerOrganizationMemberProfileRoutes(organizationsRoutes)
+registerOrganizationOidcProviderRoutes(organizationsRoutes)

--- a/apps/kaede/src/routes/organizations/oidc-providers.ts
+++ b/apps/kaede/src/routes/organizations/oidc-providers.ts
@@ -1,0 +1,230 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { getOidcRuntimeConfig } from '../../config/runtime.js'
+import { authOkResponseSchema } from '../../schemas/auth.js'
+import { errorResponseSchema } from '../../schemas/common.js'
+import {
+  createOrganizationOidcProviderRequestSchema,
+  organizationOidcProviderParamsSchema,
+  organizationOidcProviderSchema,
+  organizationOidcProvidersResponseSchema,
+  updateOrganizationOidcProviderRequestSchema,
+} from '../../schemas/organization-oidc-auth.js'
+import { organizationIdParamsSchema } from '../../schemas/organizations.js'
+import { requireActiveSessionUser } from '../../usecases/auth/index.js'
+import {
+  createOrganizationOidcProvider,
+  disableOrganizationOidcProvider,
+  getOrganizationOidcProviders,
+  patchOrganizationOidcProvider,
+} from '../../usecases/organization-oidc-auth/index.js'
+import { getSessionTokenFromCookie } from '../auth/cookie.js'
+
+const authErrorBody = {
+  error_code: 'AUTH_UNAUTHENTICATED',
+  error_message: 'login required',
+} as const
+
+export const registerOrganizationOidcProviderRoutes = (app: OpenAPIHono) => {
+  const listRoute = createRoute({
+    method: 'get',
+    path: '/{organizationId}/oidc-providers',
+    tags: ['Organization Auth'],
+    request: { params: organizationIdParamsSchema },
+    responses: {
+      200: {
+        description: 'OIDC providers',
+        content: { 'application/json': { schema: organizationOidcProvidersResponseSchema } },
+      },
+      401: {
+        description: 'login required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      403: {
+        description: 'owner required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+    },
+  })
+  app.openapi(listRoute, async (c) => {
+    const actor = await requireActiveSessionUser(getSessionTokenFromCookie(c))
+    if (!actor.ok) return c.json(authErrorBody, 401)
+    const result = await getOrganizationOidcProviders(
+      c.req.valid('param').organizationId,
+      actor.value.id
+    )
+    if (!result.ok)
+      return c.json(
+        { error_code: result.error.type, error_message: 'owner permission is required' },
+        403
+      )
+    return c.json(result.value, 200)
+  })
+
+  const createRouteDefinition = createRoute({
+    method: 'post',
+    path: '/{organizationId}/oidc-providers',
+    tags: ['Organization Auth'],
+    request: {
+      params: organizationIdParamsSchema,
+      body: {
+        content: { 'application/json': { schema: createOrganizationOidcProviderRequestSchema } },
+      },
+    },
+    responses: {
+      201: {
+        description: 'OIDC provider created',
+        content: { 'application/json': { schema: organizationOidcProviderSchema } },
+      },
+      401: {
+        description: 'login required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      403: {
+        description: 'owner required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      422: {
+        description: 'invalid provider config',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+    },
+  })
+  app.openapi(createRouteDefinition, async (c) => {
+    const actor = await requireActiveSessionUser(getSessionTokenFromCookie(c))
+    if (!actor.ok) return c.json(authErrorBody, 401)
+    const config = getOidcRuntimeConfig()
+    const result = await createOrganizationOidcProvider(
+      c.req.valid('param').organizationId,
+      actor.value.id,
+      c.req.valid('json'),
+      config.googleClientId
+    )
+    if (!result.ok) {
+      if (result.error.type === 'OIDC_PROVIDER_CONFIG_INVALID') {
+        return c.json(
+          { error_code: result.error.type, error_message: 'OIDC provider config is invalid' },
+          422
+        )
+      }
+      return c.json(
+        { error_code: result.error.type, error_message: 'owner permission is required' },
+        403
+      )
+    }
+    return c.json(result.value, 201)
+  })
+
+  const patchRoute = createRoute({
+    method: 'patch',
+    path: '/{organizationId}/oidc-providers/{providerId}',
+    tags: ['Organization Auth'],
+    request: {
+      params: organizationOidcProviderParamsSchema,
+      body: {
+        content: { 'application/json': { schema: updateOrganizationOidcProviderRequestSchema } },
+      },
+    },
+    responses: {
+      200: {
+        description: 'OIDC provider updated',
+        content: { 'application/json': { schema: organizationOidcProviderSchema } },
+      },
+      401: {
+        description: 'login required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      403: {
+        description: 'owner required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      404: {
+        description: 'provider not found',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      422: {
+        description: 'invalid provider config',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+    },
+  })
+  app.openapi(patchRoute, async (c) => {
+    const actor = await requireActiveSessionUser(getSessionTokenFromCookie(c))
+    if (!actor.ok) return c.json(authErrorBody, 401)
+    const params = c.req.valid('param')
+    const result = await patchOrganizationOidcProvider(
+      params.organizationId,
+      params.providerId,
+      actor.value.id,
+      c.req.valid('json'),
+      getOidcRuntimeConfig().googleClientId
+    )
+    if (!result.ok) {
+      if (result.error.type === 'OIDC_PROVIDER_NOT_FOUND') {
+        return c.json(
+          { error_code: result.error.type, error_message: 'OIDC provider not found' },
+          404
+        )
+      }
+      if (result.error.type === 'OIDC_PROVIDER_CONFIG_INVALID') {
+        return c.json(
+          { error_code: result.error.type, error_message: 'OIDC provider config is invalid' },
+          422
+        )
+      }
+      return c.json(
+        { error_code: result.error.type, error_message: 'owner permission is required' },
+        403
+      )
+    }
+    return c.json(result.value, 200)
+  })
+
+  const deleteRoute = createRoute({
+    method: 'delete',
+    path: '/{organizationId}/oidc-providers/{providerId}',
+    tags: ['Organization Auth'],
+    request: { params: organizationOidcProviderParamsSchema },
+    responses: {
+      200: {
+        description: 'OIDC provider disabled',
+        content: { 'application/json': { schema: authOkResponseSchema } },
+      },
+      401: {
+        description: 'login required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      403: {
+        description: 'owner required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      404: {
+        description: 'provider not found',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+    },
+  })
+  app.openapi(deleteRoute, async (c) => {
+    const actor = await requireActiveSessionUser(getSessionTokenFromCookie(c))
+    if (!actor.ok) return c.json(authErrorBody, 401)
+    const params = c.req.valid('param')
+    const result = await disableOrganizationOidcProvider(
+      params.organizationId,
+      params.providerId,
+      actor.value.id
+    )
+    if (!result.ok) {
+      if (result.error.type === 'OIDC_PROVIDER_NOT_FOUND') {
+        return c.json(
+          { error_code: result.error.type, error_message: 'OIDC provider not found' },
+          404
+        )
+      }
+      return c.json(
+        { error_code: result.error.type, error_message: 'owner permission is required' },
+        403
+      )
+    }
+    return c.json({ ok: true as const }, 200)
+  })
+}

--- a/apps/kaede/src/schemas/organization-oidc-auth.ts
+++ b/apps/kaede/src/schemas/organization-oidc-auth.ts
@@ -1,0 +1,99 @@
+import { z } from '@hono/zod-openapi'
+import { isoDatetimeSchema, uuidSchema } from './common.js'
+import { organizationIdParamsSchema, organizationSlugSchema } from './organizations.js'
+
+const safeReturnToSchema = z
+  .string()
+  .min(1)
+  .max(2048)
+  .refine(
+    (value) => value.startsWith('/') && !value.startsWith('//') && !value.includes('\\'),
+    'return_to must be a safe application-relative path'
+  )
+
+export const oidcIntentSchema = z.enum([
+  'login',
+  'reauthenticate',
+  'accept_invite',
+  'link_identity',
+])
+
+export const organizationOidcStartParamsSchema = z.object({
+  organizationSlug: organizationSlugSchema,
+  providerId: uuidSchema,
+})
+
+export const organizationOidcStartRequestSchema = z
+  .object({
+    intent: oidcIntentSchema,
+    return_to: safeReturnToSchema,
+    invite_token: z.string().min(1).optional(),
+  })
+  .superRefine((value, context) => {
+    if (value.intent === 'accept_invite' && !value.invite_token) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'invite_token is required for accept_invite',
+        path: ['invite_token'],
+      })
+    }
+    if (value.intent !== 'accept_invite' && value.invite_token) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'invite_token is only allowed for accept_invite',
+        path: ['invite_token'],
+      })
+    }
+  })
+
+export const organizationOidcStartResponseSchema = z.object({
+  authorization_url: z.string().url(),
+})
+
+const hostedDomainSchema = z
+  .string()
+  .min(1)
+  .max(253)
+  .regex(/^[a-zA-Z0-9](?:[a-zA-Z0-9.-]*[a-zA-Z0-9])?$/)
+
+export const createOrganizationOidcProviderRequestSchema = z.object({
+  display_name: z.string().trim().min(1).max(255),
+  issuer: z.enum(['accounts.google.com', 'https://accounts.google.com']),
+  client_id: z.string().trim().min(1).max(2048),
+  allowed_hosted_domains: z.array(hostedDomainSchema).max(100).nullable().optional(),
+  enabled: z.boolean().default(true),
+})
+
+export const updateOrganizationOidcProviderRequestSchema =
+  createOrganizationOidcProviderRequestSchema
+    .partial()
+    .refine((value) => Object.keys(value).length > 0, 'at least one field is required')
+
+export const organizationOidcProviderSchema = z.object({
+  id: uuidSchema,
+  organization_id: uuidSchema,
+  display_name: z.string(),
+  issuer: z.string(),
+  client_id: z.string(),
+  allowed_hosted_domains: z.array(z.string()).nullable(),
+  enabled: z.boolean(),
+  created_at: isoDatetimeSchema,
+  updated_at: isoDatetimeSchema,
+})
+
+export const organizationOidcProvidersResponseSchema = z.object({
+  providers: z.array(organizationOidcProviderSchema),
+})
+
+export const organizationOidcProviderParamsSchema = organizationIdParamsSchema.extend({
+  providerId: uuidSchema,
+})
+
+export type CreateOrganizationOidcProviderRequest = z.infer<
+  typeof createOrganizationOidcProviderRequestSchema
+>
+export type OrganizationOidcStartRequest = z.infer<typeof organizationOidcStartRequestSchema>
+export type OidcIntent = z.infer<typeof oidcIntentSchema>
+export type UpdateOrganizationOidcProviderRequest = z.infer<
+  typeof updateOrganizationOidcProviderRequestSchema
+>

--- a/apps/kaede/src/server.ts
+++ b/apps/kaede/src/server.ts
@@ -7,6 +7,7 @@ import { getRuntimeConfig } from './config/runtime.js'
 import { requestActorMiddleware } from './middleware/request-actor.js'
 import { registerApiRoutes } from './routes/index.js'
 import { organizationLocalAuthRoutes } from './routes/organization-local-auth/index.js'
+import { organizationOidcAuthRoutes } from './routes/organization-oidc-auth/index.js'
 
 export const createApp = () => {
   const app = new OpenAPIHono()
@@ -35,6 +36,7 @@ export const createApp = () => {
 
   // Local loginはSessionなしでも利用でき、Sessionがある場合だけreauthenticateとして扱う。
   app.route('/api/organizations', organizationLocalAuthRoutes)
+  app.route('/api/organizations', organizationOidcAuthRoutes)
 
   app.onError((err, c) => {
     Sentry.captureException(err)

--- a/apps/kaede/src/services/auth/google-oidc-client.test.ts
+++ b/apps/kaede/src/services/auth/google-oidc-client.test.ts
@@ -100,6 +100,7 @@ describe('GoogleOidcClient', () => {
     )
 
     await expect(client.verifyIdToken({ idToken, nonce: 'nonce-value' })).resolves.toEqual({
+      issuer: 'https://accounts.google.com',
       sub: 'google-subject',
       email: 'user@example.com',
       emailVerified: true,
@@ -109,5 +110,41 @@ describe('GoogleOidcClient', () => {
     await expect(client.verifyIdToken({ idToken, nonce: 'wrong-nonce' })).rejects.toThrow(
       'Google ID token nonce mismatch'
     )
+  }, 15_000)
+
+  it('Google の issuer alias と複数 audience の authorized party を検証する', async () => {
+    const { publicKey, privateKey } = await generateKeyPair('RS256')
+    const publicJwk = await exportJWK(publicKey)
+    const createToken = (azp: string) =>
+      new SignJWT({
+        sub: 'google-subject',
+        email: 'user@example.com',
+        email_verified: true,
+        nonce: 'nonce-value',
+        azp,
+      })
+        .setProtectedHeader({ alg: 'RS256', kid: 'test-key' })
+        .setIssuedAt()
+        .setIssuer('accounts.google.com')
+        .setAudience(['client-id', 'another-audience'])
+        .setExpirationTime('5m')
+        .sign(privateKey)
+    const client = new GoogleOidcClient(
+      {
+        clientId: 'client-id',
+        clientSecret: 'client-secret',
+        redirectUri: 'https://api.example.test/callback',
+      },
+      {
+        jwks: { keys: [{ ...publicJwk, kid: 'test-key', alg: 'RS256', use: 'sig' }] },
+      }
+    )
+
+    await expect(
+      client.verifyIdToken({ idToken: await createToken('client-id'), nonce: 'nonce-value' })
+    ).resolves.toMatchObject({ issuer: 'accounts.google.com', sub: 'google-subject' })
+    await expect(
+      client.verifyIdToken({ idToken: await createToken('another-client'), nonce: 'nonce-value' })
+    ).rejects.toThrow('Google ID token authorized party mismatch')
   }, 15_000)
 })

--- a/apps/kaede/src/services/auth/google-oidc-client.ts
+++ b/apps/kaede/src/services/auth/google-oidc-client.ts
@@ -21,6 +21,7 @@ export interface GoogleOidcClientOptions {
 }
 
 export interface GoogleIdTokenClaims {
+  issuer: string
   sub: string
   email: string
   emailVerified: boolean
@@ -29,6 +30,7 @@ export interface GoogleIdTokenClaims {
 }
 
 interface GoogleIdTokenPayload extends JWTPayload {
+  azp?: unknown
   email?: unknown
   email_verified?: unknown
   name?: unknown
@@ -142,8 +144,13 @@ export class GoogleOidcClient {
     if (googlePayload.nonce !== nonce) {
       throw new Error('Google ID token nonce mismatch')
     }
+    const audiences = Array.isArray(googlePayload.aud) ? googlePayload.aud : [googlePayload.aud]
+    if (audiences.length > 1 && googlePayload.azp !== this.config.clientId) {
+      throw new Error('Google ID token authorized party mismatch')
+    }
 
     return {
+      issuer: requireStringClaim(googlePayload, 'iss'),
       sub: requireStringClaim(googlePayload, 'sub'),
       email: requireStringClaim(googlePayload, 'email'),
       emailVerified: googlePayload.email_verified === true,

--- a/apps/kaede/src/services/organization-oidc-auth/index.ts
+++ b/apps/kaede/src/services/organization-oidc-auth/index.ts
@@ -1,0 +1,2 @@
+export * from './repository.js'
+export * from './security.js'

--- a/apps/kaede/src/services/organization-oidc-auth/repository.ts
+++ b/apps/kaede/src/services/organization-oidc-auth/repository.ts
@@ -1,0 +1,350 @@
+import { sql } from 'kysely'
+import type { Insertable } from 'kysely'
+import type {
+  AuditEvents,
+  AuthenticationEvents,
+  OidcIdentities,
+  OidcLoginTransactions,
+  OrganizationMemberOidcIdentities,
+  OrganizationOidcProviders,
+  SessionMembershipAuthentications,
+} from '../db/generated.js'
+import { db } from '../db/index.js'
+import type { DbExecutor } from '../executor.js'
+
+export const findOrganizationOidcProviderContext = async (
+  organizationSlug: string,
+  providerId: string,
+  executor: DbExecutor = db
+) =>
+  executor
+    .selectFrom('organization_oidc_providers as provider')
+    .innerJoin('organizations as organization', 'organization.id', 'provider.organization_id')
+    .innerJoin(
+      'organization_auth_settings as settings',
+      'settings.organization_id',
+      'organization.id'
+    )
+    .select([
+      'provider.id as provider_id',
+      'provider.organization_id',
+      'provider.name as provider_name',
+      'provider.issuer',
+      'provider.client_id',
+      'provider.scopes',
+      'provider.allowed_hosted_domains',
+      'provider.enabled as provider_enabled',
+      'organization.status as organization_status',
+      'settings.oidc_auth_enabled',
+      'settings.policy_version',
+      'settings.membership_grant_ttl_seconds',
+      'settings.reauthentication_interval_seconds',
+    ])
+    .where('organization.slug', '=', organizationSlug)
+    .where('provider.id', '=', providerId)
+    .executeTakeFirst()
+
+export const findOrganizationOidcProviderContextById = async (
+  providerId: string,
+  executor: DbExecutor = db
+) =>
+  executor
+    .selectFrom('organization_oidc_providers as provider')
+    .innerJoin('organizations as organization', 'organization.id', 'provider.organization_id')
+    .innerJoin(
+      'organization_auth_settings as settings',
+      'settings.organization_id',
+      'organization.id'
+    )
+    .select([
+      'provider.id as provider_id',
+      'provider.organization_id',
+      'provider.name as provider_name',
+      'provider.issuer',
+      'provider.client_id',
+      'provider.scopes',
+      'provider.allowed_hosted_domains',
+      'provider.enabled as provider_enabled',
+      'organization.status as organization_status',
+      'settings.oidc_auth_enabled',
+      'settings.policy_version',
+      'settings.membership_grant_ttl_seconds',
+      'settings.reauthentication_interval_seconds',
+    ])
+    .where('provider.id', '=', providerId)
+    .executeTakeFirst()
+
+export const insertOidcLoginTransaction = async (
+  transaction: Insertable<OidcLoginTransactions>,
+  executor: DbExecutor = db
+) =>
+  executor
+    .insertInto('oidc_login_transactions')
+    .values(transaction)
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+export const claimOidcLoginTransaction = async (
+  stateHash: string,
+  now: Date,
+  executor: DbExecutor = db
+) =>
+  executor
+    .updateTable('oidc_login_transactions')
+    .set({ consumed_at: now })
+    .where('state_hash', '=', stateHash)
+    .where('consumed_at', 'is', null)
+    .where('expires_at', '>', now)
+    .returningAll()
+    .executeTakeFirst()
+
+export const oidcLoginTransactionStateExists = async (
+  stateHash: string,
+  executor: DbExecutor = db
+) =>
+  Boolean(
+    await executor
+      .selectFrom('oidc_login_transactions')
+      .select('id')
+      .where('state_hash', '=', stateHash)
+      .executeTakeFirst()
+  )
+
+export const findActiveInviteIdByTokenHash = async (
+  organizationId: string,
+  tokenHash: string,
+  now: Date,
+  executor: DbExecutor = db
+) =>
+  executor
+    .selectFrom('organization_invites')
+    .select('id')
+    .where('organization_id', '=', organizationId)
+    .where('token_hash', '=', tokenHash)
+    .where('revoked_at', 'is', null)
+    .where('redeemed_at', 'is', null)
+    .where('expires_at', '>', now)
+    .executeTakeFirst()
+
+export const findActiveMembershipByOrganizationAndUser = async (
+  organizationId: string,
+  userId: string,
+  executor: DbExecutor = db
+) =>
+  executor
+    .selectFrom('organization_memberships')
+    .selectAll()
+    .where('organization_id', '=', organizationId)
+    .where('user_id', '=', userId)
+    .where('status', '=', 'active')
+    .executeTakeFirst()
+
+export const findValidSessionById = async (
+  sessionId: string,
+  now: Date,
+  executor: DbExecutor = db
+) =>
+  executor
+    .selectFrom('sessions')
+    .selectAll()
+    .where('id', '=', sessionId)
+    .where('revoked_at', 'is', null)
+    .where('expires_at', '>', now)
+    .executeTakeFirst()
+
+export const findRecentMembershipGrant = async (
+  sessionId: string,
+  organizationId: string,
+  userId: string,
+  policyVersion: string,
+  reauthenticatedAfter: Date,
+  now: Date,
+  executor: DbExecutor = db
+) =>
+  executor
+    .selectFrom('session_membership_authentications as grant')
+    .innerJoin('organization_memberships as membership', 'membership.id', 'grant.membership_id')
+    .select(['grant.session_id', 'grant.membership_id'])
+    .where('grant.session_id', '=', sessionId)
+    .where('grant.user_id', '=', userId)
+    .where('membership.organization_id', '=', organizationId)
+    .where('membership.status', '=', 'active')
+    .where('grant.policy_version', '=', policyVersion)
+    .where('grant.authenticated_at', '>=', reauthenticatedAfter)
+    .where('grant.expires_at', '>', now)
+    .where('grant.revoked_at', 'is', null)
+    .executeTakeFirst()
+
+export const findOidcIdentity = async (
+  issuer: string,
+  subject: string,
+  executor: DbExecutor = db
+) =>
+  executor
+    .selectFrom('oidc_identities')
+    .selectAll()
+    .where('issuer', '=', issuer)
+    .where('subject', '=', subject)
+    .executeTakeFirst()
+
+export const insertOidcIdentity = async (
+  identity: Insertable<OidcIdentities>,
+  executor: DbExecutor
+) =>
+  executor.insertInto('oidc_identities').values(identity).returningAll().executeTakeFirstOrThrow()
+
+export const updateOidcIdentityClaims = async (
+  identityId: string,
+  values: { last_claimed_email: string | null; last_claimed_email_verified: boolean | null },
+  executor: DbExecutor
+) =>
+  executor
+    .updateTable('oidc_identities')
+    .set(values)
+    .where('id', '=', identityId)
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+export const findActiveOidcMembershipLink = async (
+  providerId: string,
+  identityId: string,
+  executor: DbExecutor = db
+) =>
+  executor
+    .selectFrom('organization_member_oidc_identities as link')
+    .innerJoin('organization_memberships as membership', 'membership.id', 'link.membership_id')
+    .innerJoin('users as user', 'user.id', 'link.user_id')
+    .select([
+      'link.id as link_id',
+      'link.membership_id',
+      'link.organization_id',
+      'link.user_id',
+      'membership.role as membership_role',
+      'membership.status as membership_status',
+      'user.status as user_status',
+    ])
+    .where('link.organization_oidc_provider_id', '=', providerId)
+    .where('link.oidc_identity_id', '=', identityId)
+    .where('link.revoked_at', 'is', null)
+    .executeTakeFirst()
+
+export const upsertOidcMembershipLink = async (
+  link: Insertable<OrganizationMemberOidcIdentities>,
+  executor: DbExecutor
+) => {
+  const existing = await executor
+    .selectFrom('organization_member_oidc_identities')
+    .selectAll()
+    .where('membership_id', '=', link.membership_id)
+    .where('organization_oidc_provider_id', '=', link.organization_oidc_provider_id)
+    .where('oidc_identity_id', '=', link.oidc_identity_id)
+    .executeTakeFirst()
+
+  if (existing) {
+    return executor
+      .updateTable('organization_member_oidc_identities')
+      .set({ revoked_at: null })
+      .where('id', '=', existing.id)
+      .returningAll()
+      .executeTakeFirstOrThrow()
+  }
+
+  return executor
+    .insertInto('organization_member_oidc_identities')
+    .values(link)
+    .returningAll()
+    .executeTakeFirstOrThrow()
+}
+
+export const upsertOidcMembershipGrant = async (
+  grant: Insertable<SessionMembershipAuthentications>,
+  executor: DbExecutor
+) =>
+  executor
+    .insertInto('session_membership_authentications')
+    .values(grant)
+    .onConflict((oc) =>
+      oc.columns(['session_id', 'membership_id']).doUpdateSet({
+        user_id: grant.user_id,
+        auth_method: 'oidc',
+        policy_version: grant.policy_version,
+        local_credential_id: null,
+        member_oidc_identity_id: grant.member_oidc_identity_id,
+        authenticated_at: grant.authenticated_at,
+        expires_at: grant.expires_at,
+        revoked_at: null,
+      })
+    )
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+export const insertOidcAuthenticationEvent = async (
+  event: Insertable<AuthenticationEvents>,
+  executor: DbExecutor
+) =>
+  executor
+    .insertInto('authentication_events')
+    .values(event)
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+export const insertOidcAuditEvent = async (event: Insertable<AuditEvents>, executor: DbExecutor) =>
+  executor.insertInto('audit_events').values(event).executeTakeFirst()
+
+export const listOidcProviders = async (organizationId: string, executor: DbExecutor = db) =>
+  executor
+    .selectFrom('organization_oidc_providers')
+    .selectAll()
+    .where('organization_id', '=', organizationId)
+    .orderBy('created_at', 'asc')
+    .execute()
+
+export const insertOidcProvider = async (
+  provider: Insertable<OrganizationOidcProviders>,
+  executor: DbExecutor
+) =>
+  executor
+    .insertInto('organization_oidc_providers')
+    .values(provider)
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+export const updateOidcProvider = async (
+  organizationId: string,
+  providerId: string,
+  provider: Partial<Insertable<OrganizationOidcProviders>>,
+  executor: DbExecutor
+) =>
+  executor
+    .updateTable('organization_oidc_providers')
+    .set(provider)
+    .where('organization_id', '=', organizationId)
+    .where('id', '=', providerId)
+    .returningAll()
+    .executeTakeFirst()
+
+export const findActiveOwnerMembershipForUpdate = async (
+  organizationId: string,
+  userId: string,
+  executor: DbExecutor
+) =>
+  executor
+    .selectFrom('organization_memberships')
+    .selectAll()
+    .where('organization_id', '=', organizationId)
+    .where('user_id', '=', userId)
+    .where('role', '=', 'owner')
+    .where('status', '=', 'active')
+    .forUpdate()
+    .executeTakeFirst()
+
+export const incrementOrganizationPolicyVersion = async (
+  organizationId: string,
+  executor: DbExecutor
+) =>
+  executor
+    .updateTable('organization_auth_settings')
+    .set({ policy_version: sql`policy_version + 1` })
+    .where('organization_id', '=', organizationId)
+    .returningAll()
+    .executeTakeFirstOrThrow()

--- a/apps/kaede/src/services/organization-oidc-auth/security.test.ts
+++ b/apps/kaede/src/services/organization-oidc-auth/security.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import {
+  canonicalizeOidcIssuer,
+  decryptPkceCodeVerifier,
+  encryptPkceCodeVerifier,
+  isHostedDomainAllowed,
+  normalizeHostedDomains,
+} from './security.js'
+
+describe('organization OIDC security helpers', () => {
+  it('Google issuer aliasesをcanonical issuerへ統一する', () => {
+    expect(canonicalizeOidcIssuer('accounts.google.com')).toBe('https://accounts.google.com')
+    expect(canonicalizeOidcIssuer('https://accounts.google.com')).toBe(
+      'https://accounts.google.com'
+    )
+    expect(canonicalizeOidcIssuer('https://issuer.example.test')).toBe(
+      'https://issuer.example.test'
+    )
+  })
+
+  it('PKCE verifierを暗号化して復号できる', () => {
+    const encrypted = encryptPkceCodeVerifier('code-verifier', 'transaction-secret')
+
+    expect(encrypted).not.toContain('code-verifier')
+    expect(decryptPkceCodeVerifier(encrypted, 'transaction-secret')).toBe('code-verifier')
+    expect(() => decryptPkceCodeVerifier(encrypted, 'wrong-secret')).toThrow()
+  })
+
+  it('Hosted Domain未設定なら個人Googleと任意Workspaceを許可する', () => {
+    expect(isHostedDomainAllowed(null, null)).toBe(true)
+    expect(isHostedDomainAllowed('other-workspace.example', null)).toBe(true)
+  })
+
+  it('Hosted Domain設定時だけhd一致を要求する', () => {
+    const allowed = normalizeHostedDomains([' Company-A.Example ', 'company-a.example'])
+
+    expect(allowed).toEqual(['company-a.example'])
+    expect(isHostedDomainAllowed('COMPANY-A.EXAMPLE', allowed)).toBe(true)
+    expect(isHostedDomainAllowed(null, allowed)).toBe(false)
+    expect(isHostedDomainAllowed('company-b.example', allowed)).toBe(false)
+  })
+})

--- a/apps/kaede/src/services/organization-oidc-auth/security.ts
+++ b/apps/kaede/src/services/organization-oidc-auth/security.ts
@@ -1,0 +1,58 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto'
+
+const GOOGLE_CANONICAL_ISSUER = 'https://accounts.google.com'
+const GOOGLE_ISSUER_ALIASES = new Set(['accounts.google.com', GOOGLE_CANONICAL_ISSUER])
+
+export const canonicalizeOidcIssuer = (issuer: string) =>
+  GOOGLE_ISSUER_ALIASES.has(issuer) ? GOOGLE_CANONICAL_ISSUER : issuer
+
+export const isGoogleIssuer = (issuer: string) => GOOGLE_ISSUER_ALIASES.has(issuer)
+
+export const hashOidcState = (state: string) =>
+  createHash('sha256').update(state).digest('base64url')
+
+const encryptionKey = (secret: string) => createHash('sha256').update(secret).digest()
+
+export const encryptPkceCodeVerifier = (codeVerifier: string, secret: string) => {
+  const iv = randomBytes(12)
+  const cipher = createCipheriv('aes-256-gcm', encryptionKey(secret), iv)
+  const ciphertext = Buffer.concat([cipher.update(codeVerifier, 'utf8'), cipher.final()])
+
+  return Buffer.concat([iv, cipher.getAuthTag(), ciphertext]).toString('base64url')
+}
+
+export const decryptPkceCodeVerifier = (encrypted: string, secret: string) => {
+  const payload = Buffer.from(encrypted, 'base64url')
+  if (payload.length <= 28) {
+    throw new Error('encrypted PKCE verifier is invalid')
+  }
+
+  const iv = payload.subarray(0, 12)
+  const authTag = payload.subarray(12, 28)
+  const ciphertext = payload.subarray(28)
+  const decipher = createDecipheriv('aes-256-gcm', encryptionKey(secret), iv)
+  decipher.setAuthTag(authTag)
+
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8')
+}
+
+export const normalizeHostedDomains = (domains: string[] | null | undefined) => {
+  if (!domains || domains.length === 0) return null
+
+  const normalized = [...new Set(domains.map((domain) => domain.trim().toLowerCase()))]
+  if (normalized.some((domain) => !/^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/.test(domain))) {
+    throw new Error('allowed hosted domain is invalid')
+  }
+
+  return normalized
+}
+
+export const isHostedDomainAllowed = (
+  hostedDomain: string | null,
+  allowedHostedDomains: string[] | null
+) => {
+  if (allowedHostedDomains === null) return true
+  if (!hostedDomain) return false
+
+  return allowedHostedDomains.includes(hostedDomain.trim().toLowerCase())
+}

--- a/apps/kaede/src/usecases/organization-oidc-auth/callback.ts
+++ b/apps/kaede/src/usecases/organization-oidc-auth/callback.ts
@@ -1,0 +1,400 @@
+import type { GoogleIdTokenClaims } from '../../services/auth/index.js'
+import { createSession, findValidSessionByToken } from '../../services/auth/index.js'
+import { db } from '../../services/db/index.js'
+import type { DbExecutor } from '../../services/executor.js'
+import {
+  canonicalizeOidcIssuer,
+  claimOidcLoginTransaction,
+  decryptPkceCodeVerifier,
+  findActiveMembershipByOrganizationAndUser,
+  findActiveOidcMembershipLink,
+  findOidcIdentity,
+  findOrganizationOidcProviderContextById,
+  findValidSessionById,
+  hashOidcState,
+  insertOidcAuthenticationEvent,
+  insertOidcIdentity,
+  isGoogleIssuer,
+  isHostedDomainAllowed,
+  oidcLoginTransactionStateExists,
+  updateOidcIdentityClaims,
+  upsertOidcMembershipGrant,
+  upsertOidcMembershipLink,
+} from '../../services/organization-oidc-auth/index.js'
+
+export const isOrganizationOidcTransactionState = (state: string, executor: DbExecutor = db) =>
+  oidcLoginTransactionStateExists(hashOidcState(state), executor)
+
+export interface OrganizationOidcCallbackClient {
+  exchangeCodeForIdToken(params: { code: string; codeVerifier: string }): Promise<string>
+  verifyIdToken(params: { idToken: string; nonce: string }): Promise<GoogleIdTokenClaims>
+}
+
+export interface OrganizationOidcInviteCompletionContext {
+  inviteId: string
+  organizationId: string
+  providerId: string
+  transactionSessionId: string | null
+  callbackSessionToken?: string
+  claims: GoogleIdTokenClaims
+  returnTo: string
+  now: Date
+  executor: DbExecutor
+}
+
+export type CompleteOrganizationOidcInvite = (
+  context: OrganizationOidcInviteCompletionContext
+) => Promise<CompleteOrganizationOidcResult>
+
+export interface CompleteOrganizationOidcOptions {
+  client: OrganizationOidcCallbackClient
+  configuredClientId: string
+  transactionSecret: string
+  sessionToken?: string
+  completeInvite?: CompleteOrganizationOidcInvite
+  now?: Date
+  executor?: DbExecutor
+}
+
+export type CompleteOrganizationOidcError =
+  | { type: 'OIDC_TRANSACTION_INVALID' }
+  | { type: 'OIDC_PROVIDER_ERROR' }
+  | { type: 'OIDC_PROVIDER_CONFIG_INVALID' }
+  | { type: 'OIDC_HOSTED_DOMAIN_NOT_ALLOWED' }
+  | { type: 'OIDC_EMAIL_UNVERIFIED' }
+  | { type: 'OIDC_IDENTITY_NOT_LINKED' }
+  | { type: 'OIDC_INVITE_COMPLETION_REQUIRED' }
+  | { type: 'AUTH_IDENTITY_USER_MISMATCH' }
+  | { type: 'AUTH_MEMBERSHIP_NOT_ACTIVE' }
+  | { type: 'AUTH_SESSION_REQUIRED' }
+  | { type: 'AUTH_USER_DISABLED' }
+
+export type CompleteOrganizationOidcResult =
+  | {
+      ok: true
+      value: {
+        return_to: string
+        sessionToken?: string
+      }
+    }
+  | {
+      ok: false
+      error: CompleteOrganizationOidcError
+      return_to?: string
+    }
+
+const runInTransaction = async <T>(
+  executor: DbExecutor | undefined,
+  callback: (trx: DbExecutor) => Promise<T>
+) => {
+  const base = executor ?? db
+  return 'transaction' in base ? base.transaction().execute(callback) : callback(base)
+}
+
+export const completeOrganizationOidc = async (
+  code: string | undefined,
+  state: string | undefined,
+  options: CompleteOrganizationOidcOptions
+): Promise<CompleteOrganizationOidcResult> => {
+  const now = options.now ?? new Date()
+  if (!state) {
+    return { ok: false, error: { type: 'OIDC_TRANSACTION_INVALID' } }
+  }
+
+  // stateをIdP通信より先に原子的に消費し、同じcallbackを二度処理しない。
+  const transaction = await claimOidcLoginTransaction(
+    hashOidcState(state),
+    now,
+    options.executor ?? db
+  )
+  if (!transaction) {
+    return { ok: false, error: { type: 'OIDC_TRANSACTION_INVALID' } }
+  }
+  if (!code) {
+    return {
+      ok: false,
+      error: { type: 'OIDC_PROVIDER_ERROR' },
+      return_to: transaction.return_to,
+    }
+  }
+
+  const provider = await findOrganizationOidcProviderContextById(
+    transaction.organization_oidc_provider_id,
+    options.executor ?? db
+  )
+  if (
+    provider?.organization_id !== transaction.organization_id ||
+    provider.organization_status !== 'active' ||
+    !provider.oidc_auth_enabled ||
+    !provider.provider_enabled
+  ) {
+    return {
+      ok: false,
+      error: { type: 'OIDC_PROVIDER_CONFIG_INVALID' },
+      return_to: transaction.return_to,
+    }
+  }
+  if (!isGoogleIssuer(provider.issuer) || provider.client_id !== options.configuredClientId) {
+    return {
+      ok: false,
+      error: { type: 'OIDC_PROVIDER_CONFIG_INVALID' },
+      return_to: transaction.return_to,
+    }
+  }
+
+  let claims: GoogleIdTokenClaims
+  try {
+    const codeVerifier = decryptPkceCodeVerifier(
+      transaction.pkce_code_verifier_ciphertext,
+      options.transactionSecret
+    )
+    const idToken = await options.client.exchangeCodeForIdToken({ code, codeVerifier })
+    claims = await options.client.verifyIdToken({ idToken, nonce: transaction.nonce })
+  } catch {
+    return {
+      ok: false,
+      error: { type: 'OIDC_PROVIDER_ERROR' },
+      return_to: transaction.return_to,
+    }
+  }
+
+  const issuer = canonicalizeOidcIssuer(claims.issuer)
+  if (issuer !== canonicalizeOidcIssuer(provider.issuer)) {
+    return {
+      ok: false,
+      error: { type: 'OIDC_PROVIDER_CONFIG_INVALID' },
+      return_to: transaction.return_to,
+    }
+  }
+  if (!claims.emailVerified) {
+    return {
+      ok: false,
+      error: { type: 'OIDC_EMAIL_UNVERIFIED' },
+      return_to: transaction.return_to,
+    }
+  }
+  if (!isHostedDomainAllowed(claims.hostedDomain, provider.allowed_hosted_domains)) {
+    return {
+      ok: false,
+      error: { type: 'OIDC_HOSTED_DOMAIN_NOT_ALLOWED' },
+      return_to: transaction.return_to,
+    }
+  }
+
+  if (transaction.intent === 'accept_invite') {
+    if (options.completeInvite && transaction.invite_id) {
+      return options.completeInvite({
+        inviteId: transaction.invite_id,
+        organizationId: provider.organization_id,
+        providerId: provider.provider_id,
+        transactionSessionId: transaction.session_id,
+        callbackSessionToken: options.sessionToken,
+        claims: { ...claims, issuer },
+        returnTo: transaction.return_to,
+        now,
+        executor: options.executor ?? db,
+      })
+    }
+    return {
+      ok: false,
+      error: { type: 'OIDC_INVITE_COMPLETION_REQUIRED' },
+      return_to: transaction.return_to,
+    }
+  }
+
+  return runInTransaction(options.executor, async (trx) => {
+    if (transaction.intent === 'link_identity') {
+      if (!transaction.session_id || !options.sessionToken) {
+        return {
+          ok: false,
+          error: { type: 'AUTH_SESSION_REQUIRED' },
+          return_to: transaction.return_to,
+        } as const
+      }
+      const session = await findValidSessionByToken(options.sessionToken, now, trx)
+      if (!session.ok || session.session.id !== transaction.session_id) {
+        return {
+          ok: false,
+          error: { type: 'AUTH_SESSION_REQUIRED' },
+          return_to: transaction.return_to,
+        } as const
+      }
+      const membership = await findActiveMembershipByOrganizationAndUser(
+        provider.organization_id,
+        session.session.user_id,
+        trx
+      )
+      if (!membership?.id) {
+        return {
+          ok: false,
+          error: { type: 'AUTH_MEMBERSHIP_NOT_ACTIVE' },
+          return_to: transaction.return_to,
+        } as const
+      }
+
+      const existingIdentity = await findOidcIdentity(issuer, claims.sub, trx)
+      if (existingIdentity && existingIdentity.user_id !== session.session.user_id) {
+        return {
+          ok: false,
+          error: { type: 'AUTH_IDENTITY_USER_MISMATCH' },
+          return_to: transaction.return_to,
+        } as const
+      }
+      const identity = existingIdentity
+        ? await updateOidcIdentityClaims(
+            existingIdentity.id,
+            {
+              last_claimed_email: claims.email,
+              last_claimed_email_verified: claims.emailVerified,
+            },
+            trx
+          )
+        : await insertOidcIdentity(
+            {
+              user_id: session.session.user_id,
+              issuer,
+              subject: claims.sub,
+              last_claimed_email: claims.email,
+              last_claimed_email_verified: claims.emailVerified,
+            },
+            trx
+          )
+      await upsertOidcMembershipLink(
+        {
+          membership_id: membership.id,
+          organization_id: provider.organization_id,
+          user_id: session.session.user_id,
+          organization_oidc_provider_id: provider.provider_id,
+          oidc_identity_id: identity.id,
+          revoked_at: null,
+        },
+        trx
+      )
+      await insertOidcAuthenticationEvent(
+        {
+          event_type: 'oidc_link_identity',
+          outcome: 'success',
+          user_id: session.session.user_id,
+          organization_id: provider.organization_id,
+          membership_id: membership.id,
+          session_id: session.session.id,
+          auth_method: 'oidc',
+          credential_reference_id: identity.id,
+        },
+        trx
+      )
+      return { ok: true, value: { return_to: transaction.return_to } } as const
+    }
+
+    const identity = await findOidcIdentity(issuer, claims.sub, trx)
+    if (!identity) {
+      return {
+        ok: false,
+        error: { type: 'OIDC_IDENTITY_NOT_LINKED' },
+        return_to: transaction.return_to,
+      } as const
+    }
+    const link = await findActiveOidcMembershipLink(provider.provider_id, identity.id, trx)
+    if (link?.membership_status !== 'active') {
+      return {
+        ok: false,
+        error: { type: 'AUTH_MEMBERSHIP_NOT_ACTIVE' },
+        return_to: transaction.return_to,
+      } as const
+    }
+    if (link.user_status !== 'active') {
+      return {
+        ok: false,
+        error: { type: 'AUTH_USER_DISABLED' },
+        return_to: transaction.return_to,
+      } as const
+    }
+
+    let session
+    let createdSessionToken: string | undefined
+    if (transaction.intent === 'reauthenticate') {
+      if (!transaction.session_id || !options.sessionToken) {
+        return {
+          ok: false,
+          error: { type: 'AUTH_SESSION_REQUIRED' },
+          return_to: transaction.return_to,
+        } as const
+      }
+      const cookieSession = await findValidSessionByToken(options.sessionToken, now, trx)
+      const transactionSession = await findValidSessionById(transaction.session_id, now, trx)
+      if (!cookieSession.ok || cookieSession.session.id !== transactionSession?.id) {
+        return {
+          ok: false,
+          error: { type: 'AUTH_SESSION_REQUIRED' },
+          return_to: transaction.return_to,
+        } as const
+      }
+      session = transactionSession
+    } else if (options.sessionToken) {
+      const existingSession = await findValidSessionByToken(options.sessionToken, now, trx)
+      if (existingSession.ok) session = existingSession.session
+    }
+
+    if (session && session.user_id !== identity.user_id) {
+      return {
+        ok: false,
+        error: { type: 'AUTH_IDENTITY_USER_MISMATCH' },
+        return_to: transaction.return_to,
+      } as const
+    }
+    if (!session) {
+      const created = await createSession(
+        { authMethod: 'oidc', userId: identity.user_id, now },
+        trx
+      )
+      session = created.session
+      createdSessionToken = created.token
+    }
+
+    const expiresAt = new Date(now.getTime() + provider.membership_grant_ttl_seconds * 1000)
+    await upsertOidcMembershipGrant(
+      {
+        session_id: session.id,
+        membership_id: link.membership_id,
+        user_id: identity.user_id,
+        auth_method: 'oidc',
+        policy_version: provider.policy_version,
+        local_credential_id: null,
+        member_oidc_identity_id: link.link_id,
+        authenticated_at: now,
+        expires_at: expiresAt,
+        revoked_at: null,
+      },
+      trx
+    )
+    await updateOidcIdentityClaims(
+      identity.id,
+      {
+        last_claimed_email: claims.email,
+        last_claimed_email_verified: claims.emailVerified,
+      },
+      trx
+    )
+    await insertOidcAuthenticationEvent(
+      {
+        event_type: transaction.intent === 'reauthenticate' ? 'oidc_reauthenticate' : 'oidc_login',
+        outcome: 'success',
+        user_id: identity.user_id,
+        organization_id: provider.organization_id,
+        membership_id: link.membership_id,
+        session_id: session.id,
+        auth_method: 'oidc',
+        credential_reference_id: identity.id,
+      },
+      trx
+    )
+
+    return {
+      ok: true,
+      value: {
+        return_to: transaction.return_to,
+        sessionToken: createdSessionToken,
+      },
+    } as const
+  })
+}

--- a/apps/kaede/src/usecases/organization-oidc-auth/index.ts
+++ b/apps/kaede/src/usecases/organization-oidc-auth/index.ts
@@ -1,0 +1,3 @@
+export * from './callback.js'
+export * from './providers.js'
+export * from './start.js'

--- a/apps/kaede/src/usecases/organization-oidc-auth/providers.ts
+++ b/apps/kaede/src/usecases/organization-oidc-auth/providers.ts
@@ -1,0 +1,217 @@
+import type {
+  CreateOrganizationOidcProviderRequest,
+  UpdateOrganizationOidcProviderRequest,
+} from '../../schemas/organization-oidc-auth.js'
+import { db } from '../../services/db/index.js'
+import type { DbExecutor } from '../../services/executor.js'
+import {
+  canonicalizeOidcIssuer,
+  findActiveOwnerMembershipForUpdate,
+  incrementOrganizationPolicyVersion,
+  insertOidcAuditEvent,
+  insertOidcProvider,
+  listOidcProviders,
+  normalizeHostedDomains,
+  updateOidcProvider,
+} from '../../services/organization-oidc-auth/index.js'
+
+export type OidcProviderManagementError =
+  | { type: 'AUTH_FORBIDDEN' }
+  | { type: 'OIDC_PROVIDER_NOT_FOUND' }
+  | { type: 'OIDC_PROVIDER_CONFIG_INVALID' }
+
+const runInTransaction = async <T>(
+  executor: DbExecutor | undefined,
+  callback: (trx: DbExecutor) => Promise<T>
+) => {
+  const base = executor ?? db
+  return 'transaction' in base ? base.transaction().execute(callback) : callback(base)
+}
+
+const toProviderResponse = (provider: {
+  id: string
+  organization_id: string
+  name: string
+  issuer: string
+  client_id: string
+  allowed_hosted_domains: string[] | null
+  enabled: boolean
+  created_at: Date
+  updated_at: Date
+}) => ({
+  id: provider.id,
+  organization_id: provider.organization_id,
+  display_name: provider.name,
+  issuer: provider.issuer,
+  client_id: provider.client_id,
+  allowed_hosted_domains: provider.allowed_hosted_domains,
+  enabled: provider.enabled,
+  created_at: provider.created_at.toISOString(),
+  updated_at: provider.updated_at.toISOString(),
+})
+
+const requireOwner = async (organizationId: string, userId: string, executor: DbExecutor) => {
+  const membership = await findActiveOwnerMembershipForUpdate(organizationId, userId, executor)
+  return membership?.id
+    ? { ok: true as const, membershipId: membership.id }
+    : { ok: false as const }
+}
+
+export const getOrganizationOidcProviders = async (
+  organizationId: string,
+  userId: string,
+  executor?: DbExecutor
+) =>
+  runInTransaction(executor, async (trx) => {
+    const owner = await requireOwner(organizationId, userId, trx)
+    if (!owner.ok) return { ok: false, error: { type: 'AUTH_FORBIDDEN' } } as const
+
+    const providers = await listOidcProviders(organizationId, trx)
+    return { ok: true, value: { providers: providers.map(toProviderResponse) } } as const
+  })
+
+export const createOrganizationOidcProvider = async (
+  organizationId: string,
+  userId: string,
+  payload: CreateOrganizationOidcProviderRequest,
+  configuredGoogleClientId: string,
+  executor?: DbExecutor
+) => {
+  if (payload.client_id !== configuredGoogleClientId) {
+    return { ok: false, error: { type: 'OIDC_PROVIDER_CONFIG_INVALID' } } as const
+  }
+
+  let allowedHostedDomains: string[] | null
+  try {
+    allowedHostedDomains = normalizeHostedDomains(payload.allowed_hosted_domains)
+  } catch {
+    return { ok: false, error: { type: 'OIDC_PROVIDER_CONFIG_INVALID' } } as const
+  }
+
+  return runInTransaction(executor, async (trx) => {
+    const owner = await requireOwner(organizationId, userId, trx)
+    if (!owner.ok) return { ok: false, error: { type: 'AUTH_FORBIDDEN' } } as const
+
+    const provider = await insertOidcProvider(
+      {
+        organization_id: organizationId,
+        name: payload.display_name,
+        issuer: canonicalizeOidcIssuer(payload.issuer),
+        client_id: payload.client_id,
+        client_secret_ref: null,
+        scopes: ['openid', 'email', 'profile'],
+        allowed_hosted_domains: allowedHostedDomains,
+        enabled: payload.enabled,
+      },
+      trx
+    )
+    if (provider.enabled) await incrementOrganizationPolicyVersion(organizationId, trx)
+    await insertOidcAuditEvent(
+      {
+        actor_user_id: userId,
+        actor_membership_id: owner.membershipId,
+        organization_id: organizationId,
+        target_type: 'organization_oidc_provider',
+        target_id: provider.id,
+        action: 'create',
+        changed_fields: ['provider'],
+        before_values: null,
+        after_values: { enabled: provider.enabled },
+      },
+      trx
+    )
+
+    return { ok: true, value: toProviderResponse(provider) } as const
+  })
+}
+
+export const patchOrganizationOidcProvider = async (
+  organizationId: string,
+  providerId: string,
+  userId: string,
+  payload: UpdateOrganizationOidcProviderRequest,
+  configuredGoogleClientId: string,
+  executor?: DbExecutor
+) => {
+  if (payload.client_id && payload.client_id !== configuredGoogleClientId) {
+    return { ok: false, error: { type: 'OIDC_PROVIDER_CONFIG_INVALID' } } as const
+  }
+
+  let allowedHostedDomains: string[] | null | undefined
+  try {
+    allowedHostedDomains =
+      payload.allowed_hosted_domains === undefined
+        ? undefined
+        : normalizeHostedDomains(payload.allowed_hosted_domains)
+  } catch {
+    return { ok: false, error: { type: 'OIDC_PROVIDER_CONFIG_INVALID' } } as const
+  }
+
+  return runInTransaction(executor, async (trx) => {
+    const owner = await requireOwner(organizationId, userId, trx)
+    if (!owner.ok) return { ok: false, error: { type: 'AUTH_FORBIDDEN' } } as const
+    const before = (await listOidcProviders(organizationId, trx)).find(
+      (provider) => provider.id === providerId
+    )
+    if (!before) {
+      return { ok: false, error: { type: 'OIDC_PROVIDER_NOT_FOUND' } } as const
+    }
+
+    const provider = await updateOidcProvider(
+      organizationId,
+      providerId,
+      {
+        ...(payload.display_name === undefined ? {} : { name: payload.display_name }),
+        ...(payload.issuer === undefined ? {} : { issuer: canonicalizeOidcIssuer(payload.issuer) }),
+        ...(payload.client_id === undefined ? {} : { client_id: payload.client_id }),
+        ...(allowedHostedDomains === undefined
+          ? {}
+          : { allowed_hosted_domains: allowedHostedDomains }),
+        ...(payload.enabled === undefined ? {} : { enabled: payload.enabled }),
+      },
+      trx
+    )
+    if (!provider) {
+      return { ok: false, error: { type: 'OIDC_PROVIDER_NOT_FOUND' } } as const
+    }
+
+    const policyChanged =
+      before.enabled !== provider.enabled ||
+      before.issuer !== provider.issuer ||
+      before.client_id !== provider.client_id ||
+      JSON.stringify(before.allowed_hosted_domains) !==
+        JSON.stringify(provider.allowed_hosted_domains)
+    if (policyChanged) await incrementOrganizationPolicyVersion(organizationId, trx)
+    await insertOidcAuditEvent(
+      {
+        actor_user_id: userId,
+        actor_membership_id: owner.membershipId,
+        organization_id: organizationId,
+        target_type: 'organization_oidc_provider',
+        target_id: provider.id,
+        action: 'update',
+        changed_fields: Object.keys(payload),
+        before_values: { enabled: before.enabled },
+        after_values: { enabled: provider.enabled },
+      },
+      trx
+    )
+
+    return { ok: true, value: toProviderResponse(provider) } as const
+  })
+}
+
+export const disableOrganizationOidcProvider = async (
+  organizationId: string,
+  providerId: string,
+  userId: string,
+  executor?: DbExecutor
+) =>
+  patchOrganizationOidcProvider(
+    organizationId,
+    providerId,
+    userId,
+    { enabled: false },
+    '',
+    executor
+  )

--- a/apps/kaede/src/usecases/organization-oidc-auth/start.ts
+++ b/apps/kaede/src/usecases/organization-oidc-auth/start.ts
@@ -1,0 +1,189 @@
+import type { OrganizationOidcStartRequest } from '../../schemas/organization-oidc-auth.js'
+import {
+  findValidSessionByToken,
+  generateOidcNonce,
+  generateOidcState,
+  generatePkceCodeVerifier,
+  hashActivationToken,
+} from '../../services/auth/index.js'
+import { db } from '../../services/db/index.js'
+import type { DbExecutor } from '../../services/executor.js'
+import {
+  encryptPkceCodeVerifier,
+  findActiveInviteIdByTokenHash,
+  findActiveMembershipByOrganizationAndUser,
+  findOrganizationOidcProviderContext,
+  findRecentMembershipGrant,
+  hashOidcState,
+  insertOidcLoginTransaction,
+  isGoogleIssuer,
+} from '../../services/organization-oidc-auth/index.js'
+
+const OIDC_TRANSACTION_TTL_MS = 10 * 60 * 1000
+
+export interface OrganizationOidcAuthorizationClient {
+  createAuthorizationUrl(params: { codeVerifier: string; nonce: string; state: string }): string
+}
+
+export interface StartOrganizationOidcOptions {
+  client: OrganizationOidcAuthorizationClient
+  configuredClientId: string
+  transactionSecret: string
+  now?: Date
+  executor?: DbExecutor
+}
+
+export type StartOrganizationOidcError =
+  | { type: 'AUTH_METHOD_NOT_ALLOWED' }
+  | { type: 'AUTH_SESSION_REQUIRED' }
+  | { type: 'AUTH_SESSION_EXPIRED' }
+  | { type: 'AUTH_SESSION_REVOKED' }
+  | { type: 'AUTH_MEMBERSHIP_NOT_ACTIVE' }
+  | { type: 'AUTH_MEMBERSHIP_REAUTHENTICATION_REQUIRED' }
+  | { type: 'OIDC_PROVIDER_NOT_FOUND' }
+  | { type: 'OIDC_PROVIDER_CONFIG_INVALID' }
+  | { type: 'INVITE_INVALID' }
+
+const runInTransaction = async <T>(
+  executor: DbExecutor | undefined,
+  callback: (trx: DbExecutor) => Promise<T>
+) => {
+  const base = executor ?? db
+  return 'transaction' in base ? base.transaction().execute(callback) : callback(base)
+}
+
+const mapSessionError = (
+  error: 'SESSION_NOT_FOUND' | 'SESSION_EXPIRED' | 'SESSION_REVOKED'
+): StartOrganizationOidcError => {
+  switch (error) {
+    case 'SESSION_EXPIRED':
+      return { type: 'AUTH_SESSION_EXPIRED' }
+    case 'SESSION_REVOKED':
+      return { type: 'AUTH_SESSION_REVOKED' }
+    case 'SESSION_NOT_FOUND':
+      return { type: 'AUTH_SESSION_REQUIRED' }
+  }
+}
+
+export const startOrganizationOidc = async (
+  organizationSlug: string,
+  providerId: string,
+  sessionToken: string | undefined,
+  payload: OrganizationOidcStartRequest,
+  options: StartOrganizationOidcOptions
+) => {
+  const now = options.now ?? new Date()
+
+  return runInTransaction(options.executor, async (trx) => {
+    const provider = await findOrganizationOidcProviderContext(organizationSlug, providerId, trx)
+    if (!provider) {
+      return { ok: false, error: { type: 'OIDC_PROVIDER_NOT_FOUND' } } as const
+    }
+    if (
+      provider.organization_status !== 'active' ||
+      !provider.oidc_auth_enabled ||
+      !provider.provider_enabled
+    ) {
+      return { ok: false, error: { type: 'AUTH_METHOD_NOT_ALLOWED' } } as const
+    }
+    if (!isGoogleIssuer(provider.issuer) || provider.client_id !== options.configuredClientId) {
+      return { ok: false, error: { type: 'OIDC_PROVIDER_CONFIG_INVALID' } } as const
+    }
+
+    let sessionId: string | null = null
+    let sessionUserId: string | null = null
+    if (sessionToken) {
+      const session = await findValidSessionByToken(sessionToken, now, trx)
+      if (!session.ok) return { ok: false, error: mapSessionError(session.error) } as const
+      sessionId = session.session.id
+      sessionUserId = session.session.user_id
+    }
+    if (payload.intent === 'reauthenticate' || payload.intent === 'link_identity') {
+      if (!sessionId || !sessionUserId) {
+        return { ok: false, error: { type: 'AUTH_SESSION_REQUIRED' } } as const
+      }
+      const membership = await findActiveMembershipByOrganizationAndUser(
+        provider.organization_id,
+        sessionUserId,
+        trx
+      )
+      if (!membership?.id) {
+        return { ok: false, error: { type: 'AUTH_MEMBERSHIP_NOT_ACTIVE' } } as const
+      }
+      if (payload.intent === 'link_identity') {
+        const recentAfter = new Date(
+          now.getTime() - provider.reauthentication_interval_seconds * 1000
+        )
+        const recentGrant = await findRecentMembershipGrant(
+          sessionId,
+          provider.organization_id,
+          sessionUserId,
+          provider.policy_version,
+          recentAfter,
+          now,
+          trx
+        )
+        if (!recentGrant) {
+          return {
+            ok: false,
+            error: { type: 'AUTH_MEMBERSHIP_REAUTHENTICATION_REQUIRED' },
+          } as const
+        }
+      }
+    }
+
+    let inviteId: string | null = null
+    if (payload.intent === 'accept_invite') {
+      if (!payload.invite_token) {
+        return { ok: false, error: { type: 'INVITE_INVALID' } } as const
+      }
+      const invite = await findActiveInviteIdByTokenHash(
+        provider.organization_id,
+        hashActivationToken(payload.invite_token),
+        now,
+        trx
+      )
+      if (!invite) return { ok: false, error: { type: 'INVITE_INVALID' } } as const
+      inviteId = invite.id
+    }
+
+    const state = generateOidcState()
+    const nonce = generateOidcNonce()
+    const codeVerifier = generatePkceCodeVerifier()
+    await insertOidcLoginTransaction(
+      {
+        state_hash: hashOidcState(state),
+        organization_id: provider.organization_id,
+        organization_oidc_provider_id: provider.provider_id,
+        session_id:
+          payload.intent === 'reauthenticate' ||
+          payload.intent === 'link_identity' ||
+          payload.intent === 'accept_invite'
+            ? sessionId
+            : null,
+        invite_id: inviteId,
+        intent: payload.intent,
+        nonce,
+        pkce_code_verifier_ciphertext: encryptPkceCodeVerifier(
+          codeVerifier,
+          options.transactionSecret
+        ),
+        return_to: payload.return_to,
+        expires_at: new Date(now.getTime() + OIDC_TRANSACTION_TTL_MS),
+        consumed_at: null,
+      },
+      trx
+    )
+
+    return {
+      ok: true,
+      value: {
+        authorization_url: options.client.createAuthorizationUrl({
+          codeVerifier,
+          nonce,
+          state,
+        }),
+      },
+    } as const
+  })
+}

--- a/apps/kaede/tests/services/auth/organization-oidc-auth.test.ts
+++ b/apps/kaede/tests/services/auth/organization-oidc-auth.test.ts
@@ -1,0 +1,411 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { hashActivationToken } from '../../../src/services/auth/activation-token.js'
+import { createSession } from '../../../src/services/auth/session-repository.js'
+import { createDb } from '../../../src/services/db/client.js'
+import {
+  completeOrganizationOidc,
+  isOrganizationOidcTransactionState,
+} from '../../../src/usecases/organization-oidc-auth/callback.js'
+import {
+  createOrganizationOidcProvider,
+  getOrganizationOidcProviders,
+} from '../../../src/usecases/organization-oidc-auth/providers.js'
+import { startOrganizationOidc } from '../../../src/usecases/organization-oidc-auth/start.js'
+import { resetDatabase } from '../../db/helpers.js'
+
+const db = createDb()
+const now = new Date('2026-08-11T10:00:00.000Z')
+const configuredClientId = 'google-client-id'
+const transactionSecret = 'test-oidc-transaction-secret'
+
+const createUser = async (email: string) =>
+  db
+    .insertInto('users')
+    .values({
+      email,
+      contact_email: email,
+      normalized_contact_email: email.toLowerCase(),
+      display_name: email,
+      password_hash: null,
+      global_role: 'none',
+      status: 'active',
+      password_changed_at: null,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+const createFixture = async ({
+  allowedHostedDomains = null,
+}: { allowedHostedDomains?: string[] | null } = {}) => {
+  const user = await createUser('oidc-user@example.test')
+  const organization = await db
+    .insertInto('organizations')
+    .values({ name: 'OIDC Organization', slug: 'oidc-organization' })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  await db
+    .insertInto('organization_auth_settings')
+    .values({
+      organization_id: organization.id,
+      local_auth_enabled: false,
+      oidc_auth_enabled: true,
+      membership_grant_ttl_seconds: 28_800,
+      reauthentication_interval_seconds: 14_400,
+    })
+    .execute()
+  const membership = await db
+    .insertInto('organization_memberships')
+    .values({ organization_id: organization.id, user_id: user.id, role: 'member' })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  if (!membership.id) throw new Error('membership id is required')
+  const provider = await db
+    .insertInto('organization_oidc_providers')
+    .values({
+      organization_id: organization.id,
+      name: 'Google',
+      issuer: 'https://accounts.google.com',
+      client_id: configuredClientId,
+      client_secret_ref: null,
+      scopes: ['openid', 'email', 'profile'],
+      allowed_hosted_domains: allowedHostedDomains,
+      enabled: true,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+  return { membership: { ...membership, id: membership.id }, organization, provider, user }
+}
+
+const linkIdentity = async (
+  fixture: Awaited<ReturnType<typeof createFixture>>,
+  subject = 'google-subject'
+) => {
+  const identity = await db
+    .insertInto('oidc_identities')
+    .values({
+      user_id: fixture.user.id,
+      issuer: 'https://accounts.google.com',
+      subject,
+      last_claimed_email: fixture.user.email,
+      last_claimed_email_verified: true,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const link = await db
+    .insertInto('organization_member_oidc_identities')
+    .values({
+      membership_id: fixture.membership.id,
+      organization_id: fixture.organization.id,
+      user_id: fixture.user.id,
+      organization_oidc_provider_id: fixture.provider.id,
+      oidc_identity_id: identity.id,
+      revoked_at: null,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  return { identity, link }
+}
+
+const startLogin = async (
+  fixture: Awaited<ReturnType<typeof createFixture>>,
+  sessionToken?: string
+) => {
+  const result = await startOrganizationOidc(
+    fixture.organization.slug,
+    fixture.provider.id,
+    sessionToken,
+    { intent: 'login', return_to: '/orgs/oidc-organization' },
+    {
+      client: {
+        createAuthorizationUrl: ({ state }) =>
+          `https://accounts.google.com/o/oauth2/v2/auth?state=${encodeURIComponent(state)}`,
+      },
+      configuredClientId,
+      transactionSecret,
+      now,
+      executor: db,
+    }
+  )
+  expect(result.ok).toBe(true)
+  if (!result.ok) throw new Error(result.error.type)
+  const state = new URL(result.value.authorization_url).searchParams.get('state')
+  if (!state) throw new Error('state is required')
+  return state
+}
+
+const callbackClient = ({
+  hostedDomain = null,
+  subject = 'google-subject',
+}: {
+  hostedDomain?: string | null
+  subject?: string
+} = {}) => ({
+  exchangeCodeForIdToken: () => Promise.resolve('id-token'),
+  verifyIdToken: () =>
+    Promise.resolve({
+      issuer: 'accounts.google.com',
+      sub: subject,
+      email: 'oidc-user@example.test',
+      emailVerified: true,
+      name: 'OIDC User',
+      hostedDomain,
+    }),
+})
+
+describe('organization OIDC authentication', () => {
+  beforeEach(async () => {
+    await resetDatabase(db)
+  })
+
+  afterAll(async () => {
+    await db.destroy()
+  })
+
+  it('canonical issuerのIdentity LinkからSessionと対象Membership Grantを作る', async () => {
+    const fixture = await createFixture()
+    const { link } = await linkIdentity(fixture)
+    const state = await startLogin(fixture)
+
+    const result = await completeOrganizationOidc('authorization-code', state, {
+      client: callbackClient(),
+      configuredClientId,
+      transactionSecret,
+      now,
+      executor: db,
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.value.sessionToken).toBeDefined()
+    const grant = await db
+      .selectFrom('session_membership_authentications')
+      .selectAll()
+      .where('membership_id', '=', fixture.membership.id)
+      .executeTakeFirstOrThrow()
+    expect(grant).toMatchObject({
+      auth_method: 'oidc',
+      member_oidc_identity_id: link.id,
+      policy_version: '1',
+      user_id: fixture.user.id,
+    })
+    expect(grant.expires_at).toEqual(new Date('2026-08-11T18:00:00.000Z'))
+  })
+
+  it('state transactionを先に原子的に消費しcallbackの再利用を拒否する', async () => {
+    const fixture = await createFixture()
+    await linkIdentity(fixture)
+    const state = await startLogin(fixture)
+    const options = {
+      client: callbackClient(),
+      configuredClientId,
+      transactionSecret,
+      now,
+      executor: db,
+    }
+
+    await expect(
+      completeOrganizationOidc('authorization-code', state, options)
+    ).resolves.toMatchObject({ ok: true })
+    await expect(completeOrganizationOidc('authorization-code', state, options)).resolves.toEqual({
+      ok: false,
+      error: { type: 'OIDC_TRANSACTION_INVALID' },
+    })
+    await expect(isOrganizationOidcTransactionState(state, db)).resolves.toBe(true)
+  })
+
+  it('IdP error callbackでもstate transactionを消費する', async () => {
+    const fixture = await createFixture()
+    await linkIdentity(fixture)
+    const state = await startLogin(fixture)
+    const options = {
+      client: callbackClient(),
+      configuredClientId,
+      transactionSecret,
+      now,
+      executor: db,
+    }
+
+    await expect(completeOrganizationOidc(undefined, state, options)).resolves.toEqual({
+      ok: false,
+      error: { type: 'OIDC_PROVIDER_ERROR' },
+      return_to: '/orgs/oidc-organization',
+    })
+    await expect(completeOrganizationOidc('authorization-code', state, options)).resolves.toEqual({
+      ok: false,
+      error: { type: 'OIDC_TRANSACTION_INVALID' },
+    })
+  })
+
+  it('既存Session UserとOIDC Identity Userが異なる場合はGrantを作らない', async () => {
+    const fixture = await createFixture()
+    await linkIdentity(fixture)
+    const otherUser = await createUser('other-user@example.test')
+    const session = await createSession({ userId: otherUser.id, now }, db)
+    const state = await startLogin(fixture, session.token)
+
+    const result = await completeOrganizationOidc('authorization-code', state, {
+      client: callbackClient(),
+      configuredClientId,
+      transactionSecret,
+      sessionToken: session.token,
+      now,
+      executor: db,
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      error: { type: 'AUTH_IDENTITY_USER_MISMATCH' },
+      return_to: '/orgs/oidc-organization',
+    })
+    await expect(
+      db.selectFrom('session_membership_authentications').selectAll().execute()
+    ).resolves.toEqual([])
+  })
+
+  it('allowed_hosted_domains設定時はID tokenのhd一致を要求する', async () => {
+    const fixture = await createFixture({ allowedHostedDomains: ['company-a.example'] })
+    await linkIdentity(fixture)
+    const state = await startLogin(fixture)
+
+    const result = await completeOrganizationOidc('authorization-code', state, {
+      client: callbackClient({ hostedDomain: null }),
+      configuredClientId,
+      transactionSecret,
+      now,
+      executor: db,
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      error: { type: 'OIDC_HOSTED_DOMAIN_NOT_ALLOWED' },
+      return_to: '/orgs/oidc-organization',
+    })
+  })
+
+  it('active ownerだけがProviderを作成できissuer/domainを正規化してpolicyを更新する', async () => {
+    const fixture = await createFixture()
+    await db
+      .deleteFrom('organization_oidc_providers')
+      .where('id', '=', fixture.provider.id)
+      .execute()
+
+    const forbidden = await getOrganizationOidcProviders(
+      fixture.organization.id,
+      fixture.user.id,
+      db
+    )
+    expect(forbidden).toEqual({ ok: false, error: { type: 'AUTH_FORBIDDEN' } })
+
+    await db
+      .updateTable('organization_memberships')
+      .set({ role: 'owner' })
+      .where('id', '=', fixture.membership.id)
+      .execute()
+    const result = await createOrganizationOidcProvider(
+      fixture.organization.id,
+      fixture.user.id,
+      {
+        display_name: 'Google Workspace',
+        issuer: 'accounts.google.com',
+        client_id: configuredClientId,
+        allowed_hosted_domains: [' Company-A.Example ', 'company-a.example'],
+        enabled: true,
+      },
+      configuredClientId,
+      db
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.value).toMatchObject({
+      issuer: 'https://accounts.google.com',
+      allowed_hosted_domains: ['company-a.example'],
+      enabled: true,
+    })
+    const settings = await db
+      .selectFrom('organization_auth_settings')
+      .select('policy_version')
+      .where('organization_id', '=', fixture.organization.id)
+      .executeTakeFirstOrThrow()
+    expect(settings.policy_version).toBe('2')
+  })
+
+  it('accept_inviteはverified claimsを注入されたcompletionへ渡しstateを再利用させない', async () => {
+    const fixture = await createFixture()
+    const inviteToken = 'single-use-invite-token'
+    const invite = await db
+      .insertInto('organization_invites')
+      .values({
+        organization_id: fixture.organization.id,
+        created_by_user_id: fixture.user.id,
+        created_by_membership_id: fixture.membership.id,
+        email: 'legacy-unused@example.test',
+        token_hash: hashActivationToken(inviteToken),
+        role: 'member',
+        expires_at: new Date('2026-08-12T10:00:00.000Z'),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    let state = ''
+    const start = await startOrganizationOidc(
+      fixture.organization.slug,
+      fixture.provider.id,
+      undefined,
+      {
+        intent: 'accept_invite',
+        invite_token: inviteToken,
+        return_to: '/invites/complete',
+      },
+      {
+        client: {
+          createAuthorizationUrl: (params) => {
+            state = params.state
+            return `https://accounts.google.com/o/oauth2/v2/auth?state=${params.state}`
+          },
+        },
+        configuredClientId,
+        transactionSecret,
+        now,
+        executor: db,
+      }
+    )
+    expect(start.ok).toBe(true)
+    const completeInvite = vi.fn().mockResolvedValue({
+      ok: true,
+      value: { return_to: '/invites/complete' },
+    })
+    const options = {
+      client: callbackClient({ hostedDomain: 'company-a.example' }),
+      configuredClientId,
+      transactionSecret,
+      completeInvite,
+      now,
+      executor: db,
+    }
+
+    await expect(completeOrganizationOidc('authorization-code', state, options)).resolves.toEqual({
+      ok: true,
+      value: { return_to: '/invites/complete' },
+    })
+    expect(completeInvite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        inviteId: invite.id,
+        organizationId: fixture.organization.id,
+        providerId: fixture.provider.id,
+        transactionSessionId: null,
+        claims: expect.objectContaining({
+          issuer: 'https://accounts.google.com',
+          sub: 'google-subject',
+          hostedDomain: 'company-a.example',
+        }),
+      })
+    )
+
+    await expect(completeOrganizationOidc('authorization-code', state, options)).resolves.toEqual({
+      ok: false,
+      error: { type: 'OIDC_TRANSACTION_INVALID' },
+    })
+    expect(completeInvite).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
Closes part of #219

- Add Organization OIDC provider management and four-intent transaction flow
- Validate state, PKCE, nonce, issuer, audience/azp, expiry, and hosted-domain policy
- Reuse the legacy Google callback and prevent replayed Organization state from falling back
- Add Identity/Link/Grant handling with Session User mismatch rejection
- Expose the accept_invite completeInvite boundary in the same callback; final Invite wiring is handled by the Invite integration PR

Tests: ESLint, TypeScript, unit 467, DB integration 238