### PR TITLE
Enforce organization membership grant authorization

### DIFF
--- a/apps/kaede/src/middleware/organization-authorization.test.ts
+++ b/apps/kaede/src/middleware/organization-authorization.test.ts
@@ -1,0 +1,194 @@
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { evaluateMembershipGrant } from '../services/organization-authorization/authorization.js'
+import { organizationAuthorizationMiddleware } from './organization-authorization.js'
+import type { RequestActorHonoEnv } from './request-actor-context.js'
+
+const { findMembershipGrantContextMock } = vi.hoisted(() => ({
+  findMembershipGrantContextMock: vi.fn(),
+}))
+
+vi.mock('../services/organization-authorization/index.js', () => ({
+  findMembershipGrantContext: findMembershipGrantContextMock,
+}))
+
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const membershipId = '33333333-3333-4333-8333-333333333333'
+const userId = '11111111-1111-4111-8111-111111111111'
+const now = new Date('2026-08-11T12:00:00.000Z')
+
+const activeContext = {
+  organization_id: organizationId,
+  membership_id: membershipId,
+  membership_role: 'manager',
+  membership_status: 'active',
+  membership_left_at: null,
+  organization_status: 'active',
+  local_auth_enabled: true,
+  oidc_auth_enabled: true,
+  current_policy_version: '2',
+  reauthentication_interval_seconds: 7200,
+  grant_auth_method: 'local',
+  grant_policy_version: '2',
+  grant_authenticated_at: new Date('2026-08-11T11:00:00.000Z'),
+  grant_expires_at: new Date('2026-08-11T13:00:00.000Z'),
+  grant_revoked_at: null,
+  local_credential_enabled: true,
+  oidc_identity_revoked_at: null,
+  oidc_provider_enabled: null,
+}
+
+const createApp = (withActor = true) => {
+  const app = new Hono<RequestActorHonoEnv>()
+  if (withActor) {
+    app.use('/api/*', async (c, next) => {
+      c.set('requestActor', {
+        type: 'user',
+        user_id: userId,
+        email: 'member@example.com',
+        global_role: 'none',
+        account_state: 'active',
+        memberships: [
+          { organization_id: organizationId, organization_name: 'Example', role: 'manager' },
+        ],
+      })
+      c.set('requestSessionId', 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa')
+      await next()
+    })
+  }
+  app.use(
+    '/api/organizations/:organizationId/*',
+    organizationAuthorizationMiddleware({ now: () => now })
+  )
+  app.get('/api/organizations/:organizationId', (c) => c.json({ ok: true }))
+  app.get('/api/organizations/:organizationId/resource', (c) => c.json({ ok: true }))
+  return app
+}
+
+describe('evaluateMembershipGrant', () => {
+  it.each([
+    ['grant_missing', { grant_auth_method: null }],
+    ['grant_revoked', { grant_revoked_at: new Date('2026-08-11T11:30:00.000Z') }],
+    ['grant_expired', { grant_expires_at: now }],
+    ['reauthentication_interval_elapsed', { reauthentication_interval_seconds: 3600 }],
+    ['policy_changed', { grant_policy_version: '1' }],
+    ['auth_method_not_allowed', { local_auth_enabled: false }],
+  ] as const)('%s を安定した再認証理由として返す', (reason, override) => {
+    const result = evaluateMembershipGrant({ ...activeContext, ...override }, 'member', now)
+
+    expect(result).toMatchObject({
+      ok: false,
+      type: 'reauthentication_required',
+      membershipId,
+      reason,
+    })
+  })
+
+  it('active grantの確認後にroleを認可する', () => {
+    expect(evaluateMembershipGrant(activeContext, 'manager', now)).toMatchObject({
+      ok: true,
+      membershipId,
+      role: 'manager',
+    })
+    expect(evaluateMembershipGrant(activeContext, 'owner', now)).toEqual({
+      ok: false,
+      type: 'role_forbidden',
+      membershipId,
+    })
+  })
+
+  it('reauthentication intervalの直前は許可し、境界時刻で再認証を要求する', () => {
+    const context = { ...activeContext, reauthentication_interval_seconds: 3600 }
+
+    expect(
+      evaluateMembershipGrant(context, 'member', new Date('2026-08-11T11:59:59.999Z'))
+    ).toMatchObject({ ok: true })
+    expect(evaluateMembershipGrant(context, 'member', now)).toMatchObject({
+      ok: false,
+      type: 'reauthentication_required',
+      reason: 'reauthentication_interval_elapsed',
+    })
+  })
+
+  it('別userやinactive Membershipをquery結果なし/forbiddenとして扱う', () => {
+    expect(evaluateMembershipGrant(undefined, 'member', now)).toEqual({
+      ok: false,
+      type: 'organization_forbidden',
+    })
+    expect(
+      evaluateMembershipGrant({ ...activeContext, membership_status: 'suspended' }, 'member', now)
+    ).toEqual({ ok: false, type: 'organization_forbidden' })
+  })
+})
+
+describe('organizationAuthorizationMiddleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('有効なsessionとMembership grantならorganization routeへ進む', async () => {
+    findMembershipGrantContextMock.mockResolvedValue(activeContext)
+    const response = await createApp().request(`/api/organizations/${organizationId}/resource`)
+
+    expect(response.status).toBe(200)
+    expect(findMembershipGrantContextMock).toHaveBeenCalledWith(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      userId,
+      organizationId
+    )
+  })
+
+  it('organization直下のrouteも認可対象にできる', async () => {
+    findMembershipGrantContextMock.mockResolvedValue(activeContext)
+    const app = new Hono<RequestActorHonoEnv>()
+    app.use('/api/*', async (c, next) => {
+      c.set('requestActor', {
+        type: 'user',
+        user_id: userId,
+        email: 'member@example.com',
+        global_role: 'none',
+        account_state: 'active',
+        memberships: [],
+      })
+      c.set('requestSessionId', 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa')
+      await next()
+    })
+    app.use(
+      '/api/organizations/:organizationId',
+      organizationAuthorizationMiddleware({ now: () => now })
+    )
+    app.get('/api/organizations/:organizationId', (c) => c.json({ ok: true }))
+
+    const response = await app.request(`/api/organizations/${organizationId}`)
+    expect(response.status).toBe(200)
+    expect(findMembershipGrantContextMock).toHaveBeenCalledOnce()
+  })
+
+  it('grant期限切れはglobal sessionを失効させず403と再認証metadataを返す', async () => {
+    findMembershipGrantContextMock.mockResolvedValue({ ...activeContext, grant_expires_at: now })
+    const response = await createApp().request(`/api/organizations/${organizationId}/resource`)
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({
+      error_code: 'AUTH_MEMBERSHIP_REAUTHENTICATION_REQUIRED',
+      error_message: 'organization membership reauthentication required',
+      details: {
+        organization_id: organizationId,
+        membership_id: membershipId,
+        reason: 'grant_expired',
+        allowed_auth_methods: ['local', 'oidc'],
+      },
+    })
+  })
+
+  it('global session contextがなければ401を返す', async () => {
+    const response = await createApp(false).request(`/api/organizations/${organizationId}/resource`)
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({
+      error_code: 'AUTH_UNAUTHENTICATED',
+      error_message: 'login required',
+    })
+    expect(findMembershipGrantContextMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/kaede/src/middleware/organization-authorization.ts
+++ b/apps/kaede/src/middleware/organization-authorization.ts
@@ -1,0 +1,75 @@
+import type { Context, MiddlewareHandler } from 'hono'
+import type { MembershipRole } from '../schemas/common.js'
+import { evaluateMembershipGrant } from '../services/organization-authorization/authorization.js'
+import { findMembershipGrantContext } from '../services/organization-authorization/index.js'
+import type { RequestActorHonoEnv } from './request-actor-context.js'
+import { getRequestActor, getRequestSessionId } from './request-actor-context.js'
+
+const forbidden = (c: Context<RequestActorHonoEnv>, errorCode: string, details?: object) =>
+  c.json(
+    {
+      error_code: errorCode,
+      error_message:
+        errorCode === 'AUTH_MEMBERSHIP_REAUTHENTICATION_REQUIRED'
+          ? 'organization membership reauthentication required'
+          : errorCode === 'AUTH_DASHBOARD_FORBIDDEN'
+            ? 'dashboard access forbidden'
+            : 'organization access forbidden',
+      ...(details ? { details } : {}),
+    },
+    403
+  )
+
+export interface OrganizationAuthorizationMiddlewareOptions {
+  requiredRole?: MembershipRole
+  now?: () => Date
+}
+
+export const organizationAuthorizationMiddleware = ({
+  requiredRole = 'member',
+  now = () => new Date(),
+}: OrganizationAuthorizationMiddlewareOptions = {}): MiddlewareHandler<RequestActorHonoEnv> => {
+  return async (c, next) => {
+    const actor = getRequestActor(c)
+
+    // Shared-token clients are authenticated independently and have no user Membership grant.
+    if (actor?.type === 'service_client') {
+      await next()
+      return
+    }
+
+    const sessionId = getRequestSessionId(c)
+    if (actor?.type !== 'user' || !sessionId) {
+      return c.json({ error_code: 'AUTH_UNAUTHENTICATED', error_message: 'login required' }, 401)
+    }
+
+    const organizationId = c.req.param('organizationId')
+    if (!organizationId) {
+      return forbidden(c, 'AUTH_ORGANIZATION_FORBIDDEN')
+    }
+    const context = await findMembershipGrantContext(sessionId, actor.user_id, organizationId)
+    const result = evaluateMembershipGrant(context, requiredRole, now())
+
+    if (result.ok) {
+      await next()
+      return
+    }
+    if (result.type === 'organization_forbidden') {
+      return forbidden(c, 'AUTH_ORGANIZATION_FORBIDDEN', { organization_id: organizationId })
+    }
+    if (result.type === 'role_forbidden') {
+      return forbidden(c, 'AUTH_DASHBOARD_FORBIDDEN', {
+        organization_id: organizationId,
+        membership_id: result.membershipId,
+        required_role: requiredRole,
+      })
+    }
+
+    return forbidden(c, 'AUTH_MEMBERSHIP_REAUTHENTICATION_REQUIRED', {
+      organization_id: organizationId,
+      membership_id: result.membershipId,
+      reason: result.reason,
+      allowed_auth_methods: result.allowedAuthMethods,
+    })
+  }
+}

--- a/apps/kaede/src/middleware/request-actor-context.ts
+++ b/apps/kaede/src/middleware/request-actor-context.ts
@@ -25,6 +25,7 @@ export type RequestActor = UserRequestActor | ServiceClientRequestActor
 
 export interface RequestActorVariables {
   requestActor?: RequestActor
+  requestSessionId?: string
 }
 
 export interface RequestActorHonoEnv {
@@ -34,6 +35,7 @@ export interface RequestActorHonoEnv {
 export type RequestActorContext = Context<RequestActorHonoEnv>
 
 const requestActorKey = 'requestActor' satisfies keyof RequestActorVariables
+const requestSessionIdKey = 'requestSessionId' satisfies keyof RequestActorVariables
 
 export const setRequestActor = (c: RequestActorContext, actor: RequestActor) => {
   c.set(requestActorKey, actor)
@@ -41,6 +43,14 @@ export const setRequestActor = (c: RequestActorContext, actor: RequestActor) => 
 
 export const getRequestActor = (c: RequestActorContext): RequestActor | undefined => {
   return c.get(requestActorKey)
+}
+
+export const setRequestSessionId = (c: RequestActorContext, sessionId: string) => {
+  c.set(requestSessionIdKey, sessionId)
+}
+
+export const getRequestSessionId = (c: RequestActorContext): string | undefined => {
+  return c.get(requestSessionIdKey)
 }
 
 export const requireRequestActor = (c: RequestActorContext): RequestActor => {

--- a/apps/kaede/src/middleware/request-actor.ts
+++ b/apps/kaede/src/middleware/request-actor.ts
@@ -8,7 +8,7 @@ import { hasLocalAuthenticationGrantBySessionId } from '../services/organization
 import { findUserById, listUserOrganizationMemberships } from '../services/users/index.js'
 import { deriveAccountState } from '../usecases/authorization.js'
 import type { RequestActorHonoEnv } from './request-actor-context.js'
-import { setRequestActor } from './request-actor-context.js'
+import { setRequestActor, setRequestSessionId } from './request-actor-context.js'
 export type {
   RequestActor,
   RequestActorHonoEnv,
@@ -17,7 +17,13 @@ export type {
   UserActorMembership,
   UserRequestActor,
 } from './request-actor-context.js'
-export { getRequestActor, requireRequestActor, setRequestActor } from './request-actor-context.js'
+export {
+  getRequestActor,
+  getRequestSessionId,
+  requireRequestActor,
+  setRequestActor,
+  setRequestSessionId,
+} from './request-actor-context.js'
 
 type RequestActorContext = Context<RequestActorHonoEnv>
 
@@ -157,6 +163,7 @@ export const requestActorMiddleware = ({
         role: membership.role as 'member' | 'manager' | 'owner',
       })),
     })
+    setRequestSessionId(c, sessionResult.session.id)
 
     await next()
   }

--- a/apps/kaede/src/schemas/auth.ts
+++ b/apps/kaede/src/schemas/auth.ts
@@ -12,6 +12,31 @@ export const authMembershipSchema = z
     organization_id: uuidSchema,
     organization_name: z.string().min(1).max(255),
     role: membershipRoleSchema,
+    grant_state: z
+      .discriminatedUnion('status', [
+        z.object({
+          status: z.literal('granted'),
+          auth_method: z.enum(['local', 'oidc']),
+          authenticated_at: isoDatetimeSchema,
+          expires_at: isoDatetimeSchema,
+        }),
+        z.object({
+          status: z.literal('reauthentication_required'),
+          reason: z.enum([
+            'grant_missing',
+            'grant_revoked',
+            'grant_expired',
+            'reauthentication_interval_elapsed',
+            'policy_changed',
+            'auth_method_not_allowed',
+          ]),
+          allowed_auth_methods: z.array(z.enum(['local', 'oidc'])),
+        }),
+        z.object({
+          status: z.literal('forbidden'),
+        }),
+      ])
+      .optional(),
   })
   .openapi('AuthMembership')
 

--- a/apps/kaede/src/schemas/common.ts
+++ b/apps/kaede/src/schemas/common.ts
@@ -111,6 +111,7 @@ export const authErrorCodes = [
   'AUTH_PASSWORD_LOGIN_DISABLED',
   'AUTH_DASHBOARD_FORBIDDEN',
   'AUTH_ORGANIZATION_FORBIDDEN',
+  'AUTH_MEMBERSHIP_REAUTHENTICATION_REQUIRED',
 ] as const
 
 export const authErrorCodeSchema = z.enum(authErrorCodes).openapi({
@@ -128,6 +129,7 @@ export const authErrorMessages: Record<AuthErrorCode, string> = {
   AUTH_ACTIVATION_TOKEN_INVALID: 'activation token is invalid',
   AUTH_INVALID_CREDENTIALS: 'invalid email or password',
   AUTH_ORGANIZATION_FORBIDDEN: 'organization access forbidden',
+  AUTH_MEMBERSHIP_REAUTHENTICATION_REQUIRED: 'organization membership reauthentication required',
   AUTH_PASSWORD_CHANGE_REQUIRED: 'password change required',
   AUTH_PASSWORD_LOGIN_DISABLED: 'password login is disabled',
   AUTH_SESSION_EXPIRED: 'session expired',
@@ -142,6 +144,7 @@ export const authErrorStatuses: Record<AuthErrorCode, 401 | 403> = {
   AUTH_ACTIVATION_TOKEN_INVALID: 401,
   AUTH_INVALID_CREDENTIALS: 401,
   AUTH_ORGANIZATION_FORBIDDEN: 403,
+  AUTH_MEMBERSHIP_REAUTHENTICATION_REQUIRED: 403,
   AUTH_PASSWORD_CHANGE_REQUIRED: 403,
   AUTH_PASSWORD_LOGIN_DISABLED: 403,
   AUTH_SESSION_EXPIRED: 401,

--- a/apps/kaede/src/server.ts
+++ b/apps/kaede/src/server.ts
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/node'
 import { cors } from 'hono/cors'
 import { HTTPException } from 'hono/http-exception'
 import { getRuntimeConfig } from './config/runtime.js'
+import { organizationAuthorizationMiddleware } from './middleware/organization-authorization.js'
 import { requestActorMiddleware } from './middleware/request-actor.js'
 import { registerApiRoutes } from './routes/index.js'
 import { organizationLocalAuthRoutes } from './routes/organization-local-auth/index.js'
@@ -58,6 +59,10 @@ export const createApp = () => {
       sharedToken: runtimeConfig.app.apiSharedToken,
     })
   )
+
+  const authorizeOrganization = organizationAuthorizationMiddleware()
+  app.use('/api/organizations/:organizationId', authorizeOrganization)
+  app.use('/api/organizations/:organizationId/*', authorizeOrganization)
 
   const healthRoute = createRoute({
     method: 'get',

--- a/apps/kaede/src/services/organization-authorization/authorization.ts
+++ b/apps/kaede/src/services/organization-authorization/authorization.ts
@@ -1,0 +1,116 @@
+import type { MembershipRole } from '../../schemas/common.js'
+import type { MembershipGrantAuthMethod, MembershipGrantContext } from './repository.js'
+
+export type MembershipReauthenticationReason =
+  | 'grant_missing'
+  | 'grant_revoked'
+  | 'grant_expired'
+  | 'reauthentication_interval_elapsed'
+  | 'policy_changed'
+  | 'auth_method_not_allowed'
+
+export type MembershipGrantAuthorization =
+  | {
+      ok: true
+      membershipId: string
+      role: MembershipRole
+      authMethod: MembershipGrantAuthMethod
+      authenticatedAt: Date
+      expiresAt: Date
+    }
+  | { ok: false; type: 'organization_forbidden' }
+  | { ok: false; type: 'role_forbidden'; membershipId: string }
+  | {
+      ok: false
+      type: 'reauthentication_required'
+      membershipId: string
+      reason: MembershipReauthenticationReason
+      allowedAuthMethods: MembershipGrantAuthMethod[]
+    }
+
+const roleRanks = {
+  member: 1,
+  manager: 2,
+  owner: 3,
+} satisfies Record<MembershipRole, number>
+
+const isMembershipRole = (role: string): role is MembershipRole => role in roleRanks
+
+const allowedAuthMethods = (context: MembershipGrantContext): MembershipGrantAuthMethod[] => {
+  const methods: MembershipGrantAuthMethod[] = []
+  if (context.local_auth_enabled) methods.push('local')
+  if (context.oidc_auth_enabled) methods.push('oidc')
+  return methods
+}
+
+export const evaluateMembershipGrant = (
+  context: MembershipGrantContext | undefined,
+  requiredRole: MembershipRole,
+  now: Date
+): MembershipGrantAuthorization => {
+  if (
+    context?.organization_status !== 'active' ||
+    context.membership_status !== 'active' ||
+    context.membership_left_at !== null ||
+    !isMembershipRole(context.membership_role)
+  ) {
+    return { ok: false, type: 'organization_forbidden' }
+  }
+
+  const reauthenticationRequired = (
+    reason: MembershipReauthenticationReason
+  ): MembershipGrantAuthorization => ({
+    ok: false,
+    type: 'reauthentication_required',
+    membershipId: context.membership_id,
+    reason,
+    allowedAuthMethods: allowedAuthMethods(context),
+  })
+
+  if (
+    !context.grant_auth_method ||
+    !context.grant_policy_version ||
+    !context.grant_authenticated_at ||
+    !context.grant_expires_at
+  ) {
+    return reauthenticationRequired('grant_missing')
+  }
+  if (context.grant_revoked_at) return reauthenticationRequired('grant_revoked')
+  if (context.grant_expires_at <= now) return reauthenticationRequired('grant_expired')
+  if (context.grant_policy_version !== context.current_policy_version) {
+    return reauthenticationRequired('policy_changed')
+  }
+
+  const localAllowed =
+    context.grant_auth_method === 'local' &&
+    context.local_auth_enabled &&
+    context.local_credential_enabled === true
+  const oidcAllowed =
+    context.grant_auth_method === 'oidc' &&
+    context.oidc_auth_enabled &&
+    context.oidc_identity_revoked_at === null &&
+    context.oidc_provider_enabled === true
+  if (!localAllowed && !oidcAllowed) {
+    return reauthenticationRequired('auth_method_not_allowed')
+  }
+
+  if (
+    context.grant_authenticated_at.getTime() + context.reauthentication_interval_seconds * 1000 <=
+    now.getTime()
+  ) {
+    return reauthenticationRequired('reauthentication_interval_elapsed')
+  }
+
+  if (roleRanks[context.membership_role] < roleRanks[requiredRole]) {
+    return { ok: false, type: 'role_forbidden', membershipId: context.membership_id }
+  }
+
+  return {
+    ok: true,
+    membershipId: context.membership_id,
+    role: context.membership_role,
+    authMethod: context.grant_auth_method as MembershipGrantAuthMethod,
+    authenticatedAt: context.grant_authenticated_at,
+    expiresAt: context.grant_expires_at,
+  }
+}

--- a/apps/kaede/src/services/organization-authorization/index.ts
+++ b/apps/kaede/src/services/organization-authorization/index.ts
@@ -1,0 +1,7 @@
+export { evaluateMembershipGrant } from './authorization.js'
+export type {
+  MembershipGrantAuthorization,
+  MembershipReauthenticationReason,
+} from './authorization.js'
+export { findMembershipGrantContext, listMembershipGrantContexts } from './repository.js'
+export type { MembershipGrantAuthMethod, MembershipGrantContext } from './repository.js'

--- a/apps/kaede/src/services/organization-authorization/repository.ts
+++ b/apps/kaede/src/services/organization-authorization/repository.ts
@@ -1,0 +1,104 @@
+import { db } from '../db/index.js'
+import type { DbExecutor } from '../executor.js'
+
+export type MembershipGrantAuthMethod = 'local' | 'oidc'
+
+export interface MembershipGrantContext {
+  organization_id: string
+  membership_id: string
+  membership_role: string
+  membership_status: string | null
+  membership_left_at: Date | null
+  organization_status: string | null
+  local_auth_enabled: boolean
+  oidc_auth_enabled: boolean
+  current_policy_version: string
+  reauthentication_interval_seconds: number
+  grant_auth_method: string | null
+  grant_policy_version: string | null
+  grant_authenticated_at: Date | null
+  grant_expires_at: Date | null
+  grant_revoked_at: Date | null
+  local_credential_enabled: boolean | null
+  oidc_identity_revoked_at: Date | null
+  oidc_provider_enabled: boolean | null
+}
+
+const membershipGrantContextQuery = (sessionId: string, userId: string, executor: DbExecutor) =>
+  executor
+    .selectFrom('organization_memberships as membership')
+    .innerJoin('organizations as organization', 'organization.id', 'membership.organization_id')
+    .innerJoin(
+      'organization_auth_settings as auth_settings',
+      'auth_settings.organization_id',
+      'membership.organization_id'
+    )
+    .leftJoin('session_membership_authentications as grant', (join) =>
+      join
+        .onRef('grant.membership_id', '=', 'membership.id')
+        .on('grant.session_id', '=', sessionId)
+        .on('grant.user_id', '=', userId)
+    )
+    .leftJoin('organization_local_credentials as local_credential', (join) =>
+      join
+        .onRef('local_credential.id', '=', 'grant.local_credential_id')
+        .onRef('local_credential.membership_id', '=', 'membership.id')
+    )
+    .leftJoin('organization_member_oidc_identities as oidc_identity', (join) =>
+      join
+        .onRef('oidc_identity.id', '=', 'grant.member_oidc_identity_id')
+        .onRef('oidc_identity.membership_id', '=', 'membership.id')
+    )
+    .leftJoin('organization_oidc_providers as oidc_provider', (join) =>
+      join.onRef('oidc_provider.id', '=', 'oidc_identity.organization_oidc_provider_id')
+    )
+    .select([
+      'membership.organization_id',
+      'membership.id as membership_id',
+      'membership.role as membership_role',
+      'membership.status as membership_status',
+      'membership.left_at as membership_left_at',
+      'organization.status as organization_status',
+      'auth_settings.local_auth_enabled',
+      'auth_settings.oidc_auth_enabled',
+      'auth_settings.policy_version as current_policy_version',
+      'auth_settings.reauthentication_interval_seconds',
+      'grant.auth_method as grant_auth_method',
+      'grant.policy_version as grant_policy_version',
+      'grant.authenticated_at as grant_authenticated_at',
+      'grant.expires_at as grant_expires_at',
+      'grant.revoked_at as grant_revoked_at',
+      'local_credential.enabled as local_credential_enabled',
+      'oidc_identity.revoked_at as oidc_identity_revoked_at',
+      'oidc_provider.enabled as oidc_provider_enabled',
+    ])
+    .where('membership.user_id', '=', userId)
+    .where('membership.status', 'in', ['active', 'suspended'])
+
+export const findMembershipGrantContext = async (
+  sessionId: string,
+  userId: string,
+  organizationId: string,
+  executor: DbExecutor = db
+): Promise<MembershipGrantContext | undefined> => {
+  const context = await membershipGrantContextQuery(sessionId, userId, executor)
+    .where('membership.organization_id', '=', organizationId)
+    .executeTakeFirst()
+
+  if (!context?.membership_id) return undefined
+  return { ...context, membership_id: context.membership_id }
+}
+
+export const listMembershipGrantContexts = async (
+  sessionId: string,
+  userId: string,
+  executor: DbExecutor = db
+): Promise<MembershipGrantContext[]> => {
+  const contexts = await membershipGrantContextQuery(sessionId, userId, executor)
+    .orderBy('organization_id', 'asc')
+    .execute()
+
+  return contexts.filter(
+    (context): context is MembershipGrantContext => context.membership_id !== null
+  )
+}

--- a/apps/kaede/src/usecases/auth/index.ts
+++ b/apps/kaede/src/usecases/auth/index.ts
@@ -29,6 +29,10 @@ import { hashPassword, verifyPassword } from '../../services/auth/password.js'
 import { db } from '../../services/db/index.js'
 import type { DbExecutor } from '../../services/executor.js'
 import {
+  evaluateMembershipGrant,
+  listMembershipGrantContexts,
+} from '../../services/organization-authorization/index.js'
+import {
   findUserByEmail,
   findUserById,
   insertUser,
@@ -170,9 +174,19 @@ const mapActiveSessionError = (
 const buildAuthUserResponse = async (
   user: User,
   sessionAuthMethod: 'password' | 'oidc',
-  executor?: DbExecutor
+  executor?: DbExecutor,
+  grantOptions?: { sessionId: string; now: Date }
 ): Promise<AuthUserResponse> => {
   const memberships = await listUserOrganizationMemberships(user.id, executor)
+  const grantContexts = grantOptions
+    ? await listMembershipGrantContexts(grantOptions.sessionId, user.id, executor)
+    : []
+  const grantsByOrganizationId = new Map(
+    grantContexts.map((context) => [context.organization_id, context])
+  )
+  const currentMemberships = grantOptions
+    ? memberships.filter((membership) => grantsByOrganizationId.has(membership.organization_id))
+    : memberships
 
   return {
     session_auth_method: sessionAuthMethod,
@@ -185,14 +199,38 @@ const buildAuthUserResponse = async (
       account_state: deriveAccountState({
         globalRole: user.global_role as 'none' | 'admin',
         status: user.status as 'pending_activation' | 'active' | 'disabled',
-        membershipCount: memberships.length,
+        membershipCount: currentMemberships.length,
       }),
       password_changed_at: toIsoOrNull(user.password_changed_at),
-      memberships: memberships.map((membership) => ({
-        organization_id: membership.organization_id,
-        organization_name: membership.organization_name,
-        role: membership.role as 'member' | 'manager' | 'owner',
-      })),
+      memberships: currentMemberships.map((membership) => {
+        const context = grantsByOrganizationId.get(membership.organization_id)
+        const authorization = grantOptions
+          ? evaluateMembershipGrant(context, 'member', grantOptions.now)
+          : undefined
+        const grantState = !authorization
+          ? undefined
+          : authorization.ok
+            ? {
+                status: 'granted' as const,
+                auth_method: authorization.authMethod,
+                authenticated_at: authorization.authenticatedAt.toISOString(),
+                expires_at: authorization.expiresAt.toISOString(),
+              }
+            : authorization.type === 'reauthentication_required'
+              ? {
+                  status: 'reauthentication_required' as const,
+                  reason: authorization.reason,
+                  allowed_auth_methods: authorization.allowedAuthMethods,
+                }
+              : { status: 'forbidden' as const }
+
+        return {
+          organization_id: membership.organization_id,
+          organization_name: membership.organization_name,
+          role: membership.role as 'member' | 'manager' | 'owner',
+          ...(grantState ? { grant_state: grantState } : {}),
+        }
+      }),
     },
   }
 }
@@ -635,7 +673,8 @@ export const getMe = async (
     value: await buildAuthUserResponse(
       user,
       sessionResult.session.auth_method as 'password' | 'oidc',
-      executor
+      executor,
+      { sessionId: sessionResult.session.id, now }
     ),
   }
 }

--- a/apps/kaede/tests/services/auth/auth-usecase.test.ts
+++ b/apps/kaede/tests/services/auth/auth-usecase.test.ts
@@ -985,6 +985,108 @@ describe('auth usecase', () => {
     expect(result.value.user.status).toBe('active')
   })
 
+  it('getMe はMembershipごとのgrant stateを返す', async () => {
+    const user = await insertUser()
+    const organization = await db
+      .insertInto('organizations')
+      .values({ name: 'Grant Organization' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const membership = await db
+      .insertInto('organization_memberships')
+      .values({ organization_id: organization.id, user_id: user.id, role: 'member' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    if (!membership.id) throw new Error('membership id is required')
+    await db
+      .insertInto('organization_auth_settings')
+      .values({
+        organization_id: organization.id,
+        local_auth_enabled: true,
+        oidc_auth_enabled: false,
+        policy_version: 2,
+        membership_grant_ttl_seconds: 7200,
+        reauthentication_interval_seconds: 3600,
+      })
+      .execute()
+    const credential = await db
+      .insertInto('organization_local_credentials')
+      .values({
+        membership_id: membership.id,
+        organization_id: organization.id,
+        login_email: 'grant-user@example.com',
+        normalized_login_email: 'grant-user@example.com',
+        password_hash: await hashPassword('organization-password'),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const { session, token } = await createSession(
+      { userId: user.id, now: new Date('2026-08-11T10:00:00.000Z') },
+      db
+    )
+    await db
+      .insertInto('session_membership_authentications')
+      .values({
+        session_id: session.id,
+        membership_id: membership.id,
+        user_id: user.id,
+        auth_method: 'local',
+        policy_version: 2,
+        local_credential_id: credential.id,
+        authenticated_at: new Date('2026-08-11T11:00:00.000Z'),
+        expires_at: new Date('2026-08-11T13:00:00.000Z'),
+      })
+      .execute()
+    const secondOrganization = await db
+      .insertInto('organizations')
+      .values({ name: 'Missing Grant Organization' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    await db
+      .insertInto('organization_memberships')
+      .values({ organization_id: secondOrganization.id, user_id: user.id, role: 'manager' })
+      .execute()
+    await db
+      .insertInto('organization_auth_settings')
+      .values({
+        organization_id: secondOrganization.id,
+        local_auth_enabled: true,
+        oidc_auth_enabled: false,
+        membership_grant_ttl_seconds: 7200,
+        reauthentication_interval_seconds: 3600,
+      })
+      .execute()
+
+    const result = await getMe(token, new Date('2026-08-11T11:30:00.000Z'), db)
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        user: {
+          memberships: [
+            {
+              organization_id: organization.id,
+              grant_state: {
+                status: 'granted',
+                auth_method: 'local',
+                authenticated_at: '2026-08-11T11:00:00.000Z',
+                expires_at: '2026-08-11T13:00:00.000Z',
+              },
+            },
+            {
+              organization_id: secondOrganization.id,
+              grant_state: {
+                status: 'reauthentication_required',
+                reason: 'grant_missing',
+                allowed_auth_methods: ['local'],
+              },
+            },
+          ],
+        },
+      },
+    })
+  })
+
   it('verifyActivationToken は valid token の表示情報を返し token を consume しない', async () => {
     const { activationToken, organization, token, user } = await insertActivationToken()
 

--- a/apps/kaede/tests/services/organization-authorization/repository.test.ts
+++ b/apps/kaede/tests/services/organization-authorization/repository.test.ts
@@ -1,0 +1,99 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { createDb } from '../../../src/services/db/client.js'
+import {
+  findMembershipGrantContext,
+  listMembershipGrantContexts,
+} from '../../../src/services/organization-authorization/index.js'
+import { resetDatabase } from '../../db/helpers.js'
+
+const db = createDb()
+const passwordHash =
+  '$argon2id$v=19$m=65536,t=3,p=4$ZHVtbXk$zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'
+
+describe('organization authorization repository', () => {
+  beforeEach(async () => {
+    await resetDatabase(db)
+  })
+
+  afterAll(async () => {
+    await db.destroy()
+  })
+
+  it('left Membershipを除外し、再参加後のcurrent active Membershipだけを返す', async () => {
+    const user = await db
+      .insertInto('users')
+      .values({
+        email: 'grant-current@example.com',
+        display_name: 'Grant Current',
+        password_hash: passwordHash,
+        global_role: 'none',
+        status: 'active',
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const [leftOrganization, activeOrganization] = await db
+      .insertInto('organizations')
+      .values([{ name: 'Left Organization' }, { name: 'Active Organization' }])
+      .returningAll()
+      .execute()
+    const [leftMembership, activeMembership] = await db
+      .insertInto('organization_memberships')
+      .values([
+        {
+          organization_id: leftOrganization.id,
+          user_id: user.id,
+          role: 'member',
+          status: 'left',
+          left_at: new Date('2026-08-10T00:00:00.000Z'),
+        },
+        {
+          organization_id: activeOrganization.id,
+          user_id: user.id,
+          role: 'manager',
+          status: 'active',
+        },
+      ])
+      .returningAll()
+      .execute()
+    await db
+      .insertInto('organization_auth_settings')
+      .values([
+        {
+          organization_id: leftOrganization.id,
+          local_auth_enabled: true,
+          oidc_auth_enabled: false,
+          membership_grant_ttl_seconds: 7200,
+          reauthentication_interval_seconds: 3600,
+        },
+        {
+          organization_id: activeOrganization.id,
+          local_auth_enabled: true,
+          oidc_auth_enabled: false,
+          membership_grant_ttl_seconds: 7200,
+          reauthentication_interval_seconds: 3600,
+        },
+      ])
+      .execute()
+    const session = await db
+      .insertInto('sessions')
+      .values({
+        user_id: user.id,
+        session_hash: 'current-membership-session',
+        expires_at: new Date('2026-08-13T00:00:00.000Z'),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    await expect(
+      findMembershipGrantContext(session.id, user.id, leftOrganization.id, db)
+    ).resolves.toBeUndefined()
+    const contexts = await listMembershipGrantContexts(session.id, user.id, db)
+    expect(contexts).toHaveLength(1)
+    expect(contexts[0]).toMatchObject({
+      organization_id: activeOrganization.id,
+      membership_id: activeMembership.id,
+      membership_status: 'active',
+    })
+    expect(contexts[0]?.membership_id).not.toBe(leftMembership.id)
+  })
+})


### PR DESCRIPTION
Closes #219

## What changed

- Add an organization-scoped authorization guard after global session authentication.
- Require a current active Membership belonging to the global session user.
- Validate the per-session Membership grant is present, active, unexpired, within the reauthentication interval, and on the current organization policy version.
- Validate the grant Local/OIDC source and organization auth method are still enabled before applying role authorization.
- Return a stable `AUTH_MEMBERSHIP_REAUTHENTICATION_REQUIRED` 403 response with organization, Membership, reason, and allowed auth-method metadata for Mio.
- Expose per-Membership `grant_state` from `GET /api/auth/me`.
- Keep grant failure organization-local: no global logout and no revocation of grants for other organizations.
- Fetch all Membership grant contexts for `/api/auth/me` with one shared base query to avoid N+1 queries.

## Validation

- `eslint .`
- `tsc --noEmit`
- Unit tests: 84 files / 473 tests passed
- Target DB tests: 2 files / 31 tests passed
- Full DB regression before the final query refactor: 29 files / 233 tests passed
- Pre-commit Kaede format, lint, and typecheck passed