### PR TITLE
fix(kaede): Organization作成時に認証設定を初期化する

### DIFF
--- a/apps/kaede/src/services/organizations/index.ts
+++ b/apps/kaede/src/services/organizations/index.ts
@@ -1,6 +1,7 @@
 export {
   findOrganizationById,
   findOrganizationBySlug,
+  insertDefaultOrganizationAuthSettings,
   insertOrganization,
   listOrganizations,
 } from './organization-repository.js'

--- a/apps/kaede/src/services/organizations/organization-repository.ts
+++ b/apps/kaede/src/services/organizations/organization-repository.ts
@@ -1,5 +1,5 @@
 import type { Insertable, Selectable } from 'kysely'
-import type { Organizations } from '../db/generated.js'
+import type { OrganizationAuthSettings, Organizations } from '../db/generated.js'
 import { db } from '../db/index.js'
 import type { DbExecutor } from '../executor.js'
 
@@ -37,6 +37,20 @@ export const insertOrganization = async (
     .values(newOrganization)
     .returningAll()
     .executeTakeFirstOrThrow()
+}
+
+export const insertDefaultOrganizationAuthSettings = async (
+  organizationId: string,
+  executor: DbExecutor = db
+): Promise<void> => {
+  const settings: Insertable<OrganizationAuthSettings> = {
+    organization_id: organizationId,
+    local_auth_enabled: true,
+    oidc_auth_enabled: false,
+    membership_grant_ttl_seconds: 28_800,
+    reauthentication_interval_seconds: 14_400,
+  }
+  await executor.insertInto('organization_auth_settings').values(settings).executeTakeFirstOrThrow()
 }
 
 export const listOrganizations = async (executor: DbExecutor = db): Promise<Organization[]> => {

--- a/apps/kaede/src/usecases/organizations/index.ts
+++ b/apps/kaede/src/usecases/organizations/index.ts
@@ -36,6 +36,7 @@ import {
   findOrganizationCreationRequestByIdForUpdate,
   findPendingOrganizationCreationRequestByRequester,
   findOrganizationById,
+  insertDefaultOrganizationAuthSettings,
   insertOrganization,
   insertOrganizationCreationRequest,
   listOrganizationCreationRequests,
@@ -581,12 +582,16 @@ export const createOrganizationForSession = async (
     return admin
   }
 
-  const organization = await insertOrganization(
-    {
-      name: payload.name.trim(),
-    },
-    executor
-  )
+  const organization = await runInTransaction(executor, async (trx) => {
+    const created = await insertOrganization(
+      {
+        name: payload.name.trim(),
+      },
+      trx
+    )
+    await insertDefaultOrganizationAuthSettings(created.id, trx)
+    return created
+  })
 
   return {
     ok: true,
@@ -786,6 +791,8 @@ export const approveOrganizationCreationRequestForAdminSession = async (
       },
       trx
     )
+
+    await insertDefaultOrganizationAuthSettings(organization.id, trx)
 
     await insertOrganizationMembership(
       {

--- a/apps/kaede/tests/services/organizations/organization-creation-requests.test.ts
+++ b/apps/kaede/tests/services/organizations/organization-creation-requests.test.ts
@@ -188,6 +188,25 @@ describe('organization creation request usecase', () => {
       .where('user_id', '=', requester.user.id)
       .executeTakeFirstOrThrow()
     expect(membership.role).toBe('owner')
+    await expect(
+      db
+        .selectFrom('organization_auth_settings')
+        .select([
+          'local_auth_enabled',
+          'oidc_auth_enabled',
+          'policy_version',
+          'membership_grant_ttl_seconds',
+          'reauthentication_interval_seconds',
+        ])
+        .where('organization_id', '=', organization.id)
+        .executeTakeFirstOrThrow()
+    ).resolves.toEqual({
+      local_auth_enabled: true,
+      oidc_auth_enabled: false,
+      policy_version: '1',
+      membership_grant_ttl_seconds: 28_800,
+      reauthentication_interval_seconds: 14_400,
+    })
   })
 
   it('approve rejects duplicate slug', async () => {

--- a/apps/kaede/tests/services/organizations/organizations.test.ts
+++ b/apps/kaede/tests/services/organizations/organizations.test.ts
@@ -184,6 +184,25 @@ describe('organizations usecase', () => {
       .executeTakeFirstOrThrow()
 
     expect(organization.name).toBe('Group A')
+    await expect(
+      db
+        .selectFrom('organization_auth_settings')
+        .select([
+          'local_auth_enabled',
+          'oidc_auth_enabled',
+          'policy_version',
+          'membership_grant_ttl_seconds',
+          'reauthentication_interval_seconds',
+        ])
+        .where('organization_id', '=', organization.id)
+        .executeTakeFirstOrThrow()
+    ).resolves.toEqual({
+      local_auth_enabled: true,
+      oidc_auth_enabled: false,
+      policy_version: '1',
+      membership_grant_ttl_seconds: 28_800,
+      reauthentication_interval_seconds: 14_400,
+    })
   })
 
   it('admin can list organizations', async () => {


### PR DESCRIPTION
## 概要
新規Organizationに認証設定行がなく、公開Auth MethodsとMembership Guardが利用不能になる状態を防ぎます。

## 変更内容
- Organization作成と同一transactionで`organization_auth_settings`を作成
- Creation Request承認経由にも同じ初期化を適用
- 初期値はLocal有効、OIDC無効、Grant TTL 8時間、再認証4時間
- Google Hosted Domain等は推測・自動設定しない

## 検証
- lint / typecheck 成功
- Unit 525件成功
- 対象DB integration 55件成功

Refs #219