### PR TITLE
Complete organization auth read contract

### DIFF
--- a/apps/kaede/src/middleware/organization-authorization.test.ts
+++ b/apps/kaede/src/middleware/organization-authorization.test.ts
@@ -19,13 +19,17 @@ const now = new Date('2026-08-11T12:00:00.000Z')
 
 const activeContext = {
   organization_id: organizationId,
+  organization_name: 'Example',
+  organization_slug: 'example',
   membership_id: membershipId,
   membership_role: 'manager',
   membership_status: 'active',
   membership_left_at: null,
   organization_status: 'active',
+  auth_settings_available: true,
   local_auth_enabled: true,
   oidc_auth_enabled: true,
+  has_enabled_oidc_provider: true,
   current_policy_version: '2',
   reauthentication_interval_seconds: 7200,
   grant_auth_method: 'local',

--- a/apps/kaede/src/routes/auth/error.ts
+++ b/apps/kaede/src/routes/auth/error.ts
@@ -1,6 +1,6 @@
 import { toAuthErrorResponse as toCommonAuthErrorResponse } from '../../schemas/common.js'
 import type { AuthErrorCode } from '../../schemas/common.js'
 
-export const toAuthErrorResponse = (error: { type: AuthErrorCode }) => {
+export const toAuthErrorResponse = <TCode extends AuthErrorCode>(error: { type: TCode }) => {
   return toCommonAuthErrorResponse(error.type)
 }

--- a/apps/kaede/src/routes/auth/me.ts
+++ b/apps/kaede/src/routes/auth/me.ts
@@ -1,7 +1,10 @@
 import { createRoute } from '@hono/zod-openapi'
 import type { OpenAPIHono } from '@hono/zod-openapi'
-import { authUserResponseSchema } from '../../schemas/auth.js'
-import { errorResponseSchema } from '../../schemas/common.js'
+import { authMeResponseSchema } from '../../schemas/auth.js'
+import {
+  globalSessionErrorResponseSchema,
+  userAccountErrorResponseSchema,
+} from '../../schemas/common.js'
 import { getMe } from '../../usecases/auth/index.js'
 import { getSessionTokenFromCookie } from './cookie.js'
 import { toAuthErrorResponse } from './error.js'
@@ -17,7 +20,7 @@ export const registerMeRoute = (app: OpenAPIHono) => {
         description: 'current user',
         content: {
           'application/json': {
-            schema: authUserResponseSchema,
+            schema: authMeResponseSchema,
           },
         },
       },
@@ -25,7 +28,7 @@ export const registerMeRoute = (app: OpenAPIHono) => {
         description: 'login required',
         content: {
           'application/json': {
-            schema: errorResponseSchema,
+            schema: globalSessionErrorResponseSchema,
           },
         },
       },
@@ -33,7 +36,7 @@ export const registerMeRoute = (app: OpenAPIHono) => {
         description: 'user disabled',
         content: {
           'application/json': {
-            schema: errorResponseSchema,
+            schema: userAccountErrorResponseSchema,
           },
         },
       },
@@ -44,6 +47,11 @@ export const registerMeRoute = (app: OpenAPIHono) => {
     const result = await getMe(getSessionTokenFromCookie(c))
 
     if (!result.ok) {
+      if (result.error.type === 'AUTH_USER_DISABLED') {
+        const error = toAuthErrorResponse(result.error)
+        return c.json(error.body, error.status)
+      }
+
       const error = toAuthErrorResponse(result.error)
       return c.json(error.body, error.status)
     }

--- a/apps/kaede/src/routes/organization-auth-methods/index.ts
+++ b/apps/kaede/src/routes/organization-auth-methods/index.ts
@@ -1,0 +1,6 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { registerOrganizationAuthMethodsRoute } from './methods.js'
+
+export const organizationAuthMethodsRoutes = new OpenAPIHono()
+
+registerOrganizationAuthMethodsRoute(organizationAuthMethodsRoutes)

--- a/apps/kaede/src/routes/organization-auth-methods/methods.test.ts
+++ b/apps/kaede/src/routes/organization-auth-methods/methods.test.ts
@@ -1,0 +1,63 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { registerOrganizationAuthMethodsRoute } from './methods.js'
+
+const { getPublicOrganizationAuthMethodsMock } = vi.hoisted(() => ({
+  getPublicOrganizationAuthMethodsMock: vi.fn(),
+}))
+
+vi.mock('../../usecases/organization-auth-methods/index.js', () => ({
+  getPublicOrganizationAuthMethods: getPublicOrganizationAuthMethodsMock,
+}))
+
+const createApp = () => {
+  const app = new OpenAPIHono()
+  const routes = new OpenAPIHono()
+  registerOrganizationAuthMethodsRoute(routes)
+  app.route('/api/organizations', routes)
+  return app
+}
+
+describe('GET /api/organizations/:organizationSlug/auth/methods', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('secretやOrganization metadataを含めずLocal可否と有効OIDC providerだけを返す', async () => {
+    getPublicOrganizationAuthMethodsMock.mockResolvedValue({
+      local_auth_enabled: true,
+      allowed_auth_methods: ['local', 'oidc'],
+      oidc_providers: [
+        { id: '11111111-1111-4111-8111-111111111111', display_name: 'Google Workspace' },
+      ],
+    })
+
+    const response = await createApp().request('/api/organizations/example-org/auth/methods')
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    await expect(response.json()).resolves.toEqual({
+      local_auth_enabled: true,
+      allowed_auth_methods: ['local', 'oidc'],
+      oidc_providers: [
+        { id: '11111111-1111-4111-8111-111111111111', display_name: 'Google Workspace' },
+      ],
+    })
+    expect(getPublicOrganizationAuthMethodsMock).toHaveBeenCalledWith('example-org')
+  })
+
+  it('不存在・停止Organizationにも同じ空responseを返してslug enumerationを抑える', async () => {
+    getPublicOrganizationAuthMethodsMock.mockResolvedValue({
+      local_auth_enabled: false,
+      allowed_auth_methods: [],
+      oidc_providers: [],
+    })
+
+    const response = await createApp().request('/api/organizations/unknown-org/auth/methods')
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      local_auth_enabled: false,
+      allowed_auth_methods: [],
+      oidc_providers: [],
+    })
+  })
+})

