### PR TITLE
Membershipの再参加ライフサイクルを実装

### DIFF
--- a/apps/kaede/src/services/db/generated.ts
+++ b/apps/kaede/src/services/db/generated.ts
@@ -235,12 +235,12 @@ export interface OrganizationMemberProfiles {
 
 export interface OrganizationMemberships {
   created_at: Generated<Timestamp>
-  id: Generated<string | null>
-  joined_at: Generated<Timestamp | null>
+  id: Generated<string>
+  joined_at: Generated<Timestamp>
   left_at: Timestamp | null
   organization_id: string
   role: string
-  status: Generated<string | null>
+  status: Generated<string>
   updated_at: Generated<Timestamp>
   user_id: string
 }

--- a/apps/kaede/src/services/organization-authorization/repository.ts
+++ b/apps/kaede/src/services/organization-authorization/repository.ts
@@ -7,7 +7,7 @@ export interface MembershipGrantContext {
   organization_id: string
   membership_id: string
   membership_role: string
-  membership_status: string | null
+  membership_status: string
   membership_left_at: Date | null
   organization_status: string | null
   local_auth_enabled: boolean
@@ -85,8 +85,7 @@ export const findMembershipGrantContext = async (
     .where('membership.organization_id', '=', organizationId)
     .executeTakeFirst()
 
-  if (!context?.membership_id) return undefined
-  return { ...context, membership_id: context.membership_id }
+  return context
 }
 
 export const listMembershipGrantContexts = async (
@@ -98,7 +97,5 @@ export const listMembershipGrantContexts = async (
     .orderBy('organization_id', 'asc')
     .execute()
 
-  return contexts.filter(
-    (context): context is MembershipGrantContext => context.membership_id !== null
-  )
+  return contexts
 }

--- a/apps/kaede/src/services/users/user-repository.ts
+++ b/apps/kaede/src/services/users/user-repository.ts
@@ -69,6 +69,7 @@ export const findOrganizationMembership = async (
     .selectAll()
     .where('organization_id', '=', organizationId)
     .where('user_id', '=', userId)
+    .where('status', '=', 'active')
     .executeTakeFirst()
 }
 
@@ -91,9 +92,12 @@ export const upsertOrganizationMembership = async (
     .insertInto('organization_memberships')
     .values(membership)
     .onConflict((oc) =>
-      oc.columns(['organization_id', 'user_id']).doUpdateSet({
-        role: membership.role,
-      })
+      oc
+        .columns(['organization_id', 'user_id'])
+        .where('status', 'in', ['active', 'suspended'])
+        .doUpdateSet({
+          role: membership.role,
+        })
     )
     .returningAll()
     .executeTakeFirstOrThrow()
@@ -122,6 +126,7 @@ const organizationUsersQuery = (executor: DbExecutor) =>
       'pedestrian.created_at as pedestrian_created_at',
       'pedestrian.updated_at as pedestrian_updated_at',
     ])
+    .where('membership.status', 'in', ['active', 'suspended'])
 
 export const listOrganizationUsers = async (
   organizationId: string,
@@ -158,6 +163,7 @@ export const listUserOrganizationMemberships = async (
       'membership.role as role',
     ])
     .where('membership.user_id', '=', userId)
+    .where('membership.status', 'in', ['active', 'suspended'])
     .orderBy('organization.name', 'asc')
     .execute()
 }

--- a/apps/kaede/tests/services/db/membership-lifecycle.test.ts
+++ b/apps/kaede/tests/services/db/membership-lifecycle.test.ts
@@ -1,0 +1,131 @@
+import { sql } from 'kysely'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { createDb } from '../../../src/services/db/client.js'
+import {
+  findOrganizationMembership,
+  upsertOrganizationMembership,
+} from '../../../src/services/users/index.js'
+import { resetDatabase } from '../../db/helpers.js'
+
+const db = createDb()
+
+const createUserAndOrganization = async () => {
+  const user = await db
+    .insertInto('users')
+    .values({
+      email: 'membership-lifecycle@example.test',
+      display_name: 'Membership Lifecycle',
+      global_role: 'none',
+      status: 'active',
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const organization = await db
+    .insertInto('organizations')
+    .values({ name: 'Membership Lifecycle Organization' })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+  return { organization, user }
+}
+
+describe('membership lifecycle', () => {
+  beforeEach(async () => {
+    await resetDatabase(db)
+  })
+
+  afterAll(async () => {
+    await db.destroy()
+  })
+
+  it('UUIDをprimary keyとし、current MembershipだけをUserとOrganizationごとに一意にする', async () => {
+    const primaryKeyColumns = await sql<{ column_name: string }>`
+      SELECT attribute.attname AS column_name
+      FROM pg_constraint AS con
+      JOIN pg_class AS relation ON relation.oid = con.conrelid
+      JOIN unnest(con.conkey) WITH ORDINALITY AS key(attnum, position) ON true
+      JOIN pg_attribute AS attribute
+        ON attribute.attrelid = relation.oid
+       AND attribute.attnum = key.attnum
+      WHERE relation.relname = 'organization_memberships'
+        AND con.contype = 'p'
+      ORDER BY key.position
+    `.execute(db)
+
+    expect(primaryKeyColumns.rows.map((row) => row.column_name)).toEqual(['id'])
+
+    const index = await sql<{ predicate: string | null }>`
+      SELECT pg_get_expr(idx.indpred, idx.indrelid) AS predicate
+      FROM pg_index AS idx
+      JOIN pg_class AS relation ON relation.oid = idx.indexrelid
+      WHERE relation.relname = 'organization_memberships_current_user_org_key'
+    `.execute(db)
+
+    expect(index.rows[0]?.predicate).toContain('status = ANY')
+  })
+
+  it('left後の再参加では新しいMembershipを作成する', async () => {
+    const { organization, user } = await createUserAndOrganization()
+    const leftMembership = await db
+      .insertInto('organization_memberships')
+      .values({
+        organization_id: organization.id,
+        user_id: user.id,
+        role: 'member',
+        status: 'left',
+        left_at: new Date('2026-08-10T00:00:00.000Z'),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    const currentMembership = await upsertOrganizationMembership(
+      {
+        organization_id: organization.id,
+        user_id: user.id,
+        role: 'manager',
+        status: 'active',
+      },
+      db
+    )
+
+    expect(currentMembership.id).not.toBe(leftMembership.id)
+    await expect(findOrganizationMembership(organization.id, user.id, db)).resolves.toMatchObject({
+      id: currentMembership.id,
+      role: 'manager',
+      status: 'active',
+    })
+    await expect(
+      db
+        .selectFrom('organization_memberships')
+        .selectAll()
+        .where('organization_id', '=', organization.id)
+        .where('user_id', '=', user.id)
+        .execute()
+    ).resolves.toHaveLength(2)
+  })
+
+  it('current Membershipがある場合は新規行を作らずroleを更新する', async () => {
+    const { organization, user } = await createUserAndOrganization()
+    const original = await upsertOrganizationMembership(
+      {
+        organization_id: organization.id,
+        user_id: user.id,
+        role: 'member',
+        status: 'active',
+      },
+      db
+    )
+    const updated = await upsertOrganizationMembership(
+      {
+        organization_id: organization.id,
+        user_id: user.id,
+        role: 'manager',
+        status: 'active',
+      },
+      db
+    )
+
+    expect(updated.id).toBe(original.id)
+    expect(updated.role).toBe('manager')
+  })
+})

--- a/apps/kaede/tests/services/db/multi-org-auth-backfill.test.ts
+++ b/apps/kaede/tests/services/db/multi-org-auth-backfill.test.ts
@@ -1,5 +1,5 @@
 import { sql } from 'kysely'
-import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { createDb } from '../../../src/services/db/client.js'
 import {
   backfillMultiOrgAuthCore,
@@ -13,6 +13,45 @@ import { resetDatabase } from '../../db/helpers.js'
 
 const db = createDb()
 const passwordHash = '$argon2id$v=19$m=65536,t=3,p=4$ZHVtbXk$legacy-password-hash'
+
+const usePrePromotionMembershipSchema = async () => {
+  await sql`
+    ALTER TABLE organization_member_profiles
+      DROP CONSTRAINT organization_member_profiles_membership_id_fkey;
+    ALTER TABLE organization_memberships
+      DROP CONSTRAINT organization_memberships_pkey;
+    ALTER TABLE organization_memberships
+      ADD CONSTRAINT organization_memberships_pkey PRIMARY KEY (organization_id, user_id);
+    CREATE UNIQUE INDEX organization_memberships_id_key
+      ON organization_memberships (id);
+    ALTER TABLE organization_member_profiles
+      ADD CONSTRAINT organization_member_profiles_membership_id_fkey
+      FOREIGN KEY (membership_id)
+      REFERENCES organization_memberships(id) ON DELETE RESTRICT;
+    ALTER TABLE organization_memberships ALTER COLUMN id DROP NOT NULL;
+    ALTER TABLE organization_memberships ALTER COLUMN status DROP NOT NULL;
+    ALTER TABLE organization_memberships ALTER COLUMN joined_at DROP NOT NULL;
+  `.execute(db)
+}
+
+const restorePromotedMembershipSchema = async () => {
+  await sql`
+    ALTER TABLE organization_memberships ALTER COLUMN id SET NOT NULL;
+    ALTER TABLE organization_memberships ALTER COLUMN status SET NOT NULL;
+    ALTER TABLE organization_memberships ALTER COLUMN joined_at SET NOT NULL;
+    ALTER TABLE organization_member_profiles
+      DROP CONSTRAINT organization_member_profiles_membership_id_fkey;
+    ALTER TABLE organization_memberships
+      DROP CONSTRAINT organization_memberships_pkey;
+    ALTER TABLE organization_memberships
+      ADD CONSTRAINT organization_memberships_pkey
+      PRIMARY KEY USING INDEX organization_memberships_id_key;
+    ALTER TABLE organization_member_profiles
+      ADD CONSTRAINT organization_member_profiles_membership_id_fkey
+      FOREIGN KEY (membership_id)
+      REFERENCES organization_memberships(id) ON DELETE RESTRICT;
+  `.execute(db)
+}
 
 const withLegacyMeasurementConstraintsDisabled = async (insertRows: () => Promise<void>) => {
   await sql`
@@ -67,11 +106,18 @@ const createLegacyUserAndMembership = async (suffix: string) => {
 }
 
 describe('multi organization auth backfill', () => {
+  beforeAll(async () => {
+    await resetDatabase(db)
+    await usePrePromotionMembershipSchema()
+  })
+
   beforeEach(async () => {
     await resetDatabase(db)
   })
 
   afterAll(async () => {
+    await resetDatabase(db)
+    await restorePromotedMembershipSchema()
     await db.destroy()
   })
 

--- a/apps/kaede/tests/services/profiles/profiles.test.ts
+++ b/apps/kaede/tests/services/profiles/profiles.test.ts
@@ -1,4 +1,3 @@
-import { sql } from 'kysely'
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 import type { RequestActor } from '../../../src/middleware/request-actor-context.js'
 import { createDb } from '../../../src/services/db/client.js'
@@ -176,10 +175,6 @@ describe('profile usecases with database', () => {
     await db
       .transaction()
       .execute(async (trx) => {
-        await sql`ALTER TABLE organization_memberships DROP CONSTRAINT organization_memberships_pkey`.execute(
-          trx
-        )
-
         const leftMembership = await trx
           .insertInto('organization_memberships')
           .values({

--- a/db/migrations/20260812020000_add_current_membership_unique_index.sql
+++ b/db/migrations/20260812020000_add_current_membership_unique_index.sql
@@ -1,0 +1,9 @@
+-- migrate:up transaction:false
+
+CREATE UNIQUE INDEX CONCURRENTLY organization_memberships_current_user_org_key
+  ON organization_memberships (organization_id, user_id)
+  WHERE status IN ('active', 'suspended');
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS organization_memberships_current_user_org_key;

--- a/db/migrations/20260812020100_promote_membership_uuid_primary_key.sql
+++ b/db/migrations/20260812020100_promote_membership_uuid_primary_key.sql
@@ -1,0 +1,67 @@
+-- migrate:up
+
+SET LOCAL lock_timeout = '5s';
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM organization_memberships
+    WHERE id IS NULL OR status IS NULL OR joined_at IS NULL
+  ) THEN
+    RAISE EXCEPTION
+      'membership UUID primary key promotion requires the multi-organization auth backfill';
+  END IF;
+END
+$$;
+
+ALTER TABLE organization_memberships ALTER COLUMN id SET NOT NULL;
+ALTER TABLE organization_memberships ALTER COLUMN status SET NOT NULL;
+ALTER TABLE organization_memberships ALTER COLUMN joined_at SET NOT NULL;
+
+ALTER TABLE organization_memberships
+  DROP CONSTRAINT organization_memberships_pkey;
+
+ALTER TABLE organization_memberships
+  ADD CONSTRAINT organization_memberships_pkey
+  PRIMARY KEY USING INDEX organization_memberships_id_key;
+
+-- migrate:down
+
+SET LOCAL lock_timeout = '5s';
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM organization_memberships
+    GROUP BY organization_id, user_id
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION
+      'cannot restore the legacy membership primary key after a user has rejoined an organization';
+  END IF;
+END
+$$;
+
+CREATE UNIQUE INDEX organization_memberships_id_key
+  ON organization_memberships (id);
+
+ALTER TABLE organization_member_profiles
+  DROP CONSTRAINT organization_member_profiles_membership_id_fkey;
+
+ALTER TABLE organization_memberships
+  DROP CONSTRAINT organization_memberships_pkey;
+
+ALTER TABLE organization_memberships
+  ADD CONSTRAINT organization_memberships_pkey
+  PRIMARY KEY (organization_id, user_id);
+
+ALTER TABLE organization_member_profiles
+  ADD CONSTRAINT organization_member_profiles_membership_id_fkey
+  FOREIGN KEY (membership_id)
+  REFERENCES organization_memberships(id) ON DELETE RESTRICT;
+
+ALTER TABLE organization_memberships ALTER COLUMN id DROP NOT NULL;
+ALTER TABLE organization_memberships ALTER COLUMN status DROP NOT NULL;
+ALTER TABLE organization_memberships ALTER COLUMN joined_at DROP NOT NULL;

--- a/db/multi-organization-auth-backfill.md
+++ b/db/multi-organization-auth-backfill.md
@@ -78,8 +78,17 @@ pnpm multi-org-auth-backfill validate
 これはExpandで`NOT VALID`として追加した、今回のbackfillで安全に検証できるconstraintを`VALIDATE`し、
 Organization statusとMembership UUID/status/joined_atを`NOT NULL`へ昇格する。
 NOT NULL昇格では短い`lock_timeout`と一時的な`NOT VALID` CHECKの事前検証を利用し、長時間のlockと再scanを避ける。
-Membershipの旧`(organization_id, user_id)` PKと同じ意味になるcurrent Membership partial unique indexはこのPRでは追加しない。
-現行Repositoryが同制約をupsert conflict targetとして使っているため、UUID PKへの切替はRepository互換対応と同じPRで行う。
+
+全件が検証済みになった後、Membership Lifecycle migrationを適用する。このmigrationはcurrent Membership用の
+partial unique indexを先に作成してから、旧`(organization_id, user_id)` primary keyをUUID `id` primary keyへ
+切り替える。これ以降、`left` Membershipは履歴として残し、再参加時は新しいMembership IDを作成できる。
+
+```sh
+make db-up ENV=local
+```
+
+UUID primary key切替migrationは未backfill行がある場合に停止する。再参加後は旧primary keyへ戻せないため、
+本番運用はroll-forwardを基本とする。
 
 ## blocking issueの扱い
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -375,9 +375,9 @@ CREATE TABLE public.organization_memberships (
     role text NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    id uuid DEFAULT gen_random_uuid(),
-    status text DEFAULT 'active'::text,
-    joined_at timestamp with time zone DEFAULT now(),
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    status text DEFAULT 'active'::text NOT NULL,
+    joined_at timestamp with time zone DEFAULT now() NOT NULL,
     left_at timestamp with time zone,
     CONSTRAINT organization_memberships_role_chk CHECK ((role = ANY (ARRAY['member'::text, 'manager'::text, 'owner'::text])))
 );
@@ -868,7 +868,7 @@ ALTER TABLE public.organization_memberships
 --
 
 ALTER TABLE ONLY public.organization_memberships
-    ADD CONSTRAINT organization_memberships_pkey PRIMARY KEY (organization_id, user_id);
+    ADD CONSTRAINT organization_memberships_pkey PRIMARY KEY (id);
 
 
 --
@@ -1252,10 +1252,10 @@ CREATE UNIQUE INDEX organization_member_oidc_active_provider_identity_key ON pub
 
 
 --
--- Name: organization_memberships_id_key; Type: INDEX; Schema: public; Owner: -
+-- Name: organization_memberships_current_user_org_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX organization_memberships_id_key ON public.organization_memberships USING btree (id);
+CREATE UNIQUE INDEX organization_memberships_current_user_org_key ON public.organization_memberships USING btree (organization_id, user_id) WHERE (status = ANY (ARRAY['active'::text, 'suspended'::text]));
 
 
 --
@@ -2057,4 +2057,6 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20260811010551'),
     ('20260811010552'),
     ('20260811010553'),
-    ('20260812010000');
+    ('20260812010000'),
+    ('20260812020000'),
+    ('20260812020100');


### PR DESCRIPTION
Closes #219

## 変更内容
- Membership UUIDをprimary keyへ昇格
- active/suspendedだけを対象にUser×Organizationを一意化
- left後の再参加では過去行を再利用せず新しいMembershipを作成
- current MembershipだけをRepositoryの検索・一覧対象に変更
- migrationのbackfill前提、lock timeout、down時の再参加preflightを追加

## Migration
- partial unique indexはCONCURRENTLYで作成
- UUID PK切替はbackfill済みをpreflightで確認
- downは再参加済みデータがあれば停止
- up/down/upを隔離PostgreSQLで確認済み

## 確認
- Kaede unit: 481 passed
- Kaede DB: 243 passed
- ESLint / TypeScript: passed