### PR TITLE
Organization認証設定APIを追加

### DIFF
--- a/apps/kaede/src/routes/organizations/auth-settings.test.ts
+++ b/apps/kaede/src/routes/organizations/auth-settings.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import { createRouteTestApp } from '../create-route-test-app.js'
+
+const mocks = vi.hoisted(() => ({
+  getOrganizationAuthSettings: vi.fn(),
+  patchOrganizationAuthSettings: vi.fn(),
+}))
+
+vi.mock('../../usecases/organization-auth-settings/index.js', () => mocks)
+
+import { registerOrganizationAuthSettingsRoutes } from './auth-settings.js'
+
+const organizationId = '11111111-1111-4111-8111-111111111111'
+const response = {
+  organization_id: organizationId,
+  local_auth_enabled: true,
+  oidc_auth_enabled: false,
+  policy_version: 1,
+  membership_grant_ttl_seconds: 28_800,
+  reauthentication_interval_seconds: 14_400,
+  created_at: '2026-08-11T00:00:00.000Z',
+  updated_at: '2026-08-11T00:00:00.000Z',
+}
+const actor: RequestActor = {
+  type: 'user',
+  user_id: '22222222-2222-4222-8222-222222222222',
+  email: 'owner@example.com',
+  global_role: 'none',
+  account_state: 'active',
+  memberships: [{ organization_id: organizationId, organization_name: 'Example', role: 'owner' }],
+}
+
+const app = createRouteTestApp('/organizations', registerOrganizationAuthSettingsRoutes, { actor })
+
+describe('organization auth settings routes', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('GETでowner向け認証設定を返す', async () => {
+    mocks.getOrganizationAuthSettings.mockResolvedValue({ ok: true, value: response })
+
+    const result = await app.request(`/api/organizations/${organizationId}/auth-settings`)
+
+    expect(result.status).toBe(200)
+    await expect(result.json()).resolves.toEqual(response)
+    expect(mocks.getOrganizationAuthSettings).toHaveBeenCalledWith(actor, organizationId)
+  })
+
+  it('PATCHで部分更新requestをusecaseへ渡す', async () => {
+    mocks.patchOrganizationAuthSettings.mockResolvedValue({
+      ok: true,
+      value: { ...response, policy_version: 2, membership_grant_ttl_seconds: 36_000 },
+    })
+
+    const result = await app.request(`/api/organizations/${organizationId}/auth-settings`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ membership_grant_ttl_seconds: 36_000 }),
+    })
+
+    expect(result.status).toBe(200)
+    expect(mocks.patchOrganizationAuthSettings).toHaveBeenCalledWith(actor, organizationId, {
+      membership_grant_ttl_seconds: 36_000,
+    })
+  })
+
+  it('OIDC Provider不足をtyped 422 errorで返す', async () => {
+    mocks.patchOrganizationAuthSettings.mockResolvedValue({
+      ok: false,
+      error: { type: 'OIDC_PROVIDER_REQUIRED' },
+    })
+
+    const result = await app.request(`/api/organizations/${organizationId}/auth-settings`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ oidc_auth_enabled: true }),
+    })
+
+    expect(result.status).toBe(422)
+    await expect(result.json()).resolves.toEqual({
+      error_code: 'OIDC_PROVIDER_REQUIRED',
+      error_message: 'an enabled OIDC provider is required before enabling OIDC',
+    })
+  })
+
+  it('active ownerでなければtyped 403 errorを返す', async () => {
+    mocks.getOrganizationAuthSettings.mockResolvedValue({
+      ok: false,
+      error: { type: 'AUTH_DASHBOARD_FORBIDDEN' },
+    })
+
+    const result = await app.request(`/api/organizations/${organizationId}/auth-settings`)
+
+    expect(result.status).toBe(403)
+    await expect(result.json()).resolves.toEqual({
+      error_code: 'AUTH_DASHBOARD_FORBIDDEN',
+      error_message: 'active owner permission is required',
+    })
+  })
+
+  it('空PATCHを400で拒否してusecaseを呼ばない', async () => {
+    const result = await app.request(`/api/organizations/${organizationId}/auth-settings`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+
+    expect(result.status).toBe(400)
+    expect(mocks.patchOrganizationAuthSettings).not.toHaveBeenCalled()
+  })
+})