--- a/apps/kaede/src/routes/organization-auth-methods/methods.ts
+++ b/apps/kaede/src/routes/organization-auth-methods/methods.ts
@@ -1,0 +1,29 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import {
+  organizationAuthMethodsParamsSchema,
+  organizationAuthMethodsResponseSchema,
+} from '../../schemas/organization-auth-methods.js'
+import { getPublicOrganizationAuthMethods } from '../../usecases/organization-auth-methods/index.js'
+
+export const registerOrganizationAuthMethodsRoute = (app: OpenAPIHono) => {
+  const route = createRoute({
+    method: 'get',
+    path: '/{organizationSlug}/auth/methods',
+    tags: ['Organization Auth'],
+    description: '認証前または再認証時に利用可能な最小限のOrganization認証方式を返す',
+    request: { params: organizationAuthMethodsParamsSchema },
+    responses: {
+      200: {
+        description: 'public organization authentication methods',
+        content: { 'application/json': { schema: organizationAuthMethodsResponseSchema } },
+      },
+    },
+  })
+
+  app.openapi(route, async (c) => {
+    const response = await getPublicOrganizationAuthMethods(c.req.valid('param').organizationSlug)
+    c.header('Cache-Control', 'no-store')
+    return c.json(response, 200)
+  })
+}

--- a/apps/kaede/src/schemas/auth.ts
+++ b/apps/kaede/src/schemas/auth.ts
@@ -67,6 +67,70 @@ export const authUserResponseSchema = z
   })
   .openapi('AuthUserResponse')
 
+export const authMeGrantStateSchema = z
+  .discriminatedUnion('status', [
+    z.object({
+      status: z.literal('granted'),
+      reason: z.null(),
+      auth_method: z.enum(['local', 'oidc']),
+      authenticated_at: isoDatetimeSchema,
+      reauthentication_required_at: isoDatetimeSchema,
+      expires_at: isoDatetimeSchema,
+      effective_expires_at: isoDatetimeSchema,
+    }),
+    z.object({
+      status: z.literal('reauthentication_required'),
+      reason: z.enum([
+        'grant_missing',
+        'grant_revoked',
+        'grant_expired',
+        'reauthentication_interval_elapsed',
+        'policy_changed',
+        'auth_method_not_allowed',
+      ]),
+      auth_method: z.enum(['local', 'oidc']).nullable(),
+      authenticated_at: isoDatetimeSchema.nullable(),
+      reauthentication_required_at: isoDatetimeSchema.nullable(),
+      expires_at: isoDatetimeSchema.nullable(),
+      effective_expires_at: isoDatetimeSchema.nullable(),
+    }),
+    z.object({
+      status: z.literal('forbidden'),
+      reason: z.enum([
+        'membership_suspended',
+        'organization_unavailable',
+        'auth_settings_unavailable',
+      ]),
+      auth_method: z.null(),
+      authenticated_at: z.null(),
+      reauthentication_required_at: z.null(),
+      expires_at: z.null(),
+      effective_expires_at: z.null(),
+    }),
+  ])
+  .openapi('AuthMeGrantState')
+
+export const authMeMembershipSchema = z
+  .object({
+    membership_id: uuidSchema,
+    organization_id: uuidSchema,
+    organization_name: z.string().min(1).max(255),
+    organization_slug: z.string().min(1).max(63),
+    role: membershipRoleSchema,
+    status: z.enum(['active', 'suspended']),
+    allowed_auth_methods: z.array(z.enum(['local', 'oidc'])),
+    grant_state: authMeGrantStateSchema,
+  })
+  .openapi('AuthMeMembership')
+
+export const authMeResponseSchema = authUserResponseSchema
+  .extend({
+    user: authUserSchema.extend({
+      memberships: z.array(authMeMembershipSchema),
+    }),
+  })
+  .openapi('AuthMeResponse')
+
 export const changePasswordRequestSchema = z
   .object({
     current_password: z.string().min(1).max(100),
@@ -112,5 +176,6 @@ export type ActivationCompleteRequest = z.infer<typeof activationCompleteRequest
 export type ActivationVerifyRequest = z.infer<typeof activationVerifyRequestSchema>
 export type ActivationVerifyResponse = z.infer<typeof activationVerifyResponseSchema>
 export type AuthUserResponse = z.infer<typeof authUserResponseSchema>
+export type AuthMeResponse = z.infer<typeof authMeResponseSchema>
 export type ChangePasswordRequest = z.infer<typeof changePasswordRequestSchema>
 export type LoginRequest = z.infer<typeof loginRequestSchema>

--- a/apps/kaede/src/schemas/common.ts
+++ b/apps/kaede/src/schemas/common.ts
@@ -124,7 +124,52 @@ export const authErrorResponseSchema = errorResponseSchema
   })
   .openapi('AuthErrorResponse')
 
