### PR TITLE
feat(kaede): Membership管理APIを追加する

### DIFF
--- a/apps/kaede/src/routes/organizations/index.ts
+++ b/apps/kaede/src/routes/organizations/index.ts
@@ -19,6 +19,7 @@ import { registerListOrganizationTrajectoriesRoute } from './list-organization-t
 import { registerListOrganizationUsersRoute } from './list-organization-users.js'
 import { registerListOrganizationsRoute } from './list-organizations.js'
 import { registerOrganizationMemberProfileRoutes } from './member-profiles.js'
+import { registerMembershipAdministrationRoutes } from './membership-administration.js'
 import { registerOrganizationOidcProviderRoutes } from './oidc-providers.js'
 
 export const organizationsRoutes = new OpenAPIHono()
@@ -42,5 +43,6 @@ registerCreateStayHeatmapRoute(organizationsRoutes)
 registerAnalysisRunRoutes(organizationsRoutes)
 registerOrganizationAuthSettingsRoutes(organizationsRoutes)
 registerOrganizationMemberProfileRoutes(organizationsRoutes)
+registerMembershipAdministrationRoutes(organizationsRoutes)
 registerOrganizationOidcProviderRoutes(organizationsRoutes)
 registerOrganizationInviteRoutes(organizationsRoutes)

