### PR TITLE
Organization単位logoutを追加

### DIFF
--- a/apps/kaede/src/routes/organization-session-auth/index.ts
+++ b/apps/kaede/src/routes/organization-session-auth/index.ts
@@ -1,0 +1,6 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { registerOrganizationSessionLogoutRoute } from './logout.js'
+
+export const organizationSessionAuthRoutes = new OpenAPIHono()
+
+registerOrganizationSessionLogoutRoute(organizationSessionAuthRoutes)

--- a/apps/kaede/src/routes/organization-session-auth/logout.test.ts
+++ b/apps/kaede/src/routes/organization-session-auth/logout.test.ts
@@ -1,0 +1,82 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { logoutMock } = vi.hoisted(() => ({ logoutMock: vi.fn() }))
+
+vi.mock('../../usecases/organization-session-auth/index.js', () => ({
+  logoutFromOrganization: logoutMock,
+}))
+
+import { organizationSessionAuthRoutes } from './index.js'
+
+const organizationId = '11111111-1111-4111-8111-111111111111'
+const membershipId = '22222222-2222-4222-8222-222222222222'
+
+const createTestApp = () => {
+  const app = new OpenAPIHono()
+  app.route('/api/organizations', organizationSessionAuthRoutes)
+  return app
+}
+
+describe('organization session logout route', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('対象Grantだけをrevokeし、Session cookieを削除しない', async () => {
+    logoutMock.mockResolvedValue({
+      ok: true,
+      value: { organization_id: organizationId, membership_id: membershipId, revoked: true },
+    })
+
+    const response = await createTestApp().request(
+      `/api/organizations/${organizationId}/auth/logout`,
+      {
+        method: 'POST',
+        headers: {
+          cookie: 'okarin_session=session-token',
+          'user-agent': 'logout-test',
+          'x-request-id': 'request-id',
+        },
+      }
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('set-cookie')).toBeNull()
+    await expect(response.json()).resolves.toEqual({
+      organization_id: organizationId,
+      membership_id: membershipId,
+      revoked: true,
+    })
+    expect(logoutMock).toHaveBeenCalledWith(organizationId, 'session-token', {
+      requestId: 'request-id',
+      userAgent: 'logout-test',
+    })
+  })
+
+  it('Sessionなしは401を返す', async () => {
+    logoutMock.mockResolvedValue({ ok: false, error: { type: 'AUTH_UNAUTHENTICATED' } })
+
+    const response = await createTestApp().request(
+      `/api/organizations/${organizationId}/auth/logout`,
+      { method: 'POST' }
+    )
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toMatchObject({
+      error_code: 'AUTH_UNAUTHENTICATED',
+    })
+  })
+
+  it('対象Organizationに所属していない場合は403を返す', async () => {
+    logoutMock.mockResolvedValue({
+      ok: false,
+      error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' },
+    })
+
+    const response = await createTestApp().request(
+      `/api/organizations/${organizationId}/auth/logout`,
+      { method: 'POST', headers: { cookie: 'okarin_session=session-token' } }
+    )
+
+    expect(response.status).toBe(403)
+  })
+})

