### PR TITLE
身長・歩幅の単位をメートルへ統一

### DIFF
--- a/apps/kaede/src/routes/pedestrians/create-pedestrian.test.ts
+++ b/apps/kaede/src/routes/pedestrians/create-pedestrian.test.ts
@@ -233,6 +233,24 @@ describe('POST /api/pedestrians', () => {
     expect(createPedestrianMock).not.toHaveBeenCalled()
   })
 
+  it('meterではない height はバリデーションエラーを返し usecase を呼ばない', async () => {
+    const app = createRouteTestApp('/pedestrians', registerCreatePedestrianRoute)
+    const response = await app.request('/api/pedestrians', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        organization_id: '99999999-9999-4999-8999-999999999999',
+        display_name: 'test participant',
+        height: 170,
+      }),
+    })
+
+    expect(response.status).toBe(400)
+    expect(createPedestrianMock).not.toHaveBeenCalled()
+  })
+
   it('organization_id がない場合はバリデーションエラーを返し usecase を呼ばない', async () => {
     const app = createRouteTestApp('/pedestrians', registerCreatePedestrianRoute)
     const response = await app.request('/api/pedestrians', {

--- a/apps/kaede/src/schemas/pedestrians.ts
+++ b/apps/kaede/src/schemas/pedestrians.ts
@@ -23,10 +23,10 @@ export const pedestrianSchema = z
       description: 'pedestrian を画面上で識別する表示名',
     }),
     height: z.number().nullable().openapi({
-      description: '身長。未設定の場合は null',
+      description: '身長（メートル）。未設定の場合は null',
     }),
     stride_length: z.number().nullable().openapi({
-      description: '歩幅。未設定の場合は null',
+      description: '歩幅（メートル）。未設定の場合は null',
     }),
     attributes: jsonObjectSchema.openapi({
       description: 'pedestrian に紐づく任意属性',
@@ -53,11 +53,11 @@ export const createPedestrianWithoutOrganizationRequestSchema = z
     display_name: z.string().min(1).openapi({
       description: 'pedestrian を画面上で識別する表示名',
     }),
-    height: z.number().positive().nullable().optional().openapi({
-      description: '身長。未設定の場合は null',
+    height: z.number().positive().max(3).nullable().optional().openapi({
+      description: '身長（メートル）。未設定の場合は null',
     }),
-    stride_length: z.number().positive().nullable().optional().openapi({
-      description: '歩幅。未設定の場合は null',
+    stride_length: z.number().positive().max(3).nullable().optional().openapi({
+      description: '歩幅（メートル）。未設定の場合は null',
     }),
     attributes: jsonObjectSchema.optional().openapi({
       description: 'pedestrian に紐づく任意属性',

--- a/apps/kaede/src/services/migrations/multi-org-auth-backfill.ts
+++ b/apps/kaede/src/services/migrations/multi-org-auth-backfill.ts
@@ -23,8 +23,7 @@ export interface PreflightReport {
 }
 
 export interface MeasurementClassification {
-  already_m: number
-  converted_cm: number
+  valid_meters: number
   invalid: number
 }
 
@@ -33,8 +32,7 @@ export interface BackfillResult {
   contact_emails: number
   invite_creators: number
   local_credentials: number
-  measurement_values_already_m: number
-  measurement_values_converted_cm: number
+  measurement_values_copied_meters: number
   memberships: number
   member_profiles: number
   oidc_identities: number
@@ -49,8 +47,7 @@ const emptyResult = (): BackfillResult => ({
   contact_emails: 0,
   invite_creators: 0,
   local_credentials: 0,
-  measurement_values_already_m: 0,
-  measurement_values_converted_cm: 0,
+  measurement_values_copied_meters: 0,
   memberships: 0,
   member_profiles: 0,
   oidc_identities: 0,
@@ -196,8 +193,7 @@ export const getMultiOrgAuthPreflightReport = async (
         {
           blocking: true,
           code: 'PEDESTRIAN_MEASUREMENT_OUT_OF_RANGE',
-          description:
-            'Legacy measurements must be greater than 0 and at most 300 before meter normalization.',
+          description: 'Legacy measurements must be in meters, greater than 0, and at most 3.',
           scope: 'measurements',
         },
         sql<{ sample: string }>`
@@ -205,20 +201,16 @@ export const getMultiOrgAuthPreflightReport = async (
         FROM pedestrians AS p
         WHERE p.height IS NOT NULL
           AND (
-            NOT (p.height > 0 AND p.height <= 300)
-            OR round((CASE WHEN p.height <= 3 THEN p.height ELSE p.height / 100 END)::numeric, 3)
-              <= 0
+            NOT (p.height > 0 AND p.height <= 3)
+            OR round(p.height::numeric, 3) <= 0
           )
         UNION ALL
         SELECT p.id::text || ':stride_length=' || p.stride_length::text AS sample
         FROM pedestrians AS p
         WHERE p.stride_length IS NOT NULL
           AND (
-            NOT (p.stride_length > 0 AND p.stride_length <= 300)
-            OR round((CASE
-                WHEN p.stride_length <= 3 THEN p.stride_length
-                ELSE p.stride_length / 100
-              END)::numeric, 3) <= 0
+            NOT (p.stride_length > 0 AND p.stride_length <= 3)
+            OR round(p.stride_length::numeric, 3) <= 0
           )
       `
       ),
@@ -284,34 +276,20 @@ export const getMultiOrgAuthPreflightReport = async (
                 AND stride_length <= 3
                 AND round(stride_length::numeric, 3) > 0
             )
-        )::integer AS already_m,
-        (
-          count(*) FILTER (
-              WHERE height > 3 AND height <= 300 AND round((height / 100)::numeric, 3) > 0
-            )
-          + count(*) FILTER (
-              WHERE stride_length > 3
-                AND stride_length <= 300
-                AND round((stride_length / 100)::numeric, 3) > 0
-            )
-        )::integer AS converted_cm,
+        )::integer AS valid_meters,
         (
           count(*) FILTER (
               WHERE height IS NOT NULL
                 AND (
-                  NOT (height > 0 AND height <= 300)
-                  OR round((CASE WHEN height <= 3 THEN height ELSE height / 100 END)::numeric, 3)
-                    <= 0
+                  NOT (height > 0 AND height <= 3)
+                  OR round(height::numeric, 3) <= 0
                 )
             )
           + count(*) FILTER (
               WHERE stride_length IS NOT NULL
                 AND (
-                  NOT (stride_length > 0 AND stride_length <= 300)
-                  OR round((CASE
-                      WHEN stride_length <= 3 THEN stride_length
-                      ELSE stride_length / 100
-                    END)::numeric, 3) <= 0
+                  NOT (stride_length > 0 AND stride_length <= 3)
+                  OR round(stride_length::numeric, 3) <= 0
                 )
             )
         )::integer AS invalid
@@ -323,7 +301,7 @@ export const getMultiOrgAuthPreflightReport = async (
   return {
     blocking: issues.some((issue) => issue.blocking),
     issues,
-    measurements: measurementRows.rows[0] ?? { already_m: 0, converted_cm: 0, invalid: 0 },
+    measurements: measurementRows.rows[0] ?? { valid_meters: 0, invalid: 0 },
   }
 }
 
@@ -466,10 +444,8 @@ export const backfillMultiOrgAuthCore = async (
 
   for (;;) {
     const rows = await sql<{
-      height_already_m: boolean
-      height_converted_cm: boolean
-      stride_already_m: boolean
-      stride_converted_cm: boolean
+      height_copied_meters: boolean
+      stride_copied_meters: boolean
     }>`
       WITH target AS (
         SELECT
@@ -494,30 +470,24 @@ export const backfillMultiOrgAuthCore = async (
         height_meters = CASE
           WHEN profile.height_meters IS NOT NULL OR target.height IS NULL
             THEN profile.height_meters
-          WHEN target.height <= 3 THEN round(target.height::numeric, 3)
-          ELSE round((target.height / 100)::numeric, 3)
+          ELSE round(target.height::numeric, 3)
         END,
         stride_length_meters = CASE
           WHEN profile.stride_length_meters IS NOT NULL OR target.stride_length IS NULL
             THEN profile.stride_length_meters
-          WHEN target.stride_length <= 3 THEN round(target.stride_length::numeric, 3)
-          ELSE round((target.stride_length / 100)::numeric, 3)
+          ELSE round(target.stride_length::numeric, 3)
         END
       FROM target
       WHERE profile.membership_id = target.membership_id
       RETURNING
-        target.height_needs_backfill AND target.height <= 3 AS height_already_m,
-        target.height_needs_backfill AND target.height > 3 AS height_converted_cm,
-        target.stride_needs_backfill AND target.stride_length <= 3 AS stride_already_m,
-        target.stride_needs_backfill AND target.stride_length > 3 AS stride_converted_cm
+        target.height_needs_backfill AS height_copied_meters,
+        target.stride_needs_backfill AS stride_copied_meters
     `.execute(executor)
 
     if (rows.rows.length === 0) break
     for (const row of rows.rows) {
-      if (row.height_already_m) result.measurement_values_already_m += 1
-      if (row.height_converted_cm) result.measurement_values_converted_cm += 1
-      if (row.stride_already_m) result.measurement_values_already_m += 1
-      if (row.stride_converted_cm) result.measurement_values_converted_cm += 1
+      if (row.height_copied_meters) result.measurement_values_copied_meters += 1
+      if (row.stride_copied_meters) result.measurement_values_copied_meters += 1
     }
   }
 
@@ -759,8 +729,16 @@ export const validateMultiOrgAuthExpandConstraints = async (
       VALIDATE CONSTRAINT organization_memberships_status_chk;
     ALTER TABLE organization_memberships
       VALIDATE CONSTRAINT organization_memberships_left_at_chk;
+    ALTER TABLE organization_member_profiles
+      VALIDATE CONSTRAINT organization_member_profiles_height_meter_bounds_chk;
+    ALTER TABLE organization_member_profiles
+      VALIDATE CONSTRAINT organization_member_profiles_stride_meter_bounds_chk;
     ALTER TABLE pedestrians
       VALIDATE CONSTRAINT pedestrians_membership_organization_fkey;
+    ALTER TABLE pedestrians
+      VALIDATE CONSTRAINT pedestrians_height_meter_bounds_chk;
+    ALTER TABLE pedestrians
+      VALIDATE CONSTRAINT pedestrians_stride_meter_bounds_chk;
     ALTER TABLE organization_invites
       VALIDATE CONSTRAINT organization_invites_creator_org_fkey;
     ALTER TABLE organization_invites

--- a/apps/kaede/tests/services/db/multi-org-auth-backfill.test.ts
+++ b/apps/kaede/tests/services/db/multi-org-auth-backfill.test.ts
@@ -14,6 +14,25 @@ import { resetDatabase } from '../../db/helpers.js'
 const db = createDb()
 const passwordHash = '$argon2id$v=19$m=65536,t=3,p=4$ZHVtbXk$legacy-password-hash'
 
+const withLegacyMeasurementConstraintsDisabled = async (insertRows: () => Promise<void>) => {
+  await sql`
+    ALTER TABLE pedestrians
+      DROP CONSTRAINT pedestrians_height_meter_bounds_chk,
+      DROP CONSTRAINT pedestrians_stride_meter_bounds_chk
+  `.execute(db)
+  try {
+    await insertRows()
+  } finally {
+    await sql`
+      ALTER TABLE pedestrians
+        ADD CONSTRAINT pedestrians_height_meter_bounds_chk
+          CHECK (height IS NULL OR (height > 0 AND height <= 3)) NOT VALID,
+        ADD CONSTRAINT pedestrians_stride_meter_bounds_chk
+          CHECK (stride_length IS NULL OR (stride_length > 0 AND stride_length <= 3)) NOT VALID
+    `.execute(db)
+  }
+}
+
 const createLegacyUserAndMembership = async (suffix: string) => {
   const user = await db
     .insertInto('users')
@@ -111,13 +130,13 @@ describe('multi organization auth backfill', () => {
     expect(memberProfile.stride_length_meters).toBeNull()
   })
 
-  it('normalizes meter and centimeter measurements and reports their classifications', async () => {
+  it('copies meter measurements without guessing another unit', async () => {
     const { organization, user } = await createLegacyUserAndMembership('measurements')
     await db
       .insertInto('pedestrians')
       .values({
         display_name: 'Measured User',
-        height: 170,
+        height: 1.7,
         organization_id: organization.id,
         stride_length: 0.7,
         user_id: user.id,
@@ -125,7 +144,7 @@ describe('multi organization auth backfill', () => {
       .execute()
 
     const report = await getMultiOrgAuthPreflightReport(db)
-    expect(report.measurements).toEqual({ already_m: 1, converted_cm: 1, invalid: 0 })
+    expect(report.measurements).toEqual({ valid_meters: 2, invalid: 0 })
 
     const result = await backfillMultiOrgAuthCore(10, db)
     const profile = await db
@@ -133,22 +152,23 @@ describe('multi organization auth backfill', () => {
       .select(['height_meters', 'stride_length_meters'])
       .executeTakeFirstOrThrow()
     expect(profile).toEqual({ height_meters: '1.700', stride_length_meters: '0.700' })
-    expect(result.measurement_values_already_m).toBe(1)
-    expect(result.measurement_values_converted_cm).toBe(1)
+    expect(result.measurement_values_copied_meters).toBe(2)
   })
 
   it('blocks values that cannot be represented safely after normalization', async () => {
     const { organization, user } = await createLegacyUserAndMembership('invalid-measurement')
-    await db
-      .insertInto('pedestrians')
-      .values({
-        display_name: 'Invalid Measurement',
-        height: 0.0001,
-        organization_id: organization.id,
-        stride_length: 301,
-        user_id: user.id,
-      })
-      .execute()
+    await withLegacyMeasurementConstraintsDisabled(async () => {
+      await db
+        .insertInto('pedestrians')
+        .values({
+          display_name: 'Invalid Measurement',
+          height: 170,
+          organization_id: organization.id,
+          stride_length: 70,
+          user_id: user.id,
+        })
+        .execute()
+    })
 
     const report = await getMultiOrgAuthPreflightReport(db)
     expect(report.measurements.invalid).toBe(2)
@@ -159,16 +179,18 @@ describe('multi organization auth backfill', () => {
 
   it('returns an exact issue count with at most twenty samples', async () => {
     const { organization } = await createLegacyUserAndMembership('bounded-samples')
-    await db
-      .insertInto('pedestrians')
-      .values(
-        Array.from({ length: 25 }, (_, index) => ({
-          display_name: `Invalid ${index}`,
-          height: 301,
-          organization_id: organization.id,
-        }))
-      )
-      .execute()
+    await withLegacyMeasurementConstraintsDisabled(async () => {
+      await db
+        .insertInto('pedestrians')
+        .values(
+          Array.from({ length: 25 }, (_, index) => ({
+            display_name: `Invalid ${index}`,
+            height: 301,
+            organization_id: organization.id,
+          }))
+        )
+        .execute()
+    })
 
     const report = await getMultiOrgAuthPreflightReport(db)
     const issue = report.issues.find(

--- a/db/migrations/20260812010000_enforce_meter_measurement_bounds.sql
+++ b/db/migrations/20260812010000_enforce_meter_measurement_bounds.sql
@@ -1,0 +1,23 @@
+-- migrate:up
+
+ALTER TABLE organization_member_profiles
+  ADD CONSTRAINT organization_member_profiles_height_meter_bounds_chk
+  CHECK (height_meters IS NULL OR height_meters <= 3) NOT VALID,
+  ADD CONSTRAINT organization_member_profiles_stride_meter_bounds_chk
+  CHECK (stride_length_meters IS NULL OR stride_length_meters <= 3) NOT VALID;
+
+ALTER TABLE pedestrians
+  ADD CONSTRAINT pedestrians_height_meter_bounds_chk
+  CHECK (height IS NULL OR (height > 0 AND height <= 3)) NOT VALID,
+  ADD CONSTRAINT pedestrians_stride_meter_bounds_chk
+  CHECK (stride_length IS NULL OR (stride_length > 0 AND stride_length <= 3)) NOT VALID;
+
+-- migrate:down
+
+ALTER TABLE pedestrians
+  DROP CONSTRAINT pedestrians_stride_meter_bounds_chk,
+  DROP CONSTRAINT pedestrians_height_meter_bounds_chk;
+
+ALTER TABLE organization_member_profiles
+  DROP CONSTRAINT organization_member_profiles_stride_meter_bounds_chk,
+  DROP CONSTRAINT organization_member_profiles_height_meter_bounds_chk;

--- a/db/multi-organization-auth-backfill.md
+++ b/db/multi-organization-auth-backfill.md
@@ -13,17 +13,18 @@
 
 ## 測定値の正規化
 
-`pedestrians.height` と `pedestrians.stride_length` は次の規則でmeterへ統一する。
+`pedestrians.height` と `pedestrians.stride_length` は現行APIと同じくmeterとして扱う。
+値の大きさからcentimeterと推測して自動変換しない。
 
-| 既存値                      | 判定       | 保存値                             |
-| --------------------------- | ---------- | ---------------------------------- |
-| `NULL`                      | 未設定     | `NULL`                             |
-| `0 < value <= 3`            | 既にmeter  | 小数第3位へ丸める                  |
-| `3 < value <= 300`          | centimeter | `value / 100`後、小数第3位へ丸める |
-| 上記以外、または丸め後に`0` | 不正       | blocking issue。自動修正しない     |
+| 既存値                      | 判定             | 保存値                         |
+| --------------------------- | ---------------- | ------------------------------ |
+| `NULL`                      | 未設定           | `NULL`                         |
+| `0 < value <= 3`            | meter            | 小数第3位へ丸める              |
+| `value > 3`                 | 単位不一致の疑い | blocking issue。自動変換しない |
+| 上記以外、または丸め後に`0` | 不正             | blocking issue。自動修正しない |
 
-`preflight` は `already_m / converted_cm / invalid` の値数を返す。`backfill-core`も実際に書き込んだ
-`measurement_values_already_m / measurement_values_converted_cm`を返す。
+`preflight` は `valid_meters / invalid` の値数を返す。`backfill-core`も実際に書き込んだ
+`measurement_values_copied_meters`を返す。
 
 ## 実行コマンド
 
@@ -41,7 +42,7 @@ pnpm multi-org-auth-backfill verify
 - Membership UUID/status/joined_at（`joined_at`は旧Membershipの`created_at`を使用）
 - User contact emailと共通Profile
 - PedestrianとMembershipの関連
-- Organization member profile（表示名override、meterへ正規化した身長・歩幅）
+- Organization member profile（表示名override、meterの身長・歩幅）
 - Invite creator Membership
 
 ## 認証設定とCredential移行

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -832,11 +832,27 @@ ALTER TABLE ONLY public.organization_member_oidc_identities
 
 
 --
+-- Name: organization_member_profiles organization_member_profiles_height_meter_bounds_chk; Type: CHECK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE public.organization_member_profiles
+    ADD CONSTRAINT organization_member_profiles_height_meter_bounds_chk CHECK (((height_meters IS NULL) OR (height_meters <= (3)::numeric))) NOT VALID;
+
+
+--
 -- Name: organization_member_profiles organization_member_profiles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.organization_member_profiles
     ADD CONSTRAINT organization_member_profiles_pkey PRIMARY KEY (membership_id);
+
+
+--
+-- Name: organization_member_profiles organization_member_profiles_stride_meter_bounds_chk; Type: CHECK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE public.organization_member_profiles
+    ADD CONSTRAINT organization_member_profiles_stride_meter_bounds_chk CHECK (((stride_length_meters IS NULL) OR (stride_length_meters <= (3)::numeric))) NOT VALID;
 
 
 --
@@ -912,11 +928,27 @@ ALTER TABLE public.organizations
 
 
 --
+-- Name: pedestrians pedestrians_height_meter_bounds_chk; Type: CHECK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE public.pedestrians
+    ADD CONSTRAINT pedestrians_height_meter_bounds_chk CHECK (((height IS NULL) OR ((height > (0)::double precision) AND (height <= (3)::double precision)))) NOT VALID;
+
+
+--
 -- Name: pedestrians pedestrians_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.pedestrians
     ADD CONSTRAINT pedestrians_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: pedestrians pedestrians_stride_meter_bounds_chk; Type: CHECK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE public.pedestrians
+    ADD CONSTRAINT pedestrians_stride_meter_bounds_chk CHECK (((stride_length IS NULL) OR ((stride_length > (0)::double precision) AND (stride_length <= (3)::double precision)))) NOT VALID;
 
 
 --
@@ -2024,4 +2056,5 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20260811010500'),
     ('20260811010551'),
     ('20260811010552'),
-    ('20260811010553');
+    ('20260811010553'),
+    ('20260812010000');


### PR DESCRIPTION
Closes #219

## 変更内容
- legacy Pedestrian APIの身長・歩幅をmeterと明記し、0より大きく3以下へ制限
- Profile/Pedestrianのmeter上限制約をDBへ追加
- backfillのcm推測変換を廃止し、meter以外はpreflightで停止
- 運用者が入力元を確認して明示的に補正する手順へRunbookを更新

## 確認
- Kaede unit: 461 passed
- Kaede DB: 231 passed
- ESLint / TypeScript: passed
- migration up/down/up: passed