--- a/apps/kaede/src/routes/organizations/auth-settings.ts
+++ b/apps/kaede/src/routes/organizations/auth-settings.ts
@@ -1,0 +1,142 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { requireRequestActor } from '../../middleware/request-actor-context.js'
+import type { RequestActorContext } from '../../middleware/request-actor-context.js'
+import { authErrorResponseSchema, errorResponseSchema } from '../../schemas/common.js'
+import {
+  organizationAuthSettingsErrorResponseSchema,
+  organizationAuthSettingsSchema,
+  updateOrganizationAuthSettingsRequestSchema,
+} from '../../schemas/organization-auth-settings.js'
+import { organizationIdParamsSchema } from '../../schemas/organizations.js'
+import {
+  getOrganizationAuthSettings,
+  patchOrganizationAuthSettings,
+} from '../../usecases/organization-auth-settings/index.js'
+
+const commonErrorResponses = {
+  401: {
+    description: 'login required',
+    content: { 'application/json': { schema: authErrorResponseSchema } },
+  },
+  403: {
+    description: 'active owner required',
+    content: { 'application/json': { schema: authErrorResponseSchema } },
+  },
+  404: {
+    description: 'auth settings not found',
+    content: { 'application/json': { schema: organizationAuthSettingsErrorResponseSchema } },
+  },
+} as const
+
+export const registerOrganizationAuthSettingsRoutes = (app: OpenAPIHono) => {
+  const getRoute = createRoute({
+    method: 'get',
+    path: '/{organizationId}/auth-settings',
+    tags: ['Organization Auth'],
+    description: 'active ownerがOrganizationの認証Policyを取得する',
+    request: { params: organizationIdParamsSchema },
+    responses: {
+      200: {
+        description: 'organization auth settings',
+        content: { 'application/json': { schema: organizationAuthSettingsSchema } },
+      },
+      401: commonErrorResponses[401],
+      403: commonErrorResponses[403],
+      404: commonErrorResponses[404],
+    },
+  })
+
+  app.openapi(getRoute, async (c) => {
+    const result = await getOrganizationAuthSettings(
+      requireRequestActor(c as RequestActorContext),
+      c.req.valid('param').organizationId
+    )
+    if (!result.ok) {
+      if (result.error.type === 'AUTH_DASHBOARD_FORBIDDEN') {
+        return c.json(
+          { error_code: result.error.type, error_message: 'active owner permission is required' },
+          403
+        )
+      }
+      return c.json(
+        {
+          error_code: 'ORGANIZATION_AUTH_SETTINGS_NOT_FOUND' as const,
+          error_message: 'organization auth settings not found',
+        },
+        404
+      )
+    }
+    return c.json(result.value, 200)
+  })
+
+  const patchRoute = createRoute({
+    method: 'patch',
+    path: '/{organizationId}/auth-settings',
+    tags: ['Organization Auth'],
+    description: 'active ownerが認証Policyを部分更新する。実質変更時だけpolicy_versionを増加させる',
+    request: {
+      params: organizationIdParamsSchema,
+      body: {
+        required: true,
+        content: { 'application/json': { schema: updateOrganizationAuthSettingsRequestSchema } },
+      },
+    },
+    responses: {
+      200: {
+        description: 'updated organization auth settings',
+        content: { 'application/json': { schema: organizationAuthSettingsSchema } },
+      },
+      400: {
+        description: 'request validation failed',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      401: commonErrorResponses[401],
+      403: commonErrorResponses[403],
+      404: commonErrorResponses[404],
+      422: {
+        description: 'policy invariant violation',
+        content: { 'application/json': { schema: organizationAuthSettingsErrorResponseSchema } },
+      },
+    },
+  })
+
+  app.openapi(patchRoute, async (c) => {
+    const result = await patchOrganizationAuthSettings(
+      requireRequestActor(c as RequestActorContext),
+      c.req.valid('param').organizationId,
+      c.req.valid('json')
+    )
+    if (!result.ok) {
+      if (result.error.type === 'AUTH_DASHBOARD_FORBIDDEN') {
+        return c.json(
+          { error_code: result.error.type, error_message: 'active owner permission is required' },
+          403
+        )
+      }
+      if (result.error.type === 'ORGANIZATION_AUTH_SETTINGS_NOT_FOUND') {
+        return c.json(
+          { error_code: result.error.type, error_message: 'organization auth settings not found' },
+          404
+        )
+      }
+      if (result.error.type === 'OIDC_PROVIDER_REQUIRED') {
+        return c.json(
+          {
+            error_code: result.error.type,
+            error_message: 'an enabled OIDC provider is required before enabling OIDC',
+          },
+          422
+        )
+      }
+      return c.json(
+        {
+          error_code: result.error.type,
+          error_message: 'organization auth settings are invalid',
+        },
+        422
+      )
+    }
+    return c.json(result.value, 200)
+  })
+}

--- a/apps/kaede/src/routes/organizations/index.ts
+++ b/apps/kaede/src/routes/organizations/index.ts
@@ -1,5 +1,6 @@
 import { OpenAPIHono } from '@hono/zod-openapi'
 import { registerAnalysisRunRoutes } from './analysis-runs.js'
+import { registerOrganizationAuthSettingsRoutes } from './auth-settings.js'
 import { registerCreateOrganizationBuildingFloorRoute } from './create-organization-building-floor.js'
 import { registerCreateOrganizationBuildingRoute } from './create-organization-building.js'
 import { registerCreateOrganizationMembershipRoute } from './create-organization-membership.js'
@@ -39,6 +40,7 @@ registerCreateOrganizationUserActivationLinkRoute(organizationsRoutes)
 registerCreateOrganizationMembershipRoute(organizationsRoutes)
 registerCreateStayHeatmapRoute(organizationsRoutes)
 registerAnalysisRunRoutes(organizationsRoutes)
+registerOrganizationAuthSettingsRoutes(organizationsRoutes)
 registerOrganizationMemberProfileRoutes(organizationsRoutes)
 registerOrganizationOidcProviderRoutes(organizationsRoutes)
 registerOrganizationInviteRoutes(organizationsRoutes)

--- a/apps/kaede/src/schemas/organization-auth-settings.ts
+++ b/apps/kaede/src/schemas/organization-auth-settings.ts
@@ -1,0 +1,44 @@
+import { z } from '@hono/zod-openapi'
+import { errorResponseSchema, isoDatetimeSchema, uuidSchema } from './common.js'
+
+const positiveSecondsSchema = z.number().int().positive().max(2_147_483_647)
+
+export const organizationAuthSettingsSchema = z
+  .object({
+    organization_id: uuidSchema,
+    local_auth_enabled: z.boolean(),
+    oidc_auth_enabled: z.boolean(),
+    policy_version: z.number().int().positive(),
+    membership_grant_ttl_seconds: positiveSecondsSchema,
+    reauthentication_interval_seconds: positiveSecondsSchema,
+    created_at: isoDatetimeSchema,
+    updated_at: isoDatetimeSchema,
+  })
+  .openapi('OrganizationAuthSettings')
+
+export const updateOrganizationAuthSettingsRequestSchema = z
+  .object({
+    local_auth_enabled: z.boolean().optional(),
+    oidc_auth_enabled: z.boolean().optional(),
+    membership_grant_ttl_seconds: positiveSecondsSchema.optional(),
+    reauthentication_interval_seconds: positiveSecondsSchema.optional(),
+  })
+  .strict()
+  .refine((value) => Object.keys(value).length > 0, 'at least one field is required')
+  .openapi('UpdateOrganizationAuthSettingsRequest')
+
+export const organizationAuthSettingsErrorCodeSchema = z.enum([
+  'ORGANIZATION_AUTH_SETTINGS_NOT_FOUND',
+  'ORGANIZATION_AUTH_SETTINGS_INVALID',
+  'OIDC_PROVIDER_REQUIRED',
+])
+
+export const organizationAuthSettingsErrorResponseSchema = errorResponseSchema
+  .extend({
+    error_code: organizationAuthSettingsErrorCodeSchema,
+  })
+  .openapi('OrganizationAuthSettingsErrorResponse')
+
+export type UpdateOrganizationAuthSettingsRequest = z.infer<
+  typeof updateOrganizationAuthSettingsRequestSchema
+>

--- a/apps/kaede/src/services/organization-auth-settings/index.ts
+++ b/apps/kaede/src/services/organization-auth-settings/index.ts
@@ -1,0 +1,1 @@
+export * from './repository.js'

--- a/apps/kaede/src/services/organization-auth-settings/repository.ts
+++ b/apps/kaede/src/services/organization-auth-settings/repository.ts
@@ -1,0 +1,95 @@
+import { sql } from 'kysely'
+import type { Insertable, Updateable } from 'kysely'
+import type { AuditEvents, OrganizationAuthSettings } from '../db/generated.js'
+import { db } from '../db/index.js'
+import type { DbExecutor } from '../executor.js'
+
+type OrganizationAuthSettingsUpdate = Pick<
+  Updateable<OrganizationAuthSettings>,
+  | 'local_auth_enabled'
+  | 'oidc_auth_enabled'
+  | 'membership_grant_ttl_seconds'
+  | 'reauthentication_interval_seconds'
+>
+
+export const findOrganizationAuthSettings = async (
+  organizationId: string,
+  executor: DbExecutor = db
+) =>
+  executor
+    .selectFrom('organization_auth_settings')
+    .selectAll()
+    .where('organization_id', '=', organizationId)
+    .executeTakeFirst()
+
+export const findOrganizationAuthSettingsForUpdate = async (
+  organizationId: string,
+  executor: DbExecutor
+) =>
+  executor
+    .selectFrom('organization_auth_settings')
+    .selectAll()
+    .where('organization_id', '=', organizationId)
+    .forUpdate()
+    .executeTakeFirst()
+
+export const findActiveOwnerMembership = async (
+  organizationId: string,
+  userId: string,
+  executor: DbExecutor = db
+) =>
+  executor
+    .selectFrom('organization_memberships')
+    .select(['id'])
+    .where('organization_id', '=', organizationId)
+    .where('user_id', '=', userId)
+    .where('role', '=', 'owner')
+    .where('status', '=', 'active')
+    .executeTakeFirst()
+
+export const findActiveOwnerMembershipForUpdate = async (
+  organizationId: string,
+  userId: string,
+  executor: DbExecutor
+) =>
+  executor
+    .selectFrom('organization_memberships')
+    .select(['id'])
+    .where('organization_id', '=', organizationId)
+    .where('user_id', '=', userId)
+    .where('role', '=', 'owner')
+    .where('status', '=', 'active')
+    .forUpdate()
+    .executeTakeFirst()
+
+export const countEnabledOidcProviders = async (
+  organizationId: string,
+  executor: DbExecutor
+): Promise<number> => {
+  const result = await executor
+    .selectFrom('organization_oidc_providers')
+    .select(sql<number>`count(*)::integer`.as('count'))
+    .where('organization_id', '=', organizationId)
+    .where('enabled', '=', true)
+    .executeTakeFirstOrThrow()
+  return result.count
+}
+
+export const updateOrganizationAuthSettings = async (
+  organizationId: string,
+  settings: OrganizationAuthSettingsUpdate,
+  executor: DbExecutor
+) =>
+  executor
+    .updateTable('organization_auth_settings')
+    .set({ ...settings, policy_version: sql`policy_version + 1` })
+    .where('organization_id', '=', organizationId)
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+export const insertOrganizationAuthSettingsAuditEvent = async (
+  event: Insertable<AuditEvents>,
+  executor: DbExecutor
+) => {
+  await executor.insertInto('audit_events').values(event).execute()
+}

--- a/apps/kaede/src/usecases/organization-auth-settings/index.test.ts
+++ b/apps/kaede/src/usecases/organization-auth-settings/index.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import type { DbExecutor } from '../../services/executor.js'
+
+const mocks = vi.hoisted(() => ({
+  countEnabledOidcProviders: vi.fn(),
+  findActiveOwnerMembership: vi.fn(),
+  findActiveOwnerMembershipForUpdate: vi.fn(),
+  findOrganizationAuthSettings: vi.fn(),
+  findOrganizationAuthSettingsForUpdate: vi.fn(),
+  insertOrganizationAuthSettingsAuditEvent: vi.fn(),
+  updateOrganizationAuthSettings: vi.fn(),
+}))
+
+vi.mock('../../services/organization-auth-settings/index.js', () => mocks)
+vi.mock('../../services/db/index.js', () => ({ db: {} }))
+
+import { getOrganizationAuthSettings, patchOrganizationAuthSettings } from './index.js'
+
+const executor = {} as DbExecutor
+const organizationId = '11111111-1111-4111-8111-111111111111'
+const userId = '22222222-2222-4222-8222-222222222222'
+const membershipId = '33333333-3333-4333-8333-333333333333'
+const createdAt = new Date('2026-08-11T00:00:00.000Z')
+const updatedAt = new Date('2026-08-11T01:00:00.000Z')
+
+const actor: RequestActor = {
+  type: 'user',
+  user_id: userId,
+  email: 'owner@example.com',
+  global_role: 'none',
+  account_state: 'active',
+  memberships: [{ organization_id: organizationId, organization_name: 'Example', role: 'owner' }],
+}
+
+const settings = {
+  organization_id: organizationId,
+  local_auth_enabled: true,
+  oidc_auth_enabled: false,
+  policy_version: '1',
+  membership_grant_ttl_seconds: 28_800,
+  reauthentication_interval_seconds: 14_400,
+  created_at: createdAt,
+  updated_at: createdAt,
+}
+
+describe('organization auth settings usecases', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.findActiveOwnerMembership.mockResolvedValue({ id: membershipId })
+    mocks.findActiveOwnerMembershipForUpdate.mockResolvedValue({ id: membershipId })
+    mocks.findOrganizationAuthSettings.mockResolvedValue(settings)
+    mocks.findOrganizationAuthSettingsForUpdate.mockResolvedValue(settings)
+    mocks.countEnabledOidcProviders.mockResolvedValue(1)
+    mocks.updateOrganizationAuthSettings.mockImplementation((_organizationId, next) =>
+      Promise.resolve({
+        ...settings,
+        ...next,
+        policy_version: '2',
+        updated_at: updatedAt,
+      })
+    )
+  })
+
+  it('active ownerへ認証設定を返す', async () => {
+    await expect(getOrganizationAuthSettings(actor, organizationId, executor)).resolves.toEqual({
+      ok: true,
+      value: {
+        organization_id: organizationId,
+        local_auth_enabled: true,
+        oidc_auth_enabled: false,
+        policy_version: 1,
+        membership_grant_ttl_seconds: 28_800,
+        reauthentication_interval_seconds: 14_400,
+        created_at: createdAt.toISOString(),
+        updated_at: createdAt.toISOString(),
+      },
+    })
+  })
+
+  it('active ownerでなければ取得を拒否する', async () => {
+    mocks.findActiveOwnerMembership.mockResolvedValue(undefined)
+
+    await expect(getOrganizationAuthSettings(actor, organizationId, executor)).resolves.toEqual({
+      ok: false,
+      error: { type: 'AUTH_DASHBOARD_FORBIDDEN' },
+    })
+    expect(mocks.findOrganizationAuthSettings).not.toHaveBeenCalled()
+  })
+
+  it('実質変更時だけpolicy versionを1増加させAuditを記録する', async () => {
+    const result = await patchOrganizationAuthSettings(
+      actor,
+      organizationId,
+      { membership_grant_ttl_seconds: 36_000, reauthentication_interval_seconds: 18_000 },
+      executor
+    )
+
+    expect(result).toMatchObject({ ok: true, value: { policy_version: 2 } })
+    expect(mocks.updateOrganizationAuthSettings).toHaveBeenCalledOnce()
+    expect(mocks.updateOrganizationAuthSettings).toHaveBeenCalledWith(
+      organizationId,
+      {
+        local_auth_enabled: true,
+        oidc_auth_enabled: false,
+        membership_grant_ttl_seconds: 36_000,
+        reauthentication_interval_seconds: 18_000,
+      },
+      executor
+    )
+    expect(mocks.insertOrganizationAuthSettingsAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actor_user_id: userId,
+        actor_membership_id: membershipId,
+        organization_id: organizationId,
+        target_type: 'organization_auth_settings',
+        target_id: organizationId,
+        action: 'update',
+        changed_fields: ['membership_grant_ttl_seconds', 'reauthentication_interval_seconds'],
+        before_values: {
+          membership_grant_ttl_seconds: 28_800,
+          reauthentication_interval_seconds: 14_400,
+          policy_version: 1,
+        },
+        after_values: {
+          membership_grant_ttl_seconds: 36_000,
+          reauthentication_interval_seconds: 18_000,
+          policy_version: 2,
+        },
+      }),
+      executor
+    )
+  })
+
+  it('同じ値へのPATCHではversion更新もAuditも行わない', async () => {
+    const result = await patchOrganizationAuthSettings(
+      actor,
+      organizationId,
+      { local_auth_enabled: true },
+      executor
+    )
+
+    expect(result).toMatchObject({ ok: true, value: { policy_version: 1 } })
+    expect(mocks.updateOrganizationAuthSettings).not.toHaveBeenCalled()
+    expect(mocks.insertOrganizationAuthSettingsAuditEvent).not.toHaveBeenCalled()
+  })
+
+  it('すべての認証方式を無効にできない', async () => {
+    const result = await patchOrganizationAuthSettings(
+      actor,
+      organizationId,
+      { local_auth_enabled: false },
+      executor
+    )
+
+    expect(result).toEqual({
+      ok: false,
+      error: { type: 'ORGANIZATION_AUTH_SETTINGS_INVALID' },
+    })
+    expect(mocks.updateOrganizationAuthSettings).not.toHaveBeenCalled()
+  })
+
+  it('再認証期間がGrant TTLを超える設定を拒否する', async () => {
+    const result = await patchOrganizationAuthSettings(
+      actor,
+      organizationId,
+      { reauthentication_interval_seconds: 28_801 },
+      executor
+    )
+
+    expect(result).toEqual({
+      ok: false,
+      error: { type: 'ORGANIZATION_AUTH_SETTINGS_INVALID' },
+    })
+  })
+
+  it('OIDCを有効化するときはenabled Providerを要求する', async () => {
+    mocks.countEnabledOidcProviders.mockResolvedValue(0)
+
+    const result = await patchOrganizationAuthSettings(
+      actor,
+      organizationId,
+      { oidc_auth_enabled: true },
+      executor
+    )
+
+    expect(result).toEqual({ ok: false, error: { type: 'OIDC_PROVIDER_REQUIRED' } })
+    expect(mocks.updateOrganizationAuthSettings).not.toHaveBeenCalled()
+  })
+
+  it('transaction内の再確認でactive ownerでなければ更新を拒否する', async () => {
+    mocks.findActiveOwnerMembershipForUpdate.mockResolvedValue(undefined)
+
+    const result = await patchOrganizationAuthSettings(
+      actor,
+      organizationId,
+      { membership_grant_ttl_seconds: 36_000 },
+      executor
+    )
+
+    expect(result).toEqual({ ok: false, error: { type: 'AUTH_DASHBOARD_FORBIDDEN' } })
+    expect(mocks.updateOrganizationAuthSettings).not.toHaveBeenCalled()
+  })
+
+  it('認証設定行がなければ404用errorを返す', async () => {
+    mocks.findOrganizationAuthSettingsForUpdate.mockResolvedValue(undefined)
+
+    const result = await patchOrganizationAuthSettings(
+      actor,
+      organizationId,
+      { membership_grant_ttl_seconds: 36_000 },
+      executor
+    )
+
+    expect(result).toEqual({
+      ok: false,
+      error: { type: 'ORGANIZATION_AUTH_SETTINGS_NOT_FOUND' },
+    })
+    expect(mocks.updateOrganizationAuthSettings).not.toHaveBeenCalled()
+  })
+})