--- a/apps/kaede/src/routes/organization-session-auth/logout.ts
+++ b/apps/kaede/src/routes/organization-session-auth/logout.ts
@@ -1,0 +1,63 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { errorResponseSchema } from '../../schemas/common.js'
+import {
+  organizationSessionLogoutParamsSchema,
+  organizationSessionLogoutResponseSchema,
+} from '../../schemas/organization-session-auth.js'
+import { logoutFromOrganization } from '../../usecases/organization-session-auth/index.js'
+import { getSessionTokenFromCookie } from '../auth/cookie.js'
+
+const logoutError = (type: string) => {
+  if (type === 'AUTH_ORGANIZATION_FORBIDDEN') {
+    return {
+      status: 403 as const,
+      body: { error_code: type, error_message: 'organization access forbidden' },
+    }
+  }
+  return {
+    status: 401 as const,
+    body: { error_code: type, error_message: 'valid session required' },
+  }
+}
+
+export const registerOrganizationSessionLogoutRoute = (app: OpenAPIHono) => {
+  const route = createRoute({
+    method: 'post',
+    path: '/{organizationId}/auth/logout',
+    tags: ['Organization Auth'],
+    description:
+      '現在Sessionの対象Organization Membership Grantだけをrevokeし、Sessionと他Organization Grantは維持する',
+    request: { params: organizationSessionLogoutParamsSchema },
+    responses: {
+      200: {
+        description: 'organization logout succeeded',
+        content: { 'application/json': { schema: organizationSessionLogoutResponseSchema } },
+      },
+      401: {
+        description: 'valid session required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      403: {
+        description: 'organization membership required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+    },
+  })
+
+  app.openapi(route, async (c) => {
+    const result = await logoutFromOrganization(
+      c.req.valid('param').organizationId,
+      getSessionTokenFromCookie(c),
+      {
+        requestId: c.req.header('x-request-id'),
+        userAgent: c.req.header('user-agent'),
+      }
+    )
+    if (!result.ok) {
+      const error = logoutError(result.error.type)
+      return c.json(error.body, error.status)
+    }
+    return c.json(result.value, 200)
+  })
+}

--- a/apps/kaede/src/schemas/organization-session-auth.ts
+++ b/apps/kaede/src/schemas/organization-session-auth.ts
@@ -1,0 +1,14 @@
+import { z } from '@hono/zod-openapi'
+import { uuidSchema } from './common.js'
+
+export const organizationSessionLogoutParamsSchema = z
+  .object({ organizationId: uuidSchema })
+  .openapi('OrganizationSessionLogoutParams')
+
+export const organizationSessionLogoutResponseSchema = z
+  .object({
+    organization_id: uuidSchema,
+    membership_id: uuidSchema,
+    revoked: z.boolean(),
+  })
+  .openapi('OrganizationSessionLogoutResponse')

--- a/apps/kaede/src/server.ts
+++ b/apps/kaede/src/server.ts
@@ -10,6 +10,7 @@ import { registerApiRoutes } from './routes/index.js'
 import { organizationInvitesRoutes } from './routes/organization-invites/index.js'
 import { organizationLocalAuthRoutes } from './routes/organization-local-auth/index.js'
 import { organizationOidcAuthRoutes } from './routes/organization-oidc-auth/index.js'
+import { organizationSessionAuthRoutes } from './routes/organization-session-auth/index.js'
 
 export const createApp = () => {
   const app = new OpenAPIHono()
@@ -39,6 +40,8 @@ export const createApp = () => {
   // Local loginはSessionなしでも利用でき、Sessionがある場合だけreauthenticateとして扱う。
   app.route('/api/organizations', organizationLocalAuthRoutes)
   app.route('/api/organizations', organizationOidcAuthRoutes)
+  // Grantが失効済みでも対象Organizationからlogoutできるよう、Membership Guardより前に手動でSessionを検証する。
+  app.route('/api/organizations', organizationSessionAuthRoutes)
   // 招待確認・Local招待受領はSessionなしでも利用する。
   app.route('/api/invites', organizationInvitesRoutes)
 

--- a/apps/kaede/src/services/organization-session-auth/index.ts
+++ b/apps/kaede/src/services/organization-session-auth/index.ts
@@ -1,0 +1,5 @@
+export {
+  findCurrentMembershipForSessionLogout,
+  insertOrganizationSessionAuthenticationEvent,
+  revokeCurrentSessionMembershipGrant,
+} from './repository.js'

--- a/apps/kaede/src/services/organization-session-auth/repository.ts
+++ b/apps/kaede/src/services/organization-session-auth/repository.ts
@@ -1,0 +1,41 @@
+import type { Insertable } from 'kysely'
+import type { AuthenticationEvents } from '../db/generated.js'
+import { db } from '../db/index.js'
+import type { DbExecutor } from '../executor.js'
+
+export const findCurrentMembershipForSessionLogout = async (
+  organizationId: string,
+  userId: string,
+  executor: DbExecutor = db
+) =>
+  executor
+    .selectFrom('organization_memberships')
+    .select(['id', 'organization_id', 'user_id', 'status'])
+    .where('organization_id', '=', organizationId)
+    .where('user_id', '=', userId)
+    .where('status', 'in', ['active', 'suspended'])
+    .executeTakeFirst()
+
+export const revokeCurrentSessionMembershipGrant = async (
+  sessionId: string,
+  membershipId: string,
+  userId: string,
+  revokedAt: Date,
+  executor: DbExecutor
+) => {
+  const result = await executor
+    .updateTable('session_membership_authentications')
+    .set({ revoked_at: revokedAt, updated_at: revokedAt })
+    .where('session_id', '=', sessionId)
+    .where('membership_id', '=', membershipId)
+    .where('user_id', '=', userId)
+    .where('revoked_at', 'is', null)
+    .executeTakeFirst()
+
+  return result.numUpdatedRows > 0n
+}
+
+export const insertOrganizationSessionAuthenticationEvent = async (
+  event: Insertable<AuthenticationEvents>,
+  executor: DbExecutor
+) => executor.insertInto('authentication_events').values(event).executeTakeFirst()

--- a/apps/kaede/src/usecases/organization-session-auth/index.ts
+++ b/apps/kaede/src/usecases/organization-session-auth/index.ts
@@ -1,0 +1,2 @@
+export { logoutFromOrganization } from './logout.js'
+export type { OrganizationSessionLogoutResult } from './logout.js'

--- a/apps/kaede/src/usecases/organization-session-auth/logout.ts
+++ b/apps/kaede/src/usecases/organization-session-auth/logout.ts
@@ -1,0 +1,86 @@
+import { findValidSessionByToken } from '../../services/auth/index.js'
+import { db } from '../../services/db/index.js'
+import type { DbExecutor } from '../../services/executor.js'
+import {
+  findCurrentMembershipForSessionLogout,
+  insertOrganizationSessionAuthenticationEvent,
+  revokeCurrentSessionMembershipGrant,
+} from '../../services/organization-session-auth/index.js'
+
+export type OrganizationSessionLogoutResult =
+  | {
+      ok: true
+      value: { organization_id: string; membership_id: string; revoked: boolean }
+    }
+  | {
+      ok: false
+      error: { type: 'AUTH_UNAUTHENTICATED' | 'AUTH_SESSION_EXPIRED' | 'AUTH_SESSION_REVOKED' }
+    }
+  | { ok: false; error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' } }
+
+const mapSessionError = (
+  error: 'SESSION_NOT_FOUND' | 'SESSION_EXPIRED' | 'SESSION_REVOKED'
+): 'AUTH_UNAUTHENTICATED' | 'AUTH_SESSION_EXPIRED' | 'AUTH_SESSION_REVOKED' => {
+  if (error === 'SESSION_EXPIRED') return 'AUTH_SESSION_EXPIRED'
+  if (error === 'SESSION_REVOKED') return 'AUTH_SESSION_REVOKED'
+  return 'AUTH_UNAUTHENTICATED'
+}
+
+export const logoutFromOrganization = async (
+  organizationId: string,
+  sessionToken: string | undefined,
+  options: { now?: Date; requestId?: string; userAgent?: string } = {},
+  executor?: DbExecutor
+): Promise<OrganizationSessionLogoutResult> => {
+  if (!sessionToken) return { ok: false, error: { type: 'AUTH_UNAUTHENTICATED' } }
+
+  const base = executor ?? db
+  const run = async (trx: DbExecutor) => {
+    const now = options.now ?? new Date()
+    const sessionResult = await findValidSessionByToken(sessionToken, now, trx)
+    if (!sessionResult.ok) {
+      return { ok: false, error: { type: mapSessionError(sessionResult.error) } } as const
+    }
+
+    const membership = await findCurrentMembershipForSessionLogout(
+      organizationId,
+      sessionResult.session.user_id,
+      trx
+    )
+    if (!membership) {
+      return { ok: false, error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' } } as const
+    }
+
+    const revoked = await revokeCurrentSessionMembershipGrant(
+      sessionResult.session.id,
+      membership.id,
+      sessionResult.session.user_id,
+      now,
+      trx
+    )
+    await insertOrganizationSessionAuthenticationEvent(
+      {
+        event_type: 'organization_logout',
+        outcome: 'success',
+        user_id: sessionResult.session.user_id,
+        organization_id: organizationId,
+        membership_id: membership.id,
+        session_id: sessionResult.session.id,
+        request_id: options.requestId,
+        user_agent: options.userAgent,
+      },
+      trx
+    )
+
+    return {
+      ok: true,
+      value: {
+        organization_id: organizationId,
+        membership_id: membership.id,
+        revoked,
+      },
+    } as const
+  }
+
+  return 'transaction' in base ? base.transaction().execute(run) : run(base)
+}

--- a/apps/kaede/tests/services/auth/organization-session-logout.test.ts
+++ b/apps/kaede/tests/services/auth/organization-session-logout.test.ts
@@ -1,0 +1,148 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { createSession } from '../../../src/services/auth/index.js'
+import { createDb } from '../../../src/services/db/client.js'
+import { logoutFromOrganization } from '../../../src/usecases/organization-session-auth/index.js'
+import { resetDatabase } from '../../db/helpers.js'
+
+const db = createDb()
+const now = new Date('2026-08-11T12:00:00.000Z')
+
+const createGrantFixture = async () => {
+  const user = await db
+    .insertInto('users')
+    .values({
+      email: 'organization-logout@example.test',
+      display_name: 'Organization Logout',
+      global_role: 'none',
+      status: 'active',
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const organizations = await db
+    .insertInto('organizations')
+    .values([{ name: 'Organization A' }, { name: 'Organization B' }])
+    .returningAll()
+    .execute()
+  const memberships = await Promise.all(
+    organizations.map((organization) =>
+      db
+        .insertInto('organization_memberships')
+        .values({ organization_id: organization.id, user_id: user.id, role: 'member' })
+        .returningAll()
+        .executeTakeFirstOrThrow()
+    )
+  )
+  const credentials = await Promise.all(
+    memberships.map((membership, index) =>
+      db
+        .insertInto('organization_local_credentials')
+        .values({
+          membership_id: membership.id,
+          organization_id: membership.organization_id,
+          login_email: `logout-${index}@example.test`,
+          normalized_login_email: `logout-${index}@example.test`,
+          password_hash: 'test-password-hash',
+        })
+        .returningAll()
+        .executeTakeFirstOrThrow()
+    )
+  )
+  const { session, token } = await createSession({ userId: user.id, now }, db)
+  await db
+    .insertInto('session_membership_authentications')
+    .values(
+      memberships.map((membership, index) => ({
+        session_id: session.id,
+        membership_id: membership.id,
+        user_id: user.id,
+        auth_method: 'local',
+        policy_version: 1,
+        local_credential_id: credentials[index].id,
+        authenticated_at: now,
+        expires_at: new Date(now.getTime() + 3_600_000),
+      }))
+    )
+    .execute()
+
+  return { memberships, organizations, session, token }
+}
+
+describe('organization session logout', () => {
+  beforeEach(async () => resetDatabase(db))
+  afterAll(async () => db.destroy())
+
+  it('対象OrganizationのGrantだけをrevokeし、Sessionと他Organization Grantを維持する', async () => {
+    const fixture = await createGrantFixture()
+    const targetOrganization = fixture.organizations[0]
+    const targetMembership = fixture.memberships[0]
+
+    const result = await logoutFromOrganization(
+      targetOrganization.id,
+      fixture.token,
+      { now, requestId: 'request-id', userAgent: 'test-agent' },
+      db
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        organization_id: targetOrganization.id,
+        membership_id: targetMembership.id,
+        revoked: true,
+      },
+    })
+    const grants = await db
+      .selectFrom('session_membership_authentications')
+      .select(['membership_id', 'revoked_at'])
+      .where('session_id', '=', fixture.session.id)
+      .orderBy('membership_id')
+      .execute()
+    expect(grants.find((grant) => grant.membership_id === targetMembership.id)?.revoked_at).toEqual(
+      now
+    )
+    expect(
+      grants.find((grant) => grant.membership_id !== targetMembership.id)?.revoked_at
+    ).toBeNull()
+    await expect(
+      db
+        .selectFrom('sessions')
+        .select('revoked_at')
+        .where('id', '=', fixture.session.id)
+        .executeTakeFirst()
+    ).resolves.toEqual({ revoked_at: null })
+  })
+
+  it('既にrevoke済みまたはGrantなしでもidempotentに成功する', async () => {
+    const fixture = await createGrantFixture()
+    const targetOrganization = fixture.organizations[0]
+
+    await logoutFromOrganization(targetOrganization.id, fixture.token, { now }, db)
+    const second = await logoutFromOrganization(
+      targetOrganization.id,
+      fixture.token,
+      { now: new Date(now.getTime() + 1000) },
+      db
+    )
+
+    expect(second).toMatchObject({ ok: true, value: { revoked: false } })
+  })
+
+  it('current MembershipがないOrganizationは拒否してGrantを変更しない', async () => {
+    const fixture = await createGrantFixture()
+    const unrelated = await db
+      .insertInto('organizations')
+      .values({ name: 'Unrelated Organization' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    const result = await logoutFromOrganization(unrelated.id, fixture.token, { now }, db)
+
+    expect(result).toEqual({ ok: false, error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' } })
+    const revokedCount = await db
+      .selectFrom('session_membership_authentications')
+      .select(({ fn }) => fn.countAll<number>().as('count'))
+      .where('revoked_at', 'is not', null)
+      .executeTakeFirstOrThrow()
+    expect(revokedCount.count.toString()).toBe('0')
+  })
+})


### PR DESCRIPTION
Closes #219

## 変更内容
- 現在Sessionの対象Membership Grantだけをrevokeするlogout APIを追加
- Global Session、cookie、他Organization Grantは維持
- Grantなし/revoke済みでもidempotentに成功
- Membership Grant guardより前にSessionを手動検証し、失効Grantからもlogout可能
- authentication eventを同一transactionで記録

## 確認
- Kaede unit: 506 passed
- Kaede DB: 246 passed
- ESLint / TypeScript: passed