--- a/apps/kaede/src/routes/organizations/membership-administration.ts
+++ b/apps/kaede/src/routes/organizations/membership-administration.ts
@@ -1,0 +1,73 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { requireRequestActor } from '../../middleware/request-actor-context.js'
+import type { RequestActorContext } from '../../middleware/request-actor-context.js'
+import { errorResponseSchema } from '../../schemas/common.js'
+import {
+  managedMembershipSchema,
+  membershipAdministrationParamsSchema,
+  updateMembershipRequestSchema,
+} from '../../schemas/membership-administration.js'
+import { updateOrganizationMembership } from '../../usecases/membership-administration/index.js'
+
+const errorResponse = (type: string) => {
+  if (type === 'MEMBERSHIP_NOT_FOUND') {
+    return {
+      status: 404 as const,
+      body: { error_code: type, error_message: 'membership not found' },
+    }
+  }
+  if (type === 'MEMBERSHIP_LAST_OWNER' || type === 'MEMBERSHIP_LEFT') {
+    return {
+      status: 409 as const,
+      body: { error_code: type, error_message: 'membership conflict' },
+    }
+  }
+  return { status: 403 as const, body: { error_code: type, error_message: 'operation forbidden' } }
+}
+
+export const registerMembershipAdministrationRoutes = (app: OpenAPIHono) => {
+  const route = createRoute({
+    method: 'patch',
+    path: '/{organizationId}/members/{membershipId}',
+    tags: ['Organizations'],
+    description: 'Membershipのrole/statusを変更する。left Membershipは再利用しない',
+    request: {
+      params: membershipAdministrationParamsSchema,
+      body: { content: { 'application/json': { schema: updateMembershipRequestSchema } } },
+    },
+    responses: {
+      200: {
+        description: 'membership updated',
+        content: { 'application/json': { schema: managedMembershipSchema } },
+      },
+      403: {
+        description: 'operation forbidden',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      404: {
+        description: 'membership not found',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      409: {
+        description: 'membership lifecycle conflict',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+    },
+  })
+
+  app.openapi(route, async (c) => {
+    const params = c.req.valid('param')
+    const result = await updateOrganizationMembership(
+      requireRequestActor(c as RequestActorContext),
+      params.organizationId,
+      params.membershipId,
+      c.req.valid('json')
+    )
+    if (!result.ok) {
+      const error = errorResponse(result.error.type)
+      return c.json(error.body, error.status)
+    }
+    return c.json(result.value, 200)
+  })
+}

--- a/apps/kaede/src/schemas/membership-administration.ts
+++ b/apps/kaede/src/schemas/membership-administration.ts
@@ -1,0 +1,30 @@
+import { z } from '@hono/zod-openapi'
+import { membershipRoleSchema, uuidSchema } from './common.js'
+
+export const membershipAdministrationParamsSchema = z
+  .object({ organizationId: uuidSchema, membershipId: uuidSchema })
+  .openapi('MembershipAdministrationParams')
+
+export const updateMembershipRequestSchema = z
+  .object({
+    role: membershipRoleSchema.optional(),
+    status: z.enum(['active', 'suspended', 'left']).optional(),
+  })
+  .strict()
+  .refine((value) => Object.keys(value).length > 0, 'at least one field is required')
+  .openapi('UpdateMembershipRequest')
+
+export const managedMembershipSchema = z
+  .object({
+    id: uuidSchema,
+    organization_id: uuidSchema,
+    user_id: uuidSchema,
+    role: membershipRoleSchema,
+    status: z.enum(['active', 'suspended', 'left']),
+    joined_at: z.string().datetime(),
+    left_at: z.string().datetime().nullable(),
+    updated_at: z.string().datetime(),
+  })
+  .openapi('ManagedMembership')
+
+export type UpdateMembershipRequest = z.infer<typeof updateMembershipRequestSchema>

--- a/apps/kaede/src/services/membership-administration/index.ts
+++ b/apps/kaede/src/services/membership-administration/index.ts
@@ -1,0 +1,10 @@
+export {
+  countActiveOwners,
+  findCurrentMembershipByUserForUpdate,
+  findMembershipByIdForUpdate,
+  insertMembershipAdministrationAuditEvent,
+  lockOrganizationForMembershipAdministration,
+  revokeAllMembershipGrants,
+  revokeMembershipAuthenticationSources,
+  updateManagedMembership,
+} from './repository.js'

--- a/apps/kaede/src/services/membership-administration/repository.ts
+++ b/apps/kaede/src/services/membership-administration/repository.ts
@@ -1,0 +1,101 @@
+import type { Insertable, Updateable } from 'kysely'
+import type { AuditEvents, OrganizationMemberships } from '../db/generated.js'
+import { db } from '../db/index.js'
+import type { DbExecutor } from '../executor.js'
+
+export const lockOrganizationForMembershipAdministration = async (
+  organizationId: string,
+  executor: DbExecutor = db
+) =>
+  executor
+    .selectFrom('organizations')
+    .select('id')
+    .where('id', '=', organizationId)
+    .forUpdate()
+    .executeTakeFirst()
+
+export const findCurrentMembershipByUserForUpdate = async (
+  organizationId: string,
+  userId: string,
+  executor: DbExecutor
+) =>
+  executor
+    .selectFrom('organization_memberships')
+    .selectAll()
+    .where('organization_id', '=', organizationId)
+    .where('user_id', '=', userId)
+    .where('status', 'in', ['active', 'suspended'])
+    .forUpdate()
+    .executeTakeFirst()
+
+export const findMembershipByIdForUpdate = async (
+  organizationId: string,
+  membershipId: string,
+  executor: DbExecutor
+) =>
+  executor
+    .selectFrom('organization_memberships')
+    .selectAll()
+    .where('organization_id', '=', organizationId)
+    .where('id', '=', membershipId)
+    .forUpdate()
+    .executeTakeFirst()
+
+export const countActiveOwners = async (organizationId: string, executor: DbExecutor) => {
+  const row = await executor
+    .selectFrom('organization_memberships')
+    .select(({ fn }) => fn.countAll<number>().as('count'))
+    .where('organization_id', '=', organizationId)
+    .where('role', '=', 'owner')
+    .where('status', '=', 'active')
+    .executeTakeFirstOrThrow()
+  return Number.parseInt(row.count.toString(), 10)
+}
+
+export const updateManagedMembership = async (
+  membershipId: string,
+  values: Updateable<OrganizationMemberships>,
+  executor: DbExecutor
+) =>
+  executor
+    .updateTable('organization_memberships')
+    .set(values)
+    .where('id', '=', membershipId)
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+export const revokeAllMembershipGrants = async (
+  membershipId: string,
+  revokedAt: Date,
+  executor: DbExecutor
+) =>
+  executor
+    .updateTable('session_membership_authentications')
+    .set({ revoked_at: revokedAt, updated_at: revokedAt })
+    .where('membership_id', '=', membershipId)
+    .where('revoked_at', 'is', null)
+    .execute()
+
+export const revokeMembershipAuthenticationSources = async (
+  membershipId: string,
+  revokedAt: Date,
+  executor: DbExecutor
+) => {
+  await executor
+    .updateTable('organization_local_credentials')
+    .set({ enabled: false, updated_at: revokedAt })
+    .where('membership_id', '=', membershipId)
+    .where('enabled', '=', true)
+    .execute()
+  await executor
+    .updateTable('organization_member_oidc_identities')
+    .set({ revoked_at: revokedAt })
+    .where('membership_id', '=', membershipId)
+    .where('revoked_at', 'is', null)
+    .execute()
+}
+
+export const insertMembershipAdministrationAuditEvent = async (
+  event: Insertable<AuditEvents>,
+  executor: DbExecutor
+) => executor.insertInto('audit_events').values(event).executeTakeFirst()

--- a/apps/kaede/src/usecases/membership-administration/index.ts
+++ b/apps/kaede/src/usecases/membership-administration/index.ts
@@ -1,0 +1,1 @@
+export { updateOrganizationMembership } from './update.js'

--- a/apps/kaede/src/usecases/membership-administration/update.ts
+++ b/apps/kaede/src/usecases/membership-administration/update.ts
@@ -1,0 +1,129 @@
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import type { UpdateMembershipRequest } from '../../schemas/membership-administration.js'
+import { db } from '../../services/db/index.js'
+import type { DbExecutor } from '../../services/executor.js'
+import {
+  countActiveOwners,
+  findCurrentMembershipByUserForUpdate,
+  findMembershipByIdForUpdate,
+  insertMembershipAdministrationAuditEvent,
+  lockOrganizationForMembershipAdministration,
+  revokeAllMembershipGrants,
+  revokeMembershipAuthenticationSources,
+  updateManagedMembership,
+} from '../../services/membership-administration/index.js'
+
+export type MembershipAdministrationError =
+  | 'AUTH_FORBIDDEN'
+  | 'MEMBERSHIP_NOT_FOUND'
+  | 'MEMBERSHIP_ROLE_FORBIDDEN'
+  | 'MEMBERSHIP_LEFT'
+  | 'MEMBERSHIP_LAST_OWNER'
+
+const response = (membership: {
+  id: string
+  organization_id: string
+  user_id: string
+  role: string
+  status: string
+  joined_at: Date
+  left_at: Date | null
+  updated_at: Date
+}) => ({
+  id: membership.id,
+  organization_id: membership.organization_id,
+  user_id: membership.user_id,
+  role: membership.role as 'member' | 'manager' | 'owner',
+  status: membership.status as 'active' | 'suspended' | 'left',
+  joined_at: membership.joined_at.toISOString(),
+  left_at: membership.left_at?.toISOString() ?? null,
+  updated_at: membership.updated_at.toISOString(),
+})
+
+export const updateOrganizationMembership = async (
+  actor: RequestActor,
+  organizationId: string,
+  membershipId: string,
+  payload: UpdateMembershipRequest,
+  now = new Date(),
+  executor?: DbExecutor
+) => {
+  if (actor.type !== 'user') {
+    return { ok: false, error: { type: 'AUTH_FORBIDDEN' as const } } as const
+  }
+  const base = executor ?? db
+  const run = async (trx: DbExecutor) => {
+    const organization = await lockOrganizationForMembershipAdministration(organizationId, trx)
+    if (!organization) {
+      return { ok: false, error: { type: 'MEMBERSHIP_NOT_FOUND' as const } } as const
+    }
+    const actorMembership = await findCurrentMembershipByUserForUpdate(
+      organizationId,
+      actor.user_id,
+      trx
+    )
+    if (actorMembership?.status !== 'active') {
+      return { ok: false, error: { type: 'AUTH_FORBIDDEN' as const } } as const
+    }
+    const target = await findMembershipByIdForUpdate(organizationId, membershipId, trx)
+    if (!target) return { ok: false, error: { type: 'MEMBERSHIP_NOT_FOUND' as const } } as const
+    if (target.status === 'left') {
+      return { ok: false, error: { type: 'MEMBERSHIP_LEFT' as const } } as const
+    }
+
+    const nextRole = payload.role ?? (target.role as 'member' | 'manager' | 'owner')
+    const nextStatus = payload.status ?? (target.status as 'active' | 'suspended')
+    const managerAllowed =
+      actorMembership.role === 'manager' && target.role === 'member' && nextRole === 'member'
+    const ownerAllowed = actorMembership.role === 'owner'
+    if (!managerAllowed && !ownerAllowed) {
+      return { ok: false, error: { type: 'MEMBERSHIP_ROLE_FORBIDDEN' as const } } as const
+    }
+
+    const removesActiveOwner =
+      target.role === 'owner' &&
+      target.status === 'active' &&
+      (nextRole !== 'owner' || nextStatus !== 'active')
+    if (removesActiveOwner && (await countActiveOwners(organizationId, trx)) <= 1) {
+      return { ok: false, error: { type: 'MEMBERSHIP_LAST_OWNER' as const } } as const
+    }
+
+    const changedFields = [
+      ...(nextRole === target.role ? [] : ['role']),
+      ...(nextStatus === target.status ? [] : ['status']),
+    ]
+    if (changedFields.length === 0) return { ok: true, value: response(target) } as const
+
+    const updated = await updateManagedMembership(
+      target.id,
+      {
+        role: nextRole,
+        status: nextStatus,
+        left_at: nextStatus === 'left' ? now : null,
+        updated_at: now,
+      },
+      trx
+    )
+    await revokeAllMembershipGrants(target.id, now, trx)
+    if (nextStatus === 'left') {
+      await revokeMembershipAuthenticationSources(target.id, now, trx)
+    }
+    await insertMembershipAdministrationAuditEvent(
+      {
+        action: 'update',
+        actor_user_id: actor.user_id,
+        actor_membership_id: actorMembership.id,
+        organization_id: organizationId,
+        target_type: 'organization_membership',
+        target_id: target.id,
+        changed_fields: changedFields,
+        before_values: { role: target.role, status: target.status },
+        after_values: { role: updated.role, status: updated.status },
+      },
+      trx
+    )
+
+    return { ok: true, value: response(updated) } as const
+  }
+  return 'transaction' in base ? base.transaction().execute(run) : run(base)
+}

--- a/apps/kaede/tests/services/memberships/membership-administration.test.ts
+++ b/apps/kaede/tests/services/memberships/membership-administration.test.ts
@@ -1,0 +1,207 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import type { RequestActor } from '../../../src/middleware/request-actor-context.js'
+import { createSession } from '../../../src/services/auth/index.js'
+import { createDb } from '../../../src/services/db/client.js'
+import { updateOrganizationMembership } from '../../../src/usecases/membership-administration/index.js'
+import { resetDatabase } from '../../db/helpers.js'
+
+const db = createDb()
+const now = new Date('2026-08-11T12:00:00.000Z')
+
+const actor = (userId: string, organizationId: string, role: 'member' | 'manager' | 'owner') =>
+  ({
+    type: 'user',
+    user_id: userId,
+    email: `${userId}@example.test`,
+    global_role: 'none',
+    account_state: 'active',
+    memberships: [{ organization_id: organizationId, organization_name: 'Test', role }],
+  }) satisfies RequestActor
+
+const createUser = (suffix: string) =>
+  db
+    .insertInto('users')
+    .values({
+      email: `${suffix}@example.test`,
+      display_name: suffix,
+      global_role: 'none',
+      status: 'active',
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+const createFixture = async (actorRole: 'manager' | 'owner' = 'manager') => {
+  const organization = await db
+    .insertInto('organizations')
+    .values({ name: 'Membership Administration' })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const actorUser = await createUser('membership-admin-actor')
+  const targetUser = await createUser('membership-admin-target')
+  const actorMembership = await db
+    .insertInto('organization_memberships')
+    .values({ organization_id: organization.id, user_id: actorUser.id, role: actorRole })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const targetMembership = await db
+    .insertInto('organization_memberships')
+    .values({ organization_id: organization.id, user_id: targetUser.id, role: 'member' })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const credential = await db
+    .insertInto('organization_local_credentials')
+    .values({
+      membership_id: targetMembership.id,
+      organization_id: organization.id,
+      login_email: 'membership-target@example.test',
+      normalized_login_email: 'membership-target@example.test',
+      password_hash: 'test-password-hash',
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const { session } = await createSession({ userId: targetUser.id, now }, db)
+  await db
+    .insertInto('session_membership_authentications')
+    .values({
+      session_id: session.id,
+      membership_id: targetMembership.id,
+      user_id: targetUser.id,
+      auth_method: 'local',
+      policy_version: 1,
+      local_credential_id: credential.id,
+      authenticated_at: now,
+      expires_at: new Date(now.getTime() + 3_600_000),
+    })
+    .execute()
+
+  return {
+    actor: actor(actorUser.id, organization.id, actorRole),
+    actorMembership,
+    credential,
+    organization,
+    targetMembership,
+    targetUser,
+  }
+}
+
+describe('membership administration', () => {
+  beforeEach(async () => resetDatabase(db))
+  afterAll(async () => db.destroy())
+
+  it('managerはmemberをsuspendでき、対象Grantだけをrevokeする', async () => {
+    const fixture = await createFixture()
+
+    const result = await updateOrganizationMembership(
+      fixture.actor,
+      fixture.organization.id,
+      fixture.targetMembership.id,
+      { status: 'suspended' },
+      now,
+      db
+    )
+
+    expect(result).toMatchObject({ ok: true, value: { status: 'suspended', left_at: null } })
+    await expect(
+      db
+        .selectFrom('session_membership_authentications')
+        .select('revoked_at')
+        .where('membership_id', '=', fixture.targetMembership.id)
+        .executeTakeFirstOrThrow()
+    ).resolves.toEqual({ revoked_at: now })
+    await expect(
+      db
+        .selectFrom('organization_local_credentials')
+        .select('enabled')
+        .where('id', '=', fixture.credential.id)
+        .executeTakeFirstOrThrow()
+    ).resolves.toEqual({ enabled: true })
+  })
+
+  it('managerはmemberをmanagerへ昇格できない', async () => {
+    const fixture = await createFixture()
+
+    const result = await updateOrganizationMembership(
+      fixture.actor,
+      fixture.organization.id,
+      fixture.targetMembership.id,
+      { role: 'manager' },
+      now,
+      db
+    )
+
+    expect(result).toEqual({ ok: false, error: { type: 'MEMBERSHIP_ROLE_FORBIDDEN' } })
+  })
+
+  it('ownerがmemberをleftにするとleft_atを設定し認証元も無効化する', async () => {
+    const fixture = await createFixture('owner')
+
+    const result = await updateOrganizationMembership(
+      fixture.actor,
+      fixture.organization.id,
+      fixture.targetMembership.id,
+      { status: 'left' },
+      now,
+      db
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: { status: 'left', left_at: now.toISOString() },
+    })
+    await expect(
+      db
+        .selectFrom('organization_local_credentials')
+        .select('enabled')
+        .where('id', '=', fixture.credential.id)
+        .executeTakeFirstOrThrow()
+    ).resolves.toEqual({ enabled: false })
+    const audit = await db
+      .selectFrom('audit_events')
+      .select(['actor_membership_id', 'target_id', 'changed_fields'])
+      .executeTakeFirstOrThrow()
+    expect(audit).toEqual({
+      actor_membership_id: fixture.actorMembership.id,
+      target_id: fixture.targetMembership.id,
+      changed_fields: ['status'],
+    })
+  })
+
+  it('最後のactive ownerはsuspendできない', async () => {
+    const fixture = await createFixture('owner')
+
+    const result = await updateOrganizationMembership(
+      fixture.actor,
+      fixture.organization.id,
+      fixture.actorMembership.id,
+      { status: 'suspended' },
+      now,
+      db
+    )
+
+    expect(result).toEqual({ ok: false, error: { type: 'MEMBERSHIP_LAST_OWNER' } })
+  })
+
+  it('別のactive ownerがいればownerをmanagerへ変更できる', async () => {
+    const fixture = await createFixture('owner')
+    const secondOwnerUser = await createUser('second-owner')
+    await db
+      .insertInto('organization_memberships')
+      .values({
+        organization_id: fixture.organization.id,
+        user_id: secondOwnerUser.id,
+        role: 'owner',
+      })
+      .execute()
+
+    const result = await updateOrganizationMembership(
+      fixture.actor,
+      fixture.organization.id,
+      fixture.actorMembership.id,
+      { role: 'manager' },
+      now,
+      db
+    )
+
+    expect(result).toMatchObject({ ok: true, value: { role: 'manager', status: 'active' } })
+  })
+})


### PR DESCRIPTION
## 概要
Organization内Membershipのrole/statusをmanager/ownerが変更するAPIを追加します。

## 変更内容
- `PATCH /api/organizations/{organizationId}/members/{membershipId}` を追加
- managerはmemberのstatusのみ、ownerはrole/statusを変更可能
- 最後のactive ownerを保護
- `left`時に`left_at`を設定し、Grant・Local Credential・OIDC Linkを無効化
- 変更時に対象MembershipのGrantをrevokeし、Audit Eventを記録
- PostgreSQL統合テストを追加

## 検証
- lint / typecheck 成功
- Unit 520件成功
- DB統合テストはローカルDockerのTestcontainers port bind障害により未完了（GitHub Actionsで確認）

Refs #219