--- a/apps/kaede/src/usecases/organization-auth-settings/index.ts
+++ b/apps/kaede/src/usecases/organization-auth-settings/index.ts
@@ -1,0 +1,150 @@
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import type { UpdateOrganizationAuthSettingsRequest } from '../../schemas/organization-auth-settings.js'
+import type { Json } from '../../services/db/index.js'
+import { db } from '../../services/db/index.js'
+import type { DbExecutor } from '../../services/executor.js'
+import {
+  countEnabledOidcProviders,
+  findActiveOwnerMembership,
+  findActiveOwnerMembershipForUpdate,
+  findOrganizationAuthSettings,
+  findOrganizationAuthSettingsForUpdate,
+  insertOrganizationAuthSettingsAuditEvent,
+  updateOrganizationAuthSettings,
+} from '../../services/organization-auth-settings/index.js'
+
+export type OrganizationAuthSettingsError =
+  | { type: 'AUTH_DASHBOARD_FORBIDDEN' }
+  | { type: 'ORGANIZATION_AUTH_SETTINGS_NOT_FOUND' }
+  | { type: 'ORGANIZATION_AUTH_SETTINGS_INVALID' }
+  | { type: 'OIDC_PROVIDER_REQUIRED' }
+
+type Result<T> = { ok: true; value: T } | { ok: false; error: OrganizationAuthSettingsError }
+
+const runInTransaction = async <T>(
+  executor: DbExecutor | undefined,
+  callback: (trx: DbExecutor) => Promise<T>
+): Promise<T> => {
+  const baseExecutor = executor ?? db
+  return 'transaction' in baseExecutor
+    ? baseExecutor.transaction().execute((trx) => callback(trx))
+    : callback(baseExecutor)
+}
+
+const toResponse = (settings: {
+  organization_id: string
+  local_auth_enabled: boolean
+  oidc_auth_enabled: boolean
+  policy_version: string
+  membership_grant_ttl_seconds: number
+  reauthentication_interval_seconds: number
+  created_at: Date
+  updated_at: Date
+}) => ({
+  organization_id: settings.organization_id,
+  local_auth_enabled: settings.local_auth_enabled,
+  oidc_auth_enabled: settings.oidc_auth_enabled,
+  policy_version: Number(settings.policy_version),
+  membership_grant_ttl_seconds: settings.membership_grant_ttl_seconds,
+  reauthentication_interval_seconds: settings.reauthentication_interval_seconds,
+  created_at: settings.created_at.toISOString(),
+  updated_at: settings.updated_at.toISOString(),
+})
+
+const requireUserId = (actor: RequestActor): string | undefined =>
+  actor.type === 'user' ? actor.user_id : undefined
+
+export const getOrganizationAuthSettings = async (
+  actor: RequestActor,
+  organizationId: string,
+  executor: DbExecutor = db
+): Promise<Result<ReturnType<typeof toResponse>>> => {
+  const userId = requireUserId(actor)
+  if (!userId || !(await findActiveOwnerMembership(organizationId, userId, executor))) {
+    return { ok: false, error: { type: 'AUTH_DASHBOARD_FORBIDDEN' } }
+  }
+
+  const settings = await findOrganizationAuthSettings(organizationId, executor)
+  if (!settings) {
+    return { ok: false, error: { type: 'ORGANIZATION_AUTH_SETTINGS_NOT_FOUND' } }
+  }
+  return { ok: true, value: toResponse(settings) }
+}
+
+export const patchOrganizationAuthSettings = async (
+  actor: RequestActor,
+  organizationId: string,
+  payload: UpdateOrganizationAuthSettingsRequest,
+  executor?: DbExecutor
+): Promise<Result<ReturnType<typeof toResponse>>> => {
+  const userId = requireUserId(actor)
+  if (!userId) return { ok: false, error: { type: 'AUTH_DASHBOARD_FORBIDDEN' } }
+
+  return runInTransaction(executor, async (trx) => {
+    // Provider管理を含むowner操作と同じ順序でlockし、role/status変更とも直列化する。
+    const owner = await findActiveOwnerMembershipForUpdate(organizationId, userId, trx)
+    if (!owner) return { ok: false, error: { type: 'AUTH_DASHBOARD_FORBIDDEN' } }
+
+    const current = await findOrganizationAuthSettingsForUpdate(organizationId, trx)
+    if (!current) {
+      return { ok: false, error: { type: 'ORGANIZATION_AUTH_SETTINGS_NOT_FOUND' } }
+    }
+
+    const next = {
+      local_auth_enabled: payload.local_auth_enabled ?? current.local_auth_enabled,
+      oidc_auth_enabled: payload.oidc_auth_enabled ?? current.oidc_auth_enabled,
+      membership_grant_ttl_seconds:
+        payload.membership_grant_ttl_seconds ?? current.membership_grant_ttl_seconds,
+      reauthentication_interval_seconds:
+        payload.reauthentication_interval_seconds ?? current.reauthentication_interval_seconds,
+    }
+
+    if (
+      (!next.local_auth_enabled && !next.oidc_auth_enabled) ||
+      next.membership_grant_ttl_seconds <= 0 ||
+      next.reauthentication_interval_seconds <= 0 ||
+      next.reauthentication_interval_seconds > next.membership_grant_ttl_seconds
+    ) {
+      return { ok: false, error: { type: 'ORGANIZATION_AUTH_SETTINGS_INVALID' } }
+    }
+
+    if (
+      !current.oidc_auth_enabled &&
+      next.oidc_auth_enabled &&
+      (await countEnabledOidcProviders(organizationId, trx)) === 0
+    ) {
+      return { ok: false, error: { type: 'OIDC_PROVIDER_REQUIRED' } }
+    }
+
+    const changedFields = (Object.keys(next) as (keyof typeof next)[]).filter(
+      (field) => current[field] !== next[field]
+    )
+    if (changedFields.length === 0) return { ok: true, value: toResponse(current) }
+
+    const updated = await updateOrganizationAuthSettings(organizationId, next, trx)
+    const beforeValues = Object.fromEntries(changedFields.map((field) => [field, current[field]]))
+    const afterValues = Object.fromEntries(changedFields.map((field) => [field, updated[field]]))
+    await insertOrganizationAuthSettingsAuditEvent(
+      {
+        actor_user_id: userId,
+        actor_membership_id: owner.id,
+        organization_id: organizationId,
+        target_type: 'organization_auth_settings',
+        target_id: organizationId,
+        action: 'update',
+        changed_fields: changedFields,
+        before_values: {
+          ...beforeValues,
+          policy_version: Number(current.policy_version),
+        } as Json,
+        after_values: {
+          ...afterValues,
+          policy_version: Number(updated.policy_version),
+        } as Json,
+      },
+      trx
+    )
+
+    return { ok: true, value: toResponse(updated) }
+  })
+}