-export const authErrorMessages: Record<AuthErrorCode, string> = {
+const authErrorVariant = <TCode extends AuthErrorCode>(errorCode: TCode) =>
+  z.object({
+    error_code: z.literal(errorCode),
+    error_message: z.string().min(1),
+    details: z.record(z.string(), z.unknown()).optional(),
+  })
+
+export const globalSessionErrorResponseSchema = z
+  .discriminatedUnion('error_code', [
+    authErrorVariant('AUTH_UNAUTHENTICATED'),
+    authErrorVariant('AUTH_SESSION_EXPIRED'),
+    authErrorVariant('AUTH_SESSION_REVOKED'),
+  ])
+  .openapi('GlobalSessionErrorResponse')
+
+export const userAccountErrorResponseSchema = authErrorVariant('AUTH_USER_DISABLED').openapi(
+  'UserAccountErrorResponse'
+)
+
+export const organizationAuthorizationErrorResponseSchema = z
+  .discriminatedUnion('error_code', [
+    authErrorVariant('AUTH_USER_DISABLED'),
+    authErrorVariant('AUTH_PASSWORD_CHANGE_REQUIRED'),
+    authErrorVariant('AUTH_DASHBOARD_FORBIDDEN'),
+    authErrorVariant('AUTH_ORGANIZATION_FORBIDDEN'),
+    z.object({
+      error_code: z.literal('AUTH_MEMBERSHIP_REAUTHENTICATION_REQUIRED'),
+      error_message: z.string().min(1),
+      details: z.object({
+        organization_id: uuidSchema,
+        membership_id: uuidSchema,
+        reason: z.enum([
+          'grant_missing',
+          'grant_revoked',
+          'grant_expired',
+          'reauthentication_interval_elapsed',
+          'policy_changed',
+          'auth_method_not_allowed',
+        ]),
+        allowed_auth_methods: z.array(z.enum(['local', 'oidc'])),
+      }),
+    }),
+  ])
+  .openapi('OrganizationAuthorizationErrorResponse')
+
+export const authErrorMessages = {
   AUTH_DASHBOARD_FORBIDDEN: 'dashboard access forbidden',
   AUTH_ACTIVATION_TOKEN_INVALID: 'activation token is invalid',
   AUTH_INVALID_CREDENTIALS: 'invalid email or password',
@@ -137,9 +182,9 @@ export const authErrorMessages: Record<AuthErrorCode, string> = {
   AUTH_UNAUTHENTICATED: 'login required',
   AUTH_USER_DISABLED: 'user is disabled',
   AUTH_USER_LOCKED: 'account is locked due to too many failed attempts',
-}
+} as const satisfies Record<AuthErrorCode, string>
 
-export const authErrorStatuses: Record<AuthErrorCode, 401 | 403> = {
+export const authErrorStatuses = {
   AUTH_DASHBOARD_FORBIDDEN: 403,
   AUTH_ACTIVATION_TOKEN_INVALID: 401,
   AUTH_INVALID_CREDENTIALS: 401,
@@ -152,9 +197,9 @@ export const authErrorStatuses: Record<AuthErrorCode, 401 | 403> = {
   AUTH_UNAUTHENTICATED: 401,
   AUTH_USER_DISABLED: 403,
   AUTH_USER_LOCKED: 403,
-}
+} as const satisfies Record<AuthErrorCode, 401 | 403>
 
-export const toAuthErrorResponse = (errorCode: AuthErrorCode) => {
+export const toAuthErrorResponse = <TCode extends AuthErrorCode>(errorCode: TCode) => {
   return {
     body: {
       error_code: errorCode,

--- a/apps/kaede/src/schemas/organization-auth-methods.ts
+++ b/apps/kaede/src/schemas/organization-auth-methods.ts
@@ -1,0 +1,22 @@
+import { z } from '@hono/zod-openapi'
+import { uuidSchema } from './common.js'
+import { organizationSlugSchema } from './organizations.js'
+
+export const organizationAuthMethodsParamsSchema = z.object({
+  organizationSlug: organizationSlugSchema,
+})
+
+export const organizationAuthMethodsResponseSchema = z
+  .object({
+    local_auth_enabled: z.boolean(),
+    allowed_auth_methods: z.array(z.enum(['local', 'oidc'])),
+    oidc_providers: z.array(
+      z.object({
+        id: uuidSchema,
+        display_name: z.string().min(1).max(255),
+      })
+    ),
+  })
+  .openapi('OrganizationAuthMethodsResponse')
+
+export type OrganizationAuthMethodsResponse = z.infer<typeof organizationAuthMethodsResponseSchema>

--- a/apps/kaede/src/server.test.ts
+++ b/apps/kaede/src/server.test.ts
@@ -84,6 +84,68 @@ describe('createApp auth wiring', { timeout: 60_000 }, () => {
     })
   })
 
+  it('OpenAPIでglobal session 401とmembership 403を別schemaとして公開する', async () => {
+    const app = await createTestApp()
+
+    const response = await app.request('/specification')
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      paths: {
+        '/api/auth/me': {
+          get: {
+            responses: {
+              '401': {
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/GlobalSessionErrorResponse' },
+                  },
+                },
+              },
+              '403': {
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/UserAccountErrorResponse' },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/api/organizations/{organizationSlug}/auth/methods': {
+          get: {
+            responses: {
+              '200': {
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/OrganizationAuthMethodsResponse' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          GlobalSessionErrorResponse: expect.any(Object),
+          OrganizationAuthorizationErrorResponse: expect.objectContaining({
+            oneOf: expect.arrayContaining([
+              expect.objectContaining({
+                properties: expect.objectContaining({
+                  error_code: {
+                    type: 'string',
+                    enum: ['AUTH_MEMBERSHIP_REAUTHENTICATION_REQUIRED'],
+                  },
+                }),
+              }),
+            ]),
+          }),
+        },
+      },
+    })
+  })
+
   it('FRONTEND_ORIGIN があれば credential 付き CORS preflight を許可する', async () => {
     process.env.FRONTEND_ORIGIN = 'https://mio.example.test'
     resetRuntimeConfigForTests()

--- a/apps/kaede/src/server.ts
+++ b/apps/kaede/src/server.ts
@@ -7,13 +7,20 @@ import { getRuntimeConfig } from './config/runtime.js'
 import { organizationAuthorizationMiddleware } from './middleware/organization-authorization.js'
 import { requestActorMiddleware } from './middleware/request-actor.js'
 import { registerApiRoutes } from './routes/index.js'
+import { organizationAuthMethodsRoutes } from './routes/organization-auth-methods/index.js'
 import { organizationInvitesRoutes } from './routes/organization-invites/index.js'
 import { organizationLocalAuthRoutes } from './routes/organization-local-auth/index.js'
 import { organizationOidcAuthRoutes } from './routes/organization-oidc-auth/index.js'
 import { organizationSessionAuthRoutes } from './routes/organization-session-auth/index.js'
+import { organizationAuthorizationErrorResponseSchema } from './schemas/common.js'
 
 export const createApp = () => {
   const app = new OpenAPIHono()
+  // Middleware responseは個別route handlerに紐づかないため、Mio向けcomponentを明示登録する。
+  app.openAPIRegistry.register(
+    'OrganizationAuthorizationErrorResponse',
+    organizationAuthorizationErrorResponseSchema
+  )
   const runtimeConfig = getRuntimeConfig()
   const deployRef = runtimeConfig.app.deployRef
   const revision = runtimeConfig.app.revision
@@ -42,6 +49,8 @@ export const createApp = () => {
   app.route('/api/organizations', organizationOidcAuthRoutes)
   // Grantが失効済みでも対象Organizationからlogoutできるよう、Membership Guardより前に手動でSessionを検証する。
   app.route('/api/organizations', organizationSessionAuthRoutes)
+  // 認証前にも必要なため、global Session / Membership grant middlewareより先に公開する。
+  app.route('/api/organizations', organizationAuthMethodsRoutes)
   // 招待確認・Local招待受領はSessionなしでも利用する。
   app.route('/api/invites', organizationInvitesRoutes)
 

--- a/apps/kaede/src/services/organization-auth-methods/index.ts
+++ b/apps/kaede/src/services/organization-auth-methods/index.ts
@@ -1,0 +1,1 @@
+export { findPublicOrganizationAuthMethodRows } from './repository.js'

--- a/apps/kaede/src/services/organization-auth-methods/repository.ts
+++ b/apps/kaede/src/services/organization-auth-methods/repository.ts
@@ -1,0 +1,29 @@
+import { db } from '../db/index.js'
+import type { DbExecutor } from '../executor.js'
+
+export const findPublicOrganizationAuthMethodRows = async (
+  organizationSlug: string,
+  executor: DbExecutor = db
+) =>
+  executor
+    .selectFrom('organizations as organization')
+    .innerJoin(
+      'organization_auth_settings as settings',
+      'settings.organization_id',
+      'organization.id'
+    )
+    .leftJoin('organization_oidc_providers as provider', (join) =>
+      join
+        .onRef('provider.organization_id', '=', 'organization.id')
+        .on('provider.enabled', '=', true)
+    )
+    .select([
+      'settings.local_auth_enabled',
+      'settings.oidc_auth_enabled',
+      'provider.id as provider_id',
+      'provider.name as provider_display_name',
+    ])
+    .where('organization.slug', '=', organizationSlug)
+    .where('organization.status', '=', 'active')
+    .orderBy('provider.created_at', 'asc')
+    .execute()

--- a/apps/kaede/src/services/organization-authorization/authorization.ts
+++ b/apps/kaede/src/services/organization-authorization/authorization.ts
@@ -16,7 +16,9 @@ export type MembershipGrantAuthorization =
       role: MembershipRole
       authMethod: MembershipGrantAuthMethod
       authenticatedAt: Date
+      reauthenticationRequiredAt: Date
       expiresAt: Date
+      effectiveExpiresAt: Date
     }
   | { ok: false; type: 'organization_forbidden' }
   | { ok: false; type: 'role_forbidden'; membershipId: string }
@@ -36,10 +38,12 @@ const roleRanks = {
 
 const isMembershipRole = (role: string): role is MembershipRole => role in roleRanks
 
-const allowedAuthMethods = (context: MembershipGrantContext): MembershipGrantAuthMethod[] => {
+export const membershipAllowedAuthMethods = (
+  context: MembershipGrantContext
+): MembershipGrantAuthMethod[] => {
   const methods: MembershipGrantAuthMethod[] = []
   if (context.local_auth_enabled) methods.push('local')
-  if (context.oidc_auth_enabled) methods.push('oidc')
+  if (context.oidc_auth_enabled && context.has_enabled_oidc_provider) methods.push('oidc')
   return methods
 }
 
@@ -50,6 +54,7 @@ export const evaluateMembershipGrant = (
 ): MembershipGrantAuthorization => {
   if (
     context?.organization_status !== 'active' ||
+    !context.auth_settings_available ||
     context.membership_status !== 'active' ||
     context.membership_left_at !== null ||
     !isMembershipRole(context.membership_role)
@@ -64,14 +69,15 @@ export const evaluateMembershipGrant = (
     type: 'reauthentication_required',
     membershipId: context.membership_id,
     reason,
-    allowedAuthMethods: allowedAuthMethods(context),
+    allowedAuthMethods: membershipAllowedAuthMethods(context),
   })
 
   if (
     !context.grant_auth_method ||
     !context.grant_policy_version ||
     !context.grant_authenticated_at ||
-    !context.grant_expires_at
+    !context.grant_expires_at ||
+    context.reauthentication_interval_seconds === null
   ) {
     return reauthenticationRequired('grant_missing')
   }
@@ -105,12 +111,21 @@ export const evaluateMembershipGrant = (
     return { ok: false, type: 'role_forbidden', membershipId: context.membership_id }
   }
 
+  const reauthenticationRequiredAt = new Date(
+    context.grant_authenticated_at.getTime() + context.reauthentication_interval_seconds * 1000
+  )
+
   return {
     ok: true,
     membershipId: context.membership_id,
     role: context.membership_role,
     authMethod: context.grant_auth_method as MembershipGrantAuthMethod,
     authenticatedAt: context.grant_authenticated_at,
+    reauthenticationRequiredAt,
     expiresAt: context.grant_expires_at,
+    effectiveExpiresAt:
+      reauthenticationRequiredAt <= context.grant_expires_at
+        ? reauthenticationRequiredAt
+        : context.grant_expires_at,
   }
 }

--- a/apps/kaede/src/services/organization-authorization/index.ts
+++ b/apps/kaede/src/services/organization-authorization/index.ts
@@ -1,4 +1,4 @@
-export { evaluateMembershipGrant } from './authorization.js'
+export { evaluateMembershipGrant, membershipAllowedAuthMethods } from './authorization.js'
 export type {
   MembershipGrantAuthorization,
   MembershipReauthenticationReason,

--- a/apps/kaede/src/services/organization-authorization/repository.ts
+++ b/apps/kaede/src/services/organization-authorization/repository.ts
@@ -1,3 +1,4 @@
+import { sql } from 'kysely'
 import { db } from '../db/index.js'
 import type { DbExecutor } from '../executor.js'
 
@@ -5,15 +6,19 @@ export type MembershipGrantAuthMethod = 'local' | 'oidc'
 
 export interface MembershipGrantContext {
   organization_id: string
+  organization_name: string
+  organization_slug: string
   membership_id: string
   membership_role: string
   membership_status: string
   membership_left_at: Date | null
   organization_status: string | null
-  local_auth_enabled: boolean
-  oidc_auth_enabled: boolean
-  current_policy_version: string
-  reauthentication_interval_seconds: number
+  auth_settings_available: boolean
+  local_auth_enabled: boolean | null
+  oidc_auth_enabled: boolean | null
+  has_enabled_oidc_provider: boolean
+  current_policy_version: string | null
+  reauthentication_interval_seconds: number | null
   grant_auth_method: string | null
   grant_policy_version: string | null
   grant_authenticated_at: Date | null
@@ -28,7 +33,7 @@ const membershipGrantContextQuery = (sessionId: string, userId: string, executor
   executor
     .selectFrom('organization_memberships as membership')
     .innerJoin('organizations as organization', 'organization.id', 'membership.organization_id')
-    .innerJoin(
+    .leftJoin(
       'organization_auth_settings as auth_settings',
       'auth_settings.organization_id',
       'membership.organization_id'
@@ -54,13 +59,22 @@ const membershipGrantContextQuery = (sessionId: string, userId: string, executor
     )
     .select([
       'membership.organization_id',
+      'organization.name as organization_name',
+      'organization.slug as organization_slug',
       'membership.id as membership_id',
       'membership.role as membership_role',
       'membership.status as membership_status',
       'membership.left_at as membership_left_at',
       'organization.status as organization_status',
+      sql<boolean>`auth_settings.organization_id IS NOT NULL`.as('auth_settings_available'),
       'auth_settings.local_auth_enabled',
       'auth_settings.oidc_auth_enabled',
+      sql<boolean>`EXISTS (
+        SELECT 1
+        FROM organization_oidc_providers AS available_provider
+        WHERE available_provider.organization_id = membership.organization_id
+          AND available_provider.enabled = true
+      )`.as('has_enabled_oidc_provider'),
       'auth_settings.policy_version as current_policy_version',
       'auth_settings.reauthentication_interval_seconds',
       'grant.auth_method as grant_auth_method',

--- a/apps/kaede/src/usecases/auth/index.ts
+++ b/apps/kaede/src/usecases/auth/index.ts
@@ -3,6 +3,7 @@ import type {
   ActivationCompleteRequest,
   ActivationVerifyRequest,
   ActivationVerifyResponse,
+  AuthMeResponse,
   AuthUserResponse,
   ChangePasswordRequest,
   LoginRequest,
@@ -31,7 +32,9 @@ import type { DbExecutor } from '../../services/executor.js'
 import {
   evaluateMembershipGrant,
   listMembershipGrantContexts,
+  membershipAllowedAuthMethods,
 } from '../../services/organization-authorization/index.js'
+import type { MembershipGrantContext } from '../../services/organization-authorization/index.js'
 import {
   findUserByEmail,
   findUserById,
@@ -76,6 +79,10 @@ export type ActiveSessionUserResult =
       ok: false
       error: ActiveSessionUserError
     }
+
+export type GetMeResult =
+  | { ok: true; value: AuthMeResponse }
+  | { ok: false; error: ActiveSessionUserError }
 
 export interface LoginResultValue extends AuthUserResponse {
   sessionToken: string
@@ -174,19 +181,9 @@ const mapActiveSessionError = (
 const buildAuthUserResponse = async (
   user: User,
   sessionAuthMethod: 'password' | 'oidc',
-  executor?: DbExecutor,
-  grantOptions?: { sessionId: string; now: Date }
+  executor?: DbExecutor
 ): Promise<AuthUserResponse> => {
   const memberships = await listUserOrganizationMemberships(user.id, executor)
-  const grantContexts = grantOptions
-    ? await listMembershipGrantContexts(grantOptions.sessionId, user.id, executor)
-    : []
-  const grantsByOrganizationId = new Map(
-    grantContexts.map((context) => [context.organization_id, context])
-  )
-  const currentMemberships = grantOptions
-    ? memberships.filter((membership) => grantsByOrganizationId.has(membership.organization_id))
-    : memberships
 
   return {
     session_auth_method: sessionAuthMethod,
@@ -199,38 +196,155 @@ const buildAuthUserResponse = async (
       account_state: deriveAccountState({
         globalRole: user.global_role as 'none' | 'admin',
         status: user.status as 'pending_activation' | 'active' | 'disabled',
-        membershipCount: currentMemberships.length,
+        membershipCount: memberships.length,
       }),
       password_changed_at: toIsoOrNull(user.password_changed_at),
-      memberships: currentMemberships.map((membership) => {
-        const context = grantsByOrganizationId.get(membership.organization_id)
-        const authorization = grantOptions
-          ? evaluateMembershipGrant(context, 'member', grantOptions.now)
-          : undefined
-        const grantState = !authorization
-          ? undefined
-          : authorization.ok
-            ? {
-                status: 'granted' as const,
-                auth_method: authorization.authMethod,
-                authenticated_at: authorization.authenticatedAt.toISOString(),
-                expires_at: authorization.expiresAt.toISOString(),
-              }
-            : authorization.type === 'reauthentication_required'
-              ? {
-                  status: 'reauthentication_required' as const,
-                  reason: authorization.reason,
-                  allowed_auth_methods: authorization.allowedAuthMethods,
-                }
-              : { status: 'forbidden' as const }
+      memberships: memberships.map((membership) => ({
+        organization_id: membership.organization_id,
+        organization_name: membership.organization_name,
+        role: membership.role as 'member' | 'manager' | 'owner',
+      })),
+    },
+  }
+}
 
-        return {
-          organization_id: membership.organization_id,
-          organization_name: membership.organization_name,
-          role: membership.role as 'member' | 'manager' | 'owner',
-          ...(grantState ? { grant_state: grantState } : {}),
-        }
+const grantTimeline = (context: MembershipGrantContext) => {
+  const authenticatedAt = context.grant_authenticated_at
+  const expiresAt = context.grant_expires_at
+  const intervalSeconds = context.reauthentication_interval_seconds
+  if (!authenticatedAt || !expiresAt || intervalSeconds === null) {
+    return {
+      authenticated_at: null,
+      reauthentication_required_at: null,
+      expires_at: expiresAt?.toISOString() ?? null,
+      effective_expires_at: null,
+    }
+  }
+
+  const reauthenticationRequiredAt = new Date(authenticatedAt.getTime() + intervalSeconds * 1000)
+  const effectiveExpiresAt =
+    reauthenticationRequiredAt <= expiresAt ? reauthenticationRequiredAt : expiresAt
+  return {
+    authenticated_at: authenticatedAt.toISOString(),
+    reauthentication_required_at: reauthenticationRequiredAt.toISOString(),
+    expires_at: expiresAt.toISOString(),
+    effective_expires_at: effectiveExpiresAt.toISOString(),
+  }
+}
+
+const membershipGrantState = (
+  context: MembershipGrantContext,
+  now: Date
+): AuthMeResponse['user']['memberships'][number]['grant_state'] => {
+  if (context.membership_status === 'suspended') {
+    return {
+      status: 'forbidden',
+      reason: 'membership_suspended',
+      auth_method: null,
+      authenticated_at: null,
+      reauthentication_required_at: null,
+      expires_at: null,
+      effective_expires_at: null,
+    }
+  }
+  if (context.organization_status !== 'active') {
+    return {
+      status: 'forbidden',
+      reason: 'organization_unavailable',
+      auth_method: null,
+      authenticated_at: null,
+      reauthentication_required_at: null,
+      expires_at: null,
+      effective_expires_at: null,
+    }
+  }
+  if (!context.auth_settings_available) {
+    return {
+      status: 'forbidden',
+      reason: 'auth_settings_unavailable',
+      auth_method: null,
+      authenticated_at: null,
+      reauthentication_required_at: null,
+      expires_at: null,
+      effective_expires_at: null,
+    }
+  }
+
+  const authorization = evaluateMembershipGrant(context, 'member', now)
+  if (authorization.ok) {
+    return {
+      status: 'granted',
+      reason: null,
+      auth_method: authorization.authMethod,
+      authenticated_at: authorization.authenticatedAt.toISOString(),
+      reauthentication_required_at: authorization.reauthenticationRequiredAt.toISOString(),
+      expires_at: authorization.expiresAt.toISOString(),
+      effective_expires_at: authorization.effectiveExpiresAt.toISOString(),
+    }
+  }
+
+  if (authorization.type === 'reauthentication_required') {
+    const timeline = grantTimeline(context)
+    return {
+      status: 'reauthentication_required',
+      reason: authorization.reason,
+      auth_method:
+        context.grant_auth_method === 'local' || context.grant_auth_method === 'oidc'
+          ? context.grant_auth_method
+          : null,
+      ...timeline,
+    }
+  }
+
+  return {
+    status: 'forbidden',
+    reason: 'organization_unavailable',
+    auth_method: null,
+    authenticated_at: null,
+    reauthentication_required_at: null,
+    expires_at: null,
+    effective_expires_at: null,
+  }
+}
+
+const buildAuthMeResponse = async (
+  user: User,
+  sessionAuthMethod: 'password' | 'oidc',
+  sessionId: string,
+  now: Date,
+  executor?: DbExecutor
+): Promise<AuthMeResponse> => {
+  const memberships = await listMembershipGrantContexts(sessionId, user.id, executor)
+
+  return {
+    session_auth_method: sessionAuthMethod,
+    user: {
+      user_id: user.id,
+      email: user.email,
+      display_name: user.display_name,
+      global_role: user.global_role as 'none' | 'admin',
+      status: user.status as 'pending_activation' | 'active' | 'disabled',
+      account_state: deriveAccountState({
+        globalRole: user.global_role as 'none' | 'admin',
+        status: user.status as 'pending_activation' | 'active' | 'disabled',
+        membershipCount: memberships.length,
       }),
+      password_changed_at: toIsoOrNull(user.password_changed_at),
+      memberships: memberships.map((membership) => ({
+        membership_id: membership.membership_id,
+        organization_id: membership.organization_id,
+        organization_name: membership.organization_name,
+        organization_slug: membership.organization_slug,
+        role: membership.membership_role as 'member' | 'manager' | 'owner',
+        status: membership.membership_status as 'active' | 'suspended',
+        allowed_auth_methods:
+          membership.membership_status === 'active' &&
+          membership.organization_status === 'active' &&
+          membership.auth_settings_available
+            ? membershipAllowedAuthMethods(membership)
+            : [],
+        grant_state: membershipGrantState(membership, now),
+      })),
     },
   }
 }
@@ -635,7 +749,7 @@ export const getMe = async (
   sessionToken: string | undefined,
   now: Date = new Date(),
   executor?: DbExecutor
-): Promise<AuthResult<AuthUserResponse>> => {
+): Promise<GetMeResult> => {
   if (!sessionToken) {
     return {
       ok: false,
@@ -670,11 +784,12 @@ export const getMe = async (
 
   return {
     ok: true,
-    value: await buildAuthUserResponse(
+    value: await buildAuthMeResponse(
       user,
       sessionResult.session.auth_method as 'password' | 'oidc',
-      executor,
-      { sessionId: sessionResult.session.id, now }
+      sessionResult.session.id,
+      now,
+      executor
     ),
   }
 }

--- a/apps/kaede/src/usecases/organization-auth-methods/index.test.ts
+++ b/apps/kaede/src/usecases/organization-auth-methods/index.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getPublicOrganizationAuthMethods } from './index.js'
+
+const { findRowsMock } = vi.hoisted(() => ({ findRowsMock: vi.fn() }))
+
+vi.mock('../../services/organization-auth-methods/index.js', () => ({
+  findPublicOrganizationAuthMethodRows: findRowsMock,
+}))
+
+describe('getPublicOrganizationAuthMethods', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('OIDC無効時はprovider rowがあっても公開しない', async () => {
+    findRowsMock.mockResolvedValue([
+      {
+        local_auth_enabled: true,
+        oidc_auth_enabled: false,
+        provider_id: '11111111-1111-4111-8111-111111111111',
+        provider_display_name: 'Disabled by policy',
+      },
+    ])
+
+    await expect(getPublicOrganizationAuthMethods('example-org')).resolves.toEqual({
+      local_auth_enabled: true,
+      allowed_auth_methods: ['local'],
+      oidc_providers: [],
+    })
+  })
+
+  it('Organizationが利用不可なら存在理由を区別しない空responseを返す', async () => {
+    findRowsMock.mockResolvedValue([])
+
+    await expect(getPublicOrganizationAuthMethods('unknown-org')).resolves.toEqual({
+      local_auth_enabled: false,
+      allowed_auth_methods: [],
+      oidc_providers: [],
+    })
+  })
+})

--- a/apps/kaede/src/usecases/organization-auth-methods/index.ts
+++ b/apps/kaede/src/usecases/organization-auth-methods/index.ts
@@ -1,0 +1,35 @@
+import type { OrganizationAuthMethodsResponse } from '../../schemas/organization-auth-methods.js'
+import type { DbExecutor } from '../../services/executor.js'
+import { findPublicOrganizationAuthMethodRows } from '../../services/organization-auth-methods/index.js'
+
+const unavailableResponse = (): OrganizationAuthMethodsResponse => ({
+  local_auth_enabled: false,
+  allowed_auth_methods: [],
+  oidc_providers: [],
+})
+
+export const getPublicOrganizationAuthMethods = async (
+  organizationSlug: string,
+  executor?: DbExecutor
+): Promise<OrganizationAuthMethodsResponse> => {
+  const rows = await findPublicOrganizationAuthMethodRows(organizationSlug, executor)
+  if (rows.length === 0) return unavailableResponse()
+  const first = rows[0]
+
+  const oidcProviders = first.oidc_auth_enabled
+    ? rows.flatMap((row) =>
+        row.provider_id && row.provider_display_name
+          ? [{ id: row.provider_id, display_name: row.provider_display_name }]
+          : []
+      )
+    : []
+  const allowedAuthMethods: ('local' | 'oidc')[] = []
+  if (first.local_auth_enabled) allowedAuthMethods.push('local')
+  if (oidcProviders.length > 0) allowedAuthMethods.push('oidc')
+
+  return {
+    local_auth_enabled: first.local_auth_enabled,
+    allowed_auth_methods: allowedAuthMethods,
+    oidc_providers: oidcProviders,
+  }
+}

--- a/apps/kaede/tests/services/auth/auth-usecase.test.ts
+++ b/apps/kaede/tests/services/auth/auth-usecase.test.ts
@@ -1042,10 +1042,11 @@ describe('auth usecase', () => {
       .values({ name: 'Missing Grant Organization' })
       .returningAll()
       .executeTakeFirstOrThrow()
-    await db
+    const secondMembership = await db
       .insertInto('organization_memberships')
       .values({ organization_id: secondOrganization.id, user_id: user.id, role: 'manager' })
-      .execute()
+      .returningAll()
+      .executeTakeFirstOrThrow()
     await db
       .insertInto('organization_auth_settings')
       .values({
@@ -1056,35 +1057,121 @@ describe('auth usecase', () => {
         reauthentication_interval_seconds: 3600,
       })
       .execute()
+    const missingSettingsOrganization = await db
+      .insertInto('organizations')
+      .values({ name: 'Missing Settings Organization' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const missingSettingsMembership = await db
+      .insertInto('organization_memberships')
+      .values({
+        organization_id: missingSettingsOrganization.id,
+        user_id: user.id,
+        role: 'member',
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const suspendedOrganization = await db
+      .insertInto('organizations')
+      .values({ name: 'Suspended Membership Organization' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const suspendedMembership = await db
+      .insertInto('organization_memberships')
+      .values({
+        organization_id: suspendedOrganization.id,
+        user_id: user.id,
+        role: 'member',
+        status: 'suspended',
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    await db
+      .insertInto('organization_auth_settings')
+      .values({
+        organization_id: suspendedOrganization.id,
+        local_auth_enabled: true,
+        oidc_auth_enabled: false,
+        membership_grant_ttl_seconds: 7200,
+        reauthentication_interval_seconds: 3600,
+      })
+      .execute()
 
     const result = await getMe(token, new Date('2026-08-11T11:30:00.000Z'), db)
 
-    expect(result).toMatchObject({
-      ok: true,
-      value: {
-        user: {
-          memberships: [
-            {
-              organization_id: organization.id,
-              grant_state: {
-                status: 'granted',
-                auth_method: 'local',
-                authenticated_at: '2026-08-11T11:00:00.000Z',
-                expires_at: '2026-08-11T13:00:00.000Z',
-              },
-            },
-            {
-              organization_id: secondOrganization.id,
-              grant_state: {
-                status: 'reauthentication_required',
-                reason: 'grant_missing',
-                allowed_auth_methods: ['local'],
-              },
-            },
-          ],
-        },
-      },
-    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.value.user.memberships).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          membership_id: membership.id,
+          organization_id: organization.id,
+          organization_name: organization.name,
+          organization_slug: organization.slug,
+          role: 'member',
+          status: 'active',
+          allowed_auth_methods: ['local'],
+          grant_state: {
+            status: 'granted',
+            reason: null,
+            auth_method: 'local',
+            authenticated_at: '2026-08-11T11:00:00.000Z',
+            reauthentication_required_at: '2026-08-11T12:00:00.000Z',
+            expires_at: '2026-08-11T13:00:00.000Z',
+            effective_expires_at: '2026-08-11T12:00:00.000Z',
+          },
+        }),
+        expect.objectContaining({
+          membership_id: secondMembership.id,
+          organization_id: secondOrganization.id,
+          organization_slug: secondOrganization.slug,
+          role: 'manager',
+          status: 'active',
+          allowed_auth_methods: ['local'],
+          grant_state: {
+            status: 'reauthentication_required',
+            reason: 'grant_missing',
+            auth_method: null,
+            authenticated_at: null,
+            reauthentication_required_at: null,
+            expires_at: null,
+            effective_expires_at: null,
+          },
+        }),
+        expect.objectContaining({
+          membership_id: missingSettingsMembership.id,
+          organization_id: missingSettingsOrganization.id,
+          organization_slug: missingSettingsOrganization.slug,
+          status: 'active',
+          allowed_auth_methods: [],
+          grant_state: {
+            status: 'forbidden',
+            reason: 'auth_settings_unavailable',
+            auth_method: null,
+            authenticated_at: null,
+            reauthentication_required_at: null,
+            expires_at: null,
+            effective_expires_at: null,
+          },
+        }),
+        expect.objectContaining({
+          membership_id: suspendedMembership.id,
+          organization_id: suspendedOrganization.id,
+          organization_slug: suspendedOrganization.slug,
+          status: 'suspended',
+          allowed_auth_methods: [],
+          grant_state: {
+            status: 'forbidden',
+            reason: 'membership_suspended',
+            auth_method: null,
+            authenticated_at: null,
+            reauthentication_required_at: null,
+            expires_at: null,
+            effective_expires_at: null,
+          },
+        }),
+      ])
+    )
   })
 
   it('verifyActivationToken は valid token の表示情報を返し token を consume しない', async () => {

--- a/apps/kaede/tests/services/organization-auth-methods/methods.test.ts
+++ b/apps/kaede/tests/services/organization-auth-methods/methods.test.ts
@@ -1,0 +1,100 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { createDb } from '../../../src/services/db/client.js'
+import { getPublicOrganizationAuthMethods } from '../../../src/usecases/organization-auth-methods/index.js'
+import { resetDatabase } from '../../db/helpers.js'
+
+const db = createDb()
+
+describe('organization auth methods discovery', () => {
+  beforeEach(async () => {
+    await resetDatabase(db)
+  })
+
+  afterAll(async () => {
+    await db.destroy()
+  })
+
+  it('有効な認証方式とenabled OIDC providerの公開情報だけを返す', async () => {
+    const organization = await db
+      .insertInto('organizations')
+      .values({ name: 'Discovery Organization', slug: 'discovery-organization' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    await db
+      .insertInto('organization_auth_settings')
+      .values({
+        organization_id: organization.id,
+        local_auth_enabled: true,
+        oidc_auth_enabled: true,
+        membership_grant_ttl_seconds: 28_800,
+        reauthentication_interval_seconds: 14_400,
+      })
+      .execute()
+    const [enabledProvider] = await db
+      .insertInto('organization_oidc_providers')
+      .values([
+        {
+          organization_id: organization.id,
+          name: 'Enabled Provider',
+          issuer: 'https://enabled.example.test',
+          client_id: 'enabled-client',
+          client_secret_ref: 'secret/enabled',
+          scopes: ['openid', 'email'],
+          enabled: true,
+        },
+        {
+          organization_id: organization.id,
+          name: 'Disabled Provider',
+          issuer: 'https://disabled.example.test',
+          client_id: 'disabled-client',
+          client_secret_ref: 'secret/disabled',
+          scopes: ['openid'],
+          enabled: false,
+        },
+      ])
+      .returningAll()
+      .execute()
+
+    await expect(getPublicOrganizationAuthMethods(organization.slug, db)).resolves.toStrictEqual({
+      local_auth_enabled: true,
+      allowed_auth_methods: ['local', 'oidc'],
+      oidc_providers: [{ id: enabledProvider.id, display_name: 'Enabled Provider' }],
+    })
+  })
+
+  it('存在しないslug・inactive組織・設定欠落を同じ最小レスポンスにする', async () => {
+    const [inactiveOrganization, missingSettingsOrganization] = await db
+      .insertInto('organizations')
+      .values([
+        { name: 'Inactive Organization', slug: 'inactive-organization', status: 'suspended' },
+        { name: 'Missing Settings Organization', slug: 'missing-settings-organization' },
+      ])
+      .returningAll()
+      .execute()
+    await db
+      .insertInto('organization_auth_settings')
+      .values({
+        organization_id: inactiveOrganization.id,
+        local_auth_enabled: true,
+        oidc_auth_enabled: false,
+        membership_grant_ttl_seconds: 28_800,
+        reauthentication_interval_seconds: 14_400,
+      })
+      .execute()
+
+    const unavailable = {
+      local_auth_enabled: false,
+      allowed_auth_methods: [],
+      oidc_providers: [],
+    }
+    await expect(getPublicOrganizationAuthMethods('unknown', db)).resolves.toStrictEqual(
+      unavailable
+    )
+    await expect(
+      getPublicOrganizationAuthMethods(inactiveOrganization.slug, db)
+    ).resolves.toStrictEqual(unavailable)
+    await expect(
+      getPublicOrganizationAuthMethods(missingSettingsOrganization.slug, db)
+    ).resolves.toStrictEqual(unavailable)
+  })
+})

--- a/apps/kaede/tests/services/organization-authorization/repository.test.ts
+++ b/apps/kaede/tests/services/organization-authorization/repository.test.ts
@@ -96,4 +96,49 @@ describe('organization authorization repository', () => {
     })
     expect(contexts[0]?.membership_id).not.toBe(leftMembership.id)
   })
+
+  it('Auth Settingsがないcurrent Membershipも落とさず明示contextで返す', async () => {
+    const user = await db
+      .insertInto('users')
+      .values({
+        email: 'missing-settings@example.com',
+        display_name: 'Missing Settings',
+        password_hash: passwordHash,
+        global_role: 'none',
+        status: 'active',
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const organization = await db
+      .insertInto('organizations')
+      .values({ name: 'Missing Settings Organization' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const membership = await db
+      .insertInto('organization_memberships')
+      .values({ organization_id: organization.id, user_id: user.id, role: 'member' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const session = await db
+      .insertInto('sessions')
+      .values({
+        user_id: user.id,
+        session_hash: 'missing-settings-session',
+        expires_at: new Date('2026-08-13T00:00:00.000Z'),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    await expect(
+      findMembershipGrantContext(session.id, user.id, organization.id, db)
+    ).resolves.toMatchObject({
+      organization_id: organization.id,
+      organization_name: organization.name,
+      organization_slug: organization.slug,
+      membership_id: membership.id,
+      auth_settings_available: false,
+      local_auth_enabled: null,
+      oidc_auth_enabled: null,
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- complete the dedicated `GET /api/auth/me` membership/grant read contract
- add public `GET /api/organizations/{organizationSlug}/auth/methods` discovery with minimal OIDC disclosure
- preserve memberships when auth settings are missing and expose explicit unavailable/suspended states
- publish distinct OpenAPI types for global-session 401 and membership-authorization 403 errors

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (90 files, 508 tests)
- Prettier check
- DB tests added for the new repository/use-case behavior

## Known environment issue

The local DB suite could not complete because Docker/Testcontainers timed out while waiting for Ryuk/PostgreSQL host port bindings. The containers became healthy without published host ports. Please confirm the added DB tests in CI.

Part of #219