### PR TITLE
feat(kaede): OIDC Invite受領を統合する

### DIFF
--- a/apps/kaede/src/routes/auth/auth.test.ts
+++ b/apps/kaede/src/routes/auth/auth.test.ts
@@ -15,6 +15,7 @@ const {
   loginMock,
   logoutMock,
   completeOrganizationOidcMock,
+  acceptOrganizationInviteWithOidcMock,
   isOrganizationOidcTransactionStateMock,
   requireActiveSessionUserMock,
   verifyActivationTokenMock,
@@ -27,6 +28,7 @@ const {
   loginMock: vi.fn(),
   logoutMock: vi.fn(),
   completeOrganizationOidcMock: vi.fn(),
+  acceptOrganizationInviteWithOidcMock: vi.fn(),
   isOrganizationOidcTransactionStateMock: vi.fn(),
   requireActiveSessionUserMock: vi.fn(),
   verifyActivationTokenMock: vi.fn(),
@@ -35,6 +37,10 @@ const {
 vi.mock('../../usecases/organization-oidc-auth/index.js', () => ({
   completeOrganizationOidc: completeOrganizationOidcMock,
   isOrganizationOidcTransactionState: isOrganizationOidcTransactionStateMock,
+}))
+
+vi.mock('../../usecases/organization-invites/index.js', () => ({
+  acceptOrganizationInviteWithOidc: acceptOrganizationInviteWithOidcMock,
 }))
 
 vi.mock('../../services/auth/index.js', () => ({
@@ -434,7 +440,10 @@ describe('auth routes', () => {
     expect(completeOrganizationOidcMock).toHaveBeenCalledWith(
       'authorization-code',
       'organization-state',
-      expect.objectContaining({ sessionToken: undefined })
+      expect.objectContaining({
+        sessionToken: undefined,
+        completeInvite: acceptOrganizationInviteWithOidcMock,
+      })
     )
     expect(completeGoogleOidcLoginMock).not.toHaveBeenCalled()
     expect(completeGoogleOidcLinkMock).not.toHaveBeenCalled()

--- a/apps/kaede/src/routes/auth/oidc-google-callback.ts
+++ b/apps/kaede/src/routes/auth/oidc-google-callback.ts
@@ -3,6 +3,7 @@ import type { OpenAPIHono } from '@hono/zod-openapi'
 import { getAppRuntimeConfig, getOidcRuntimeConfig } from '../../config/runtime.js'
 import { GoogleOidcClient } from '../../services/auth/index.js'
 import { completeGoogleOidcLink, completeGoogleOidcLogin } from '../../usecases/auth/index.js'
+import { acceptOrganizationInviteWithOidc } from '../../usecases/organization-invites/index.js'
 import {
   completeOrganizationOidc,
   isOrganizationOidcTransactionState,
@@ -80,6 +81,7 @@ export const registerGoogleOidcCallbackRoute = (app: OpenAPIHono) => {
           configuredClientId: config.googleClientId,
           transactionSecret: config.stateCookieSecret,
           sessionToken: getSessionTokenFromCookie(c),
+          completeInvite: acceptOrganizationInviteWithOidc,
         }
       )
       if (!result.ok) {

--- a/apps/kaede/src/services/organization-invites/index.ts
+++ b/apps/kaede/src/services/organization-invites/index.ts
@@ -3,6 +3,7 @@ export {
   findActorMembership,
   findActorMembershipForUpdate,
   findEnabledLocalCredentialByEmail,
+  findInviteContextByIdForUpdate,
   findInviteContextByTokenHash,
   findInviteContextByTokenHashForUpdate,
   findMembershipStateForInvite,

--- a/apps/kaede/src/services/organization-invites/repository.ts
+++ b/apps/kaede/src/services/organization-invites/repository.ts
@@ -134,6 +134,18 @@ export const findInviteContextByTokenHashForUpdate = async (
     .executeTakeFirst()
 }
 
+export const findInviteContextByIdForUpdate = async (
+  inviteId: string,
+  organizationId: string,
+  executor: DbExecutor
+) => {
+  return inviteContextQuery(executor)
+    .where('invite.id', '=', inviteId)
+    .where('invite.organization_id', '=', organizationId)
+    .forUpdate('invite')
+    .executeTakeFirst()
+}
+
 export const findMembershipStateForInvite = async (
   organizationId: string,
   userId: string,

--- a/apps/kaede/src/services/organization-oidc-auth/repository.ts
+++ b/apps/kaede/src/services/organization-oidc-auth/repository.ts
@@ -228,6 +228,21 @@ export const findActiveOidcMembershipLink = async (
     .where('link.revoked_at', 'is', null)
     .executeTakeFirst()
 
+export const revokeActiveOidcMembershipLink = async (
+  providerId: string,
+  identityId: string,
+  revokedAt: Date,
+  executor: DbExecutor
+) =>
+  executor
+    .updateTable('organization_member_oidc_identities')
+    .set({ revoked_at: revokedAt })
+    .where('organization_oidc_provider_id', '=', providerId)
+    .where('oidc_identity_id', '=', identityId)
+    .where('revoked_at', 'is', null)
+    .returningAll()
+    .executeTakeFirst()
+
 export const upsertOidcMembershipLink = async (
   link: Insertable<OrganizationMemberOidcIdentities>,
   executor: DbExecutor

--- a/apps/kaede/src/usecases/organization-invites/index.ts
+++ b/apps/kaede/src/usecases/organization-invites/index.ts
@@ -22,6 +22,7 @@ import {
   findEnabledLocalCredentialByEmail,
   findInviteContextByTokenHash,
   findInviteContextByTokenHashForUpdate,
+  findInviteContextByIdForUpdate,
   findMembershipStateForInvite,
   findOrganizationInviteForUpdate,
   insertOrganizationInvite,
@@ -36,11 +37,25 @@ import {
   upsertLocalMembershipGrant,
 } from '../../services/organization-local-auth/index.js'
 import {
+  canonicalizeOidcIssuer,
+  findOidcIdentity,
+  findOrganizationOidcProviderContextById,
+  insertOidcIdentity,
+  revokeActiveOidcMembershipLink,
+  updateOidcIdentityClaims,
+  upsertOidcMembershipGrant,
+  upsertOidcMembershipLink,
+} from '../../services/organization-oidc-auth/index.js'
+import {
   insertAuditEvent,
   upsertOrganizationMemberProfile,
   upsertUserProfile,
 } from '../../services/profiles/index.js'
 import { findUserById, insertUser } from '../../services/users/index.js'
+import type {
+  CompleteOrganizationOidcResult,
+  OrganizationOidcInviteCompletionContext,
+} from '../organization-oidc-auth/callback.js'
 
 const INVITE_TTL_MS = 7 * 24 * 60 * 60 * 1000
 const LEGACY_INVITE_EMAIL = 'single-use-invite@invalid.local'
@@ -579,3 +594,246 @@ export const acceptOrganizationInviteWithLocalCredential = async (
     }
   })
 }
+
+export const acceptOrganizationInviteWithOidc = async (
+  context: OrganizationOidcInviteCompletionContext
+): Promise<CompleteOrganizationOidcResult> =>
+  runInTransaction(context.executor, async (trx) => {
+    const valid = validateInviteContext(
+      await findInviteContextByIdForUpdate(context.inviteId, context.organizationId, trx),
+      context.now
+    )
+    if (!valid.ok) {
+      return { ...valid, return_to: context.returnTo }
+    }
+    if (!valid.context.oidc_auth_enabled) {
+      return {
+        ok: false,
+        error: { type: 'AUTH_METHOD_NOT_ALLOWED' },
+        return_to: context.returnTo,
+      }
+    }
+
+    const provider = await findOrganizationOidcProviderContextById(context.providerId, trx)
+    if (
+      provider?.organization_id !== valid.context.organization_id ||
+      provider.organization_status !== 'active' ||
+      !provider.oidc_auth_enabled ||
+      !provider.provider_enabled
+    ) {
+      return {
+        ok: false,
+        error: { type: 'AUTH_METHOD_NOT_ALLOWED' },
+        return_to: context.returnTo,
+      }
+    }
+
+    let activeSession
+    if (context.transactionSessionId) {
+      if (!context.callbackSessionToken) {
+        return {
+          ok: false,
+          error: { type: 'AUTH_SESSION_REQUIRED' },
+          return_to: context.returnTo,
+        }
+      }
+      const foundSession = await findValidSessionByToken(
+        context.callbackSessionToken,
+        context.now,
+        trx
+      )
+      if (!foundSession.ok || foundSession.session.id !== context.transactionSessionId) {
+        return {
+          ok: false,
+          error: { type: 'AUTH_SESSION_REQUIRED' },
+          return_to: context.returnTo,
+        }
+      }
+      activeSession = foundSession.session
+    } else if (context.callbackSessionToken) {
+      return {
+        ok: false,
+        error: { type: 'AUTH_IDENTITY_USER_MISMATCH' },
+        return_to: context.returnTo,
+      }
+    }
+
+    const issuer = canonicalizeOidcIssuer(context.claims.issuer)
+    let identity = await findOidcIdentity(issuer, context.claims.sub, trx)
+    if (identity && activeSession && identity.user_id !== activeSession.user_id) {
+      return {
+        ok: false,
+        error: { type: 'AUTH_IDENTITY_USER_MISMATCH' },
+        return_to: context.returnTo,
+      }
+    }
+
+    const existingUserId = identity?.user_id ?? activeSession?.user_id
+    const userId = existingUserId ?? randomUUID()
+    if (existingUserId) {
+      const user = await findUserById(userId, trx)
+      if (user?.status !== 'active') {
+        return {
+          ok: false,
+          error: { type: 'AUTH_USER_DISABLED' },
+          return_to: context.returnTo,
+        }
+      }
+    }
+
+    // Membership conflict is checked before creating any User/Identity rows. Returning an
+    // expected conflict must not leave callback-side mutations committed.
+    const priorMembership = await findMembershipStateForInvite(
+      valid.context.organization_id,
+      userId,
+      trx
+    )
+    const conflict = membershipConflict(priorMembership?.status ?? null)
+    if (conflict) {
+      return { ok: false, error: conflict, return_to: context.returnTo }
+    }
+
+    if (!existingUserId) {
+      const displayName = context.claims.name.trim()
+      const contactEmail = context.claims.email.trim()
+      await insertUser(
+        {
+          id: userId,
+          email: `${userId}@invite.local.invalid`,
+          display_name: displayName,
+          password_hash: null,
+          password_changed_at: null,
+          status: 'active',
+          global_role: 'none',
+          contact_email: contactEmail,
+          normalized_contact_email: contactEmail.toLowerCase(),
+          contact_email_verified_at: context.now,
+          locked_until: null,
+        },
+        trx
+      )
+      await upsertUserProfile(
+        {
+          user_id: userId,
+          display_name: displayName,
+          locale: 'ja-JP',
+          timezone: 'Asia/Tokyo',
+        },
+        { display_name: displayName, locale: 'ja-JP', timezone: 'Asia/Tokyo' },
+        trx
+      )
+    }
+
+    if (!identity) {
+      identity = await insertOidcIdentity(
+        {
+          user_id: userId,
+          issuer,
+          subject: context.claims.sub,
+          last_claimed_email: context.claims.email,
+          last_claimed_email_verified: context.claims.emailVerified,
+        },
+        trx
+      )
+    } else {
+      identity = await updateOidcIdentityClaims(
+        identity.id,
+        {
+          last_claimed_email: context.claims.email,
+          last_claimed_email_verified: context.claims.emailVerified,
+        },
+        trx
+      )
+    }
+
+    const membership = await insertOrganizationMembershipForInvite(
+      {
+        id: randomUUID(),
+        organization_id: valid.context.organization_id,
+        user_id: userId,
+        role: valid.context.role,
+        status: 'active',
+        joined_at: context.now,
+        left_at: null,
+      },
+      trx
+    )
+    if (!membership.id) {
+      // This cannot occur for newly inserted rows. Throw so an executor supplied by an
+      // outer transaction also observes the failure and rolls the whole acceptance back.
+      throw new Error('Inserted Organization Membership has no id')
+    }
+    await upsertOrganizationMemberProfile(
+      {
+        membership_id: membership.id,
+        display_name: null,
+        height_meters: null,
+        stride_length_meters: null,
+      },
+      { display_name: null, height_meters: null, stride_length_meters: null },
+      trx
+    )
+
+    await revokeActiveOidcMembershipLink(provider.provider_id, identity.id, context.now, trx)
+    const link = await upsertOidcMembershipLink(
+      {
+        membership_id: membership.id,
+        organization_id: valid.context.organization_id,
+        user_id: userId,
+        organization_oidc_provider_id: provider.provider_id,
+        oidc_identity_id: identity.id,
+        revoked_at: null,
+      },
+      trx
+    )
+    if (
+      !(await consumeOrganizationInvite(valid.context.invite_id, membership.id, context.now, trx))
+    ) {
+      // The locked Invite was revalidated above, so a conditional consume miss signals an
+      // invariant violation. Propagate it to guarantee rollback instead of committing links.
+      throw new Error('Locked Organization Invite could not be consumed')
+    }
+
+    let createdSessionToken: string | undefined
+    if (!activeSession) {
+      const created = await createSession({ authMethod: 'oidc', userId, now: context.now }, trx)
+      activeSession = created.session
+      createdSessionToken = created.token
+    }
+    await upsertOidcMembershipGrant(
+      {
+        session_id: activeSession.id,
+        membership_id: membership.id,
+        user_id: userId,
+        auth_method: 'oidc',
+        policy_version: provider.policy_version,
+        local_credential_id: null,
+        member_oidc_identity_id: link.id,
+        authenticated_at: context.now,
+        expires_at: new Date(context.now.getTime() + provider.membership_grant_ttl_seconds * 1000),
+        revoked_at: null,
+      },
+      trx
+    )
+    await insertAuthenticationEvent(
+      {
+        event_type: 'oidc_invite_accept',
+        outcome: 'success',
+        user_id: userId,
+        organization_id: valid.context.organization_id,
+        membership_id: membership.id,
+        session_id: activeSession.id,
+        auth_method: 'oidc',
+        credential_reference_id: identity.id,
+      },
+      trx
+    )
+
+    return {
+      ok: true,
+      value: {
+        return_to: context.returnTo,
+        sessionToken: createdSessionToken,
+      },
+    }
+  })

--- a/apps/kaede/src/usecases/organization-oidc-auth/callback.ts
+++ b/apps/kaede/src/usecases/organization-oidc-auth/callback.ts
@@ -68,6 +68,12 @@ export type CompleteOrganizationOidcError =
   | { type: 'AUTH_MEMBERSHIP_NOT_ACTIVE' }
   | { type: 'AUTH_SESSION_REQUIRED' }
   | { type: 'AUTH_USER_DISABLED' }
+  | { type: 'AUTH_METHOD_NOT_ALLOWED' }
+  | { type: 'INVITE_INVALID' }
+  | { type: 'INVITE_EXPIRED' }
+  | { type: 'INVITE_ALREADY_REDEEMED' }
+  | { type: 'INVITE_ALREADY_MEMBER' }
+  | { type: 'INVITE_MEMBERSHIP_SUSPENDED' }
 
 export type CompleteOrganizationOidcResult =
   | {

--- a/apps/kaede/tests/services/auth/organization-oidc-auth.test.ts
+++ b/apps/kaede/tests/services/auth/organization-oidc-auth.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { hashActivationToken } from '../../../src/services/auth/activation-token.js'
 import { createSession } from '../../../src/services/auth/session-repository.js'
 import { createDb } from '../../../src/services/db/client.js'
+import { acceptOrganizationInviteWithOidc } from '../../../src/usecases/organization-invites/index.js'
 import {
   completeOrganizationOidc,
   isOrganizationOidcTransactionState,
@@ -135,10 +136,14 @@ const startLogin = async (
 }
 
 const callbackClient = ({
+  email = 'oidc-user@example.test',
   hostedDomain = null,
+  name = 'OIDC User',
   subject = 'google-subject',
 }: {
+  email?: string
   hostedDomain?: string | null
+  name?: string
   subject?: string
 } = {}) => ({
   exchangeCodeForIdToken: () => Promise.resolve('id-token'),
@@ -146,12 +151,75 @@ const callbackClient = ({
     Promise.resolve({
       issuer: 'accounts.google.com',
       sub: subject,
-      email: 'oidc-user@example.test',
+      email,
       emailVerified: true,
-      name: 'OIDC User',
+      name,
       hostedDomain,
     }),
 })
+
+const createInvite = async (
+  fixture: Awaited<ReturnType<typeof createFixture>>,
+  token = 'single-use-invite-token'
+) => {
+  const invite = await db
+    .insertInto('organization_invites')
+    .values({
+      organization_id: fixture.organization.id,
+      created_by_user_id: fixture.user.id,
+      created_by_membership_id: fixture.membership.id,
+      email: 'legacy-unused@example.test',
+      token_hash: hashActivationToken(token),
+      role: 'member',
+      expires_at: new Date('2026-08-12T10:00:00.000Z'),
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  return { invite, token }
+}
+
+const startInvite = async (
+  fixture: Awaited<ReturnType<typeof createFixture>>,
+  token: string,
+  sessionToken?: string
+) => {
+  const result = await startOrganizationOidc(
+    fixture.organization.slug,
+    fixture.provider.id,
+    sessionToken,
+    { intent: 'accept_invite', invite_token: token, return_to: '/invites/complete' },
+    {
+      client: {
+        createAuthorizationUrl: ({ state }) =>
+          `https://accounts.google.com/o/oauth2/v2/auth?state=${encodeURIComponent(state)}`,
+      },
+      configuredClientId,
+      transactionSecret,
+      now,
+      executor: db,
+    }
+  )
+  expect(result.ok).toBe(true)
+  if (!result.ok) throw new Error(result.error.type)
+  const state = new URL(result.value.authorization_url).searchParams.get('state')
+  if (!state) throw new Error('state is required')
+  return state
+}
+
+const completeInvite = (
+  state: string,
+  client: ReturnType<typeof callbackClient>,
+  sessionToken?: string
+) =>
+  completeOrganizationOidc('authorization-code', state, {
+    client,
+    configuredClientId,
+    transactionSecret,
+    completeInvite: acceptOrganizationInviteWithOidc,
+    sessionToken,
+    now,
+    executor: db,
+  })
 
 describe('organization OIDC authentication', () => {
   beforeEach(async () => {
@@ -407,5 +475,220 @@ describe('organization OIDC authentication', () => {
       error: { type: 'OIDC_TRANSACTION_INVALID' },
     })
     expect(completeInvite).toHaveBeenCalledTimes(1)
+  })
+
+  it('OIDC Invite成功後にUserからGrantまでを一括作成してInviteを消費する', async () => {
+    const fixture = await createFixture()
+    const { invite, token } = await createInvite(fixture)
+    const state = await startInvite(fixture, token)
+
+    const result = await completeInvite(
+      state,
+      callbackClient({
+        subject: 'new-invite-subject',
+        email: 'new-invite-user@example.test',
+        name: 'New Invite User',
+      })
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: { return_to: '/invites/complete', sessionToken: expect.any(String) },
+    })
+    const identity = await db
+      .selectFrom('oidc_identities')
+      .selectAll()
+      .where('subject', '=', 'new-invite-subject')
+      .executeTakeFirstOrThrow()
+    expect(identity.issuer).toBe('https://accounts.google.com')
+    const invitedUser = await db
+      .selectFrom('users')
+      .selectAll()
+      .where('id', '=', identity.user_id)
+      .executeTakeFirstOrThrow()
+    expect(invitedUser).toMatchObject({
+      contact_email: 'new-invite-user@example.test',
+      normalized_contact_email: 'new-invite-user@example.test',
+      status: 'active',
+    })
+    expect(invitedUser.contact_email_verified_at).toEqual(now)
+    const membership = await db
+      .selectFrom('organization_memberships')
+      .selectAll()
+      .where('organization_id', '=', fixture.organization.id)
+      .where('user_id', '=', identity.user_id)
+      .where('status', '=', 'active')
+      .executeTakeFirstOrThrow()
+    const redeemedInvite = await db
+      .selectFrom('organization_invites')
+      .selectAll()
+      .where('id', '=', invite.id)
+      .executeTakeFirstOrThrow()
+    expect(redeemedInvite).toMatchObject({ redeemed_membership_id: membership.id })
+    expect(redeemedInvite.redeemed_at).toEqual(now)
+    await expect(
+      db
+        .selectFrom('organization_member_profiles')
+        .selectAll()
+        .where('membership_id', '=', membership.id)
+        .executeTakeFirst()
+    ).resolves.toBeDefined()
+    await expect(
+      db
+        .selectFrom('session_membership_authentications')
+        .selectAll()
+        .where('membership_id', '=', membership.id)
+        .where('auth_method', '=', 'oidc')
+        .executeTakeFirst()
+    ).resolves.toMatchObject({ user_id: identity.user_id })
+
+    await expect(
+      completeInvite(
+        state,
+        callbackClient({ subject: 'new-invite-subject', email: 'new-invite-user@example.test' })
+      )
+    ).resolves.toEqual({ ok: false, error: { type: 'OIDC_TRANSACTION_INVALID' } })
+  })
+
+  it.each([
+    ['active', 'INVITE_ALREADY_MEMBER'],
+    ['suspended', 'INVITE_MEMBERSHIP_SUSPENDED'],
+  ] as const)(
+    '%s MembershipはInviteを消費せず拒否する',
+    async (membershipStatus, expectedError) => {
+      const fixture = await createFixture()
+      const { identity } = await linkIdentity(fixture)
+      if (membershipStatus === 'suspended') {
+        await db
+          .updateTable('organization_memberships')
+          .set({ status: 'suspended' })
+          .where('id', '=', fixture.membership.id)
+          .execute()
+      }
+      const { invite, token } = await createInvite(fixture)
+      const state = await startInvite(fixture, token)
+
+      await expect(completeInvite(state, callbackClient())).resolves.toEqual({
+        ok: false,
+        error: { type: expectedError },
+        return_to: '/invites/complete',
+      })
+      const untouchedInvite = await db
+        .selectFrom('organization_invites')
+        .selectAll()
+        .where('id', '=', invite.id)
+        .executeTakeFirstOrThrow()
+      expect(untouchedInvite.redeemed_at).toBeNull()
+      expect(untouchedInvite.redeemed_membership_id).toBeNull()
+      await expect(
+        db
+          .selectFrom('organization_memberships')
+          .select(({ fn }) => fn.countAll<string>().as('count'))
+          .where('organization_id', '=', fixture.organization.id)
+          .where('user_id', '=', identity.user_id)
+          .executeTakeFirstOrThrow()
+      ).resolves.toMatchObject({ count: '1' })
+    }
+  )
+
+  it('left Membershipは新しいMembershipを作りOIDC Linkを付け替える', async () => {
+    const fixture = await createFixture()
+    const { identity, link: oldLink } = await linkIdentity(fixture)
+    await db
+      .updateTable('organization_memberships')
+      .set({ status: 'left', left_at: new Date('2026-08-10T10:00:00.000Z') })
+      .where('id', '=', fixture.membership.id)
+      .execute()
+    const { token } = await createInvite(fixture)
+    const state = await startInvite(fixture, token)
+
+    await expect(completeInvite(state, callbackClient())).resolves.toMatchObject({ ok: true })
+    const memberships = await db
+      .selectFrom('organization_memberships')
+      .selectAll()
+      .where('organization_id', '=', fixture.organization.id)
+      .where('user_id', '=', fixture.user.id)
+      .orderBy('joined_at')
+      .execute()
+    expect(memberships).toHaveLength(2)
+    expect(memberships).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: fixture.membership.id, status: 'left' }),
+        expect.objectContaining({ status: 'active', left_at: null }),
+      ])
+    )
+    const links = await db
+      .selectFrom('organization_member_oidc_identities')
+      .selectAll()
+      .where('oidc_identity_id', '=', identity.id)
+      .orderBy('created_at')
+      .execute()
+    expect(links).toHaveLength(2)
+    expect(links.find((link) => link.id === oldLink.id)?.revoked_at).toEqual(now)
+    expect(links.find((link) => link.id !== oldLink.id)).toMatchObject({
+      membership_id: memberships.find((membership) => membership.status === 'active')?.id,
+      revoked_at: null,
+    })
+  })
+
+  it('Session UserとOIDC Identity Userが違う場合は自動統合せずInviteを消費しない', async () => {
+    const fixture = await createFixture()
+    await linkIdentity(fixture)
+    const otherUser = await createUser('invite-session-user@example.test')
+    const session = await createSession({ userId: otherUser.id, now }, db)
+    const { invite, token } = await createInvite(fixture)
+    const state = await startInvite(fixture, token, session.token)
+
+    await expect(completeInvite(state, callbackClient(), session.token)).resolves.toEqual({
+      ok: false,
+      error: { type: 'AUTH_IDENTITY_USER_MISMATCH' },
+      return_to: '/invites/complete',
+    })
+    const untouchedInvite = await db
+      .selectFrom('organization_invites')
+      .selectAll()
+      .where('id', '=', invite.id)
+      .executeTakeFirstOrThrow()
+    expect(untouchedInvite.redeemed_at).toBeNull()
+    await expect(
+      db
+        .selectFrom('organization_memberships')
+        .selectAll()
+        .where('organization_id', '=', fixture.organization.id)
+        .where('user_id', '=', otherUser.id)
+        .execute()
+    ).resolves.toEqual([])
+  })
+
+  it('OIDC開始後に取消されたInviteはcallbackで再検証して書き込まない', async () => {
+    const fixture = await createFixture()
+    const { invite, token } = await createInvite(fixture)
+    const state = await startInvite(fixture, token)
+    await db
+      .updateTable('organization_invites')
+      .set({ revoked_at: now })
+      .where('id', '=', invite.id)
+      .execute()
+
+    await expect(
+      completeInvite(
+        state,
+        callbackClient({
+          subject: 'revoked-invite-subject',
+          email: 'revoked-invite@example.test',
+        })
+      )
+    ).resolves.toEqual({
+      ok: false,
+      error: { type: 'INVITE_INVALID' },
+      return_to: '/invites/complete',
+    })
+    await expect(
+      db
+        .selectFrom('oidc_identities')
+        .selectAll()
+        .where('subject', '=', 'revoked-invite-subject')
+        .execute()
+    ).resolves.toEqual([])
   })
 })


### PR DESCRIPTION
## 概要

Organization OIDC callback の `accept_invite` を、single-use Organization Invite の受領処理へ接続します。

## 変更内容

- OIDC検証成功後に、InviteをIDで再取得して行ロックし、有効期限・取消・消費状態・Organizationを再検証
- `issuer + subject` またはOIDC開始時のSession UserだけでUserを確定し、emailによる自動統合を禁止
- User / User Profile / Membership / Member Profile / OIDC Identity Link / Invite消費 / Session Grant / Authentication Eventを1 transactionで確定
- active Membershipは未消費のまま `INVITE_ALREADY_MEMBER`、suspendedは未消費のまま拒否
- left Membershipは新しいMembershipを作り、旧OIDC Linkをrevokeして新Membershipへ付け替え
- 共有Google callback routeへ実際のInvite完了Use Caseを注入

## 影響

OIDC Invite URLを利用した参加が、既存のOIDC検証境界とsingle-use Invite境界を跨いで完了できるようになります。callback replayや開始後に取消されたInviteでは、Membership等を作成しません。

## 確認

- `npm run typecheck`
- `npm run lint`
- `npm test`（88 files / 503 tests）
- `npm run test:db`（31 files / 249 tests）
- OIDC Invite DB integration（13 tests）

Refs #219