--- a/apps/kaede/tests/services/organization-auth-settings/organization-auth-settings.test.ts
+++ b/apps/kaede/tests/services/organization-auth-settings/organization-auth-settings.test.ts
@@ -1,0 +1,172 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import type { RequestActor } from '../../../src/middleware/request-actor-context.js'
+import { createDb } from '../../../src/services/db/client.js'
+import { patchOrganizationAuthSettings } from '../../../src/usecases/organization-auth-settings/index.js'
+import { resetDatabase } from '../../db/helpers.js'
+
+const db = createDb()
+const passwordHash =
+  '$argon2id$v=19$m=65536,t=3,p=4$ZHVtbXk$zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'
+
+const createFixture = async () => {
+  const owner = await db
+    .insertInto('users')
+    .values({
+      email: 'auth-settings-owner@example.com',
+      display_name: 'Auth Settings Owner',
+      password_hash: null,
+      global_role: 'none',
+      status: 'active',
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const organization = await db
+    .insertInto('organizations')
+    .values({ name: 'Auth Settings Organization', slug: 'auth-settings-org' })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const membership = await db
+    .insertInto('organization_memberships')
+    .values({
+      organization_id: organization.id,
+      user_id: owner.id,
+      role: 'owner',
+      status: 'active',
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  if (!membership.id) throw new Error('membership id is required')
+  await db
+    .insertInto('organization_auth_settings')
+    .values({
+      organization_id: organization.id,
+      local_auth_enabled: true,
+      oidc_auth_enabled: false,
+      membership_grant_ttl_seconds: 28_800,
+      reauthentication_interval_seconds: 14_400,
+    })
+    .execute()
+  const credential = await db
+    .insertInto('organization_local_credentials')
+    .values({
+      membership_id: membership.id,
+      organization_id: organization.id,
+      login_email: owner.email,
+      normalized_login_email: owner.email,
+      password_hash: passwordHash,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const session = await db
+    .insertInto('sessions')
+    .values({
+      user_id: owner.id,
+      session_hash: 'auth-settings-session-hash',
+      expires_at: new Date('2026-08-13T00:00:00.000Z'),
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  await db
+    .insertInto('session_membership_authentications')
+    .values({
+      session_id: session.id,
+      membership_id: membership.id,
+      user_id: owner.id,
+      auth_method: 'local',
+      policy_version: 1,
+      local_credential_id: credential.id,
+      member_oidc_identity_id: null,
+      authenticated_at: new Date('2026-08-11T00:00:00.000Z'),
+      expires_at: new Date('2026-08-12T00:00:00.000Z'),
+    })
+    .execute()
+
+  const actor: RequestActor = {
+    type: 'user',
+    user_id: owner.id,
+    email: owner.email,
+    global_role: 'none',
+    account_state: 'active',
+    memberships: [
+      {
+        organization_id: organization.id,
+        organization_name: organization.name,
+        role: 'owner',
+      },
+    ],
+  }
+  return { actor, membership, organization, session }
+}
+
+describe('organization auth settings with database', () => {
+  beforeEach(async () => resetDatabase(db))
+  afterAll(async () => db.destroy())
+
+  it('PolicyとversionとAuditを同時に更新し、既存Grantは一括更新しない', async () => {
+    const fixture = await createFixture()
+
+    const result = await patchOrganizationAuthSettings(
+      fixture.actor,
+      fixture.organization.id,
+      { membership_grant_ttl_seconds: 36_000, reauthentication_interval_seconds: 18_000 },
+      db
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        policy_version: 2,
+        membership_grant_ttl_seconds: 36_000,
+        reauthentication_interval_seconds: 18_000,
+      },
+    })
+    const stored = await db
+      .selectFrom('organization_auth_settings')
+      .selectAll()
+      .where('organization_id', '=', fixture.organization.id)
+      .executeTakeFirstOrThrow()
+    expect(stored.policy_version).toBe('2')
+
+    const grant = await db
+      .selectFrom('session_membership_authentications')
+      .select(['policy_version', 'revoked_at'])
+      .where('session_id', '=', fixture.session.id)
+      .executeTakeFirstOrThrow()
+    expect(grant).toMatchObject({ policy_version: '1', revoked_at: null })
+
+    const event = await db
+      .selectFrom('audit_events')
+      .selectAll()
+      .where('organization_id', '=', fixture.organization.id)
+      .where('target_type', '=', 'organization_auth_settings')
+      .executeTakeFirstOrThrow()
+    expect(event).toMatchObject({
+      actor_user_id: fixture.actor.user_id,
+      actor_membership_id: fixture.membership.id,
+      action: 'update',
+      changed_fields: ['membership_grant_ttl_seconds', 'reauthentication_interval_seconds'],
+    })
+  })
+
+  it('enabled Providerがない状態ではOIDC master switchを有効化しない', async () => {
+    const fixture = await createFixture()
+
+    await expect(
+      patchOrganizationAuthSettings(
+        fixture.actor,
+        fixture.organization.id,
+        { oidc_auth_enabled: true },
+        db
+      )
+    ).resolves.toEqual({ ok: false, error: { type: 'OIDC_PROVIDER_REQUIRED' } })
+
+    const stored = await db
+      .selectFrom('organization_auth_settings')
+      .select(['oidc_auth_enabled', 'policy_version'])
+      .where('organization_id', '=', fixture.organization.id)
+      .executeTakeFirstOrThrow()
+    expect(stored).toEqual({ oidc_auth_enabled: false, policy_version: '1' })
+    const events = await db.selectFrom('audit_events').select('id').execute()
+    expect(events).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Closes #219

## 変更内容

- active owner限定の `GET /api/organizations/{organizationId}/auth-settings` を追加
- active owner限定の `PATCH /api/organizations/{organizationId}/auth-settings` を追加
- Local/OIDCの少なくとも一方を必須化し、TTL・再認証期間を検証
- OIDC有効化時にenabled Providerを要求
- 設定行とactor Membershipをlockし、実質変更時だけ `policy_version` を1増加
- Policy変更をAudit Eventへ同一transactionで記録
- 既存Membership Grantは更新せず、version不一致で無効化できる状態を維持
- typed OpenAPI response/error schema、Route/UseCase/DB統合テストを追加

## 影響

Organization ownerが認証Policyを取得・部分更新できるようになります。同じ値へのPATCHではversionやAudit Eventを増やしません。

## 確認

- `pnpm test`: 90 files / 517 tests passed
- `pnpm typecheck`
- `pnpm lint`
- PostgreSQL統合テスト: 1 file / 2 tests passed