### PR TITLE
feat(kaede): Membership単位Local Credential管理APIを追加する

### DIFF
--- a/apps/kaede/src/routes/organization-local-credentials/index.ts
+++ b/apps/kaede/src/routes/organization-local-credentials/index.ts
@@ -1,0 +1,6 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { registerOrganizationLocalCredentialRoutes } from './management.js'
+
+export const organizationLocalCredentialRoutes = new OpenAPIHono()
+
+registerOrganizationLocalCredentialRoutes(organizationLocalCredentialRoutes)

--- a/apps/kaede/src/routes/organization-local-credentials/management.ts
+++ b/apps/kaede/src/routes/organization-local-credentials/management.ts
@@ -1,0 +1,179 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { getRequestSessionId, requireRequestActor } from '../../middleware/request-actor-context.js'
+import type { RequestActorContext } from '../../middleware/request-actor-context.js'
+import { errorResponseSchema } from '../../schemas/common.js'
+import {
+  disableOrganizationLocalCredentialRequestSchema,
+  organizationLocalCredentialParamsSchema,
+  organizationLocalCredentialSchema,
+  putOrganizationLocalCredentialRequestSchema,
+} from '../../schemas/organization-local-credentials.js'
+import {
+  disableMyOrganizationLocalCredential,
+  getMyOrganizationLocalCredential,
+  putMyOrganizationLocalCredential,
+} from '../../usecases/organization-local-credentials/index.js'
+import type { OrganizationLocalCredentialManagementError } from '../../usecases/organization-local-credentials/index.js'
+
+const toErrorResponse = (error: OrganizationLocalCredentialManagementError) => {
+  switch (error.type) {
+    case 'AUTH_UNAUTHENTICATED':
+      return {
+        status: 401 as const,
+        body: { error_code: error.type, error_message: 'login required' },
+      }
+    case 'AUTH_INVALID_CREDENTIALS':
+      return {
+        status: 401 as const,
+        body: { error_code: error.type, error_message: 'current password is invalid' },
+      }
+    case 'AUTH_ORGANIZATION_FORBIDDEN':
+      return {
+        status: 403 as const,
+        body: { error_code: error.type, error_message: 'active membership is required' },
+      }
+    case 'AUTH_METHOD_NOT_ALLOWED':
+      return {
+        status: 403 as const,
+        body: { error_code: error.type, error_message: 'local authentication is disabled' },
+      }
+    case 'AUTH_MEMBERSHIP_REAUTHENTICATION_REQUIRED':
+      return {
+        status: 403 as const,
+        body: {
+          error_code: error.type,
+          error_message: 'recent membership authentication required',
+        },
+      }
+    case 'LOCAL_CREDENTIAL_NOT_FOUND':
+      return {
+        status: 404 as const,
+        body: { error_code: error.type, error_message: 'local credential not found' },
+      }
+    case 'LOCAL_CREDENTIAL_LAST_AUTH_METHOD':
+      return {
+        status: 409 as const,
+        body: { error_code: error.type, error_message: 'another usable login method is required' },
+      }
+    case 'LOCAL_LOGIN_EMAIL_CONFLICT':
+      return {
+        status: 409 as const,
+        body: { error_code: error.type, error_message: 'login email is already in use' },
+      }
+  }
+}
+
+const responses = {
+  200: {
+    description: 'local credential metadata（secret/hashは返さない）',
+    content: { 'application/json': { schema: organizationLocalCredentialSchema } },
+  },
+  400: {
+    description: 'request validation failed',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  401: {
+    description: 'login required or current password invalid',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  403: {
+    description: 'active membership or recent reauthentication required',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  404: {
+    description: 'credential not found',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  409: {
+    description: 'Organization内のlogin email conflict',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+} as const
+
+export const registerOrganizationLocalCredentialRoutes = (app: OpenAPIHono) => {
+  const getRoute = createRoute({
+    method: 'get',
+    path: '/{organizationId}/members/me/local-credential',
+    tags: ['Organization Local Credentials'],
+    description: '本人のMembership単位Local Credential metadataを取得する',
+    request: { params: organizationLocalCredentialParamsSchema },
+    responses,
+  })
+
+  app.openapi(getRoute, async (c) => {
+    const result = await getMyOrganizationLocalCredential(
+      requireRequestActor(c as RequestActorContext),
+      c.req.valid('param').organizationId
+    )
+    if (!result.ok) {
+      const error = toErrorResponse(result.error)
+      return c.json(error.body, error.status)
+    }
+    return c.json(result.value, 200)
+  })
+
+  const putRoute = createRoute({
+    method: 'put',
+    path: '/{organizationId}/members/me/local-credential',
+    tags: ['Organization Local Credentials'],
+    description:
+      '本人がLocal Credentialを初回設定または変更する。current passwordまたは最近のMembership認証を要求する',
+    request: {
+      params: organizationLocalCredentialParamsSchema,
+      body: {
+        required: true,
+        content: { 'application/json': { schema: putOrganizationLocalCredentialRequestSchema } },
+      },
+    },
+    responses,
+  })
+
+  app.openapi(putRoute, async (c) => {
+    const result = await putMyOrganizationLocalCredential(
+      requireRequestActor(c as RequestActorContext),
+      getRequestSessionId(c as RequestActorContext),
+      c.req.valid('param').organizationId,
+      c.req.valid('json'),
+      { requestId: c.req.header('x-request-id'), userAgent: c.req.header('user-agent') }
+    )
+    if (!result.ok) {
+      const error = toErrorResponse(result.error)
+      return c.json(error.body, error.status)
+    }
+    return c.json(result.value, 200)
+  })
+
+  const deleteRoute = createRoute({
+    method: 'delete',
+    path: '/{organizationId}/members/me/local-credential',
+    tags: ['Organization Local Credentials'],
+    description:
+      '本人のLocal Credentialを無効化する。current passwordまたは最近のMembership認証を要求する',
+    request: {
+      params: organizationLocalCredentialParamsSchema,
+      body: {
+        required: true,
+        content: {
+          'application/json': { schema: disableOrganizationLocalCredentialRequestSchema },
+        },
+      },
+    },
+    responses,
+  })
+
+  app.openapi(deleteRoute, async (c) => {
+    const result = await disableMyOrganizationLocalCredential(
+      requireRequestActor(c as RequestActorContext),
+      getRequestSessionId(c as RequestActorContext),
+      c.req.valid('param').organizationId,
+      c.req.valid('json'),
+      { requestId: c.req.header('x-request-id'), userAgent: c.req.header('user-agent') }
+    )
+    if (!result.ok) {
+      const error = toErrorResponse(result.error)
+      return c.json(error.body, error.status)
+    }
+    return c.json(result.value, 200)
+  })
+}

--- a/apps/kaede/src/schemas/organization-local-credentials.ts
+++ b/apps/kaede/src/schemas/organization-local-credentials.ts
@@ -1,0 +1,50 @@
+import { z } from '@hono/zod-openapi'
+import { isoDatetimeSchema, uuidSchema } from './common.js'
+
+export const organizationLocalCredentialParamsSchema = z
+  .object({ organizationId: uuidSchema })
+  .openapi('OrganizationLocalCredentialParams')
+
+const passwordSchema = z
+  .string()
+  .min(1)
+  .max(100)
+  .refine((value) => value.trim().length > 0, 'password must not be blank')
+
+export const organizationLocalCredentialSchema = z
+  .discriminatedUnion('configured', [
+    z.object({
+      organization_id: uuidSchema,
+      membership_id: uuidSchema,
+      configured: z.literal(false),
+    }),
+    z.object({
+      organization_id: uuidSchema,
+      membership_id: uuidSchema,
+      configured: z.literal(true),
+      login_email: z.string().email().max(255),
+      enabled: z.boolean(),
+      password_changed_at: isoDatetimeSchema,
+      updated_at: isoDatetimeSchema,
+    }),
+  ])
+  .openapi('OrganizationLocalCredential')
+
+export const putOrganizationLocalCredentialRequestSchema = z
+  .object({
+    login_email: z.string().email().max(255),
+    new_password: passwordSchema,
+    current_password: passwordSchema.optional(),
+  })
+  .openapi('PutOrganizationLocalCredentialRequest')
+
+export const disableOrganizationLocalCredentialRequestSchema = z
+  .object({ current_password: passwordSchema.optional() })
+  .openapi('DisableOrganizationLocalCredentialRequest')
+
+export type PutOrganizationLocalCredentialRequest = z.infer<
+  typeof putOrganizationLocalCredentialRequestSchema
+>
+export type DisableOrganizationLocalCredentialRequest = z.infer<
+  typeof disableOrganizationLocalCredentialRequestSchema
+>

--- a/apps/kaede/src/server.ts
+++ b/apps/kaede/src/server.ts
@@ -10,6 +10,7 @@ import { registerApiRoutes } from './routes/index.js'
 import { organizationAuthMethodsRoutes } from './routes/organization-auth-methods/index.js'
 import { organizationInvitesRoutes } from './routes/organization-invites/index.js'
 import { organizationLocalAuthRoutes } from './routes/organization-local-auth/index.js'
+import { organizationLocalCredentialRoutes } from './routes/organization-local-credentials/index.js'
 import { organizationOidcAuthRoutes } from './routes/organization-oidc-auth/index.js'
 import { organizationSessionAuthRoutes } from './routes/organization-session-auth/index.js'
 import { organizationAuthorizationErrorResponseSchema } from './schemas/common.js'
@@ -76,6 +77,10 @@ export const createApp = () => {
       sharedToken: runtimeConfig.app.apiSharedToken,
     })
   )
+
+  // Credential変更はcurrent passwordでも認可できるため、通常のMembership Grant Guardより前で
+  // 本人Session・Membership・再認証条件を専用Use Caseが検証する。
+  app.route('/api/organizations', organizationLocalCredentialRoutes)
 
   const authorizeOrganization = organizationAuthorizationMiddleware()
   app.use('/api/organizations/:organizationId', authorizeOrganization)

--- a/apps/kaede/src/services/organization-local-credentials/index.ts
+++ b/apps/kaede/src/services/organization-local-credentials/index.ts
@@ -1,0 +1,1 @@
+export * from './repository.js'

--- a/apps/kaede/src/services/organization-local-credentials/repository.ts
+++ b/apps/kaede/src/services/organization-local-credentials/repository.ts
@@ -1,0 +1,171 @@
+import type { Insertable, Updateable } from 'kysely'
+import type { AuditEvents, OrganizationLocalCredentials } from '../db/generated.js'
+import { db } from '../db/index.js'
+import type { DbExecutor } from '../executor.js'
+
+export const findLocalCredentialMembershipContext = async (
+  organizationId: string,
+  userId: string,
+  executor: DbExecutor = db,
+  lock = false
+) => {
+  let query = executor
+    .selectFrom('organization_memberships as membership')
+    .innerJoin('organizations as organization', 'organization.id', 'membership.organization_id')
+    .innerJoin(
+      'organization_auth_settings as settings',
+      'settings.organization_id',
+      'organization.id'
+    )
+    .select([
+      'membership.id as membership_id',
+      'membership.organization_id',
+      'membership.user_id',
+      'settings.local_auth_enabled',
+      'settings.policy_version',
+      'settings.reauthentication_interval_seconds',
+    ])
+    .where('membership.organization_id', '=', organizationId)
+    .where('membership.user_id', '=', userId)
+    .where('membership.status', '=', 'active')
+    .where('organization.status', '=', 'active')
+
+  if (lock) query = query.forUpdate('membership')
+  return query.executeTakeFirst()
+}
+
+export const findLocalCredentialByMembership = async (
+  membershipId: string,
+  executor: DbExecutor = db,
+  lock = false
+) => {
+  let query = executor
+    .selectFrom('organization_local_credentials')
+    .selectAll()
+    .where('membership_id', '=', membershipId)
+
+  if (lock) query = query.forUpdate()
+  return query.executeTakeFirst()
+}
+
+export const findRecentCredentialManagementGrant = async (
+  sessionId: string,
+  membershipId: string,
+  userId: string,
+  policyVersion: string,
+  reauthenticatedAfter: Date,
+  now: Date,
+  executor: DbExecutor
+) =>
+  executor
+    .selectFrom('session_membership_authentications')
+    .select('session_id')
+    .where('session_id', '=', sessionId)
+    .where('membership_id', '=', membershipId)
+    .where('user_id', '=', userId)
+    .where('policy_version', '=', policyVersion)
+    .where('authenticated_at', '>=', reauthenticatedAfter)
+    .where('expires_at', '>', now)
+    .where('revoked_at', 'is', null)
+    .executeTakeFirst()
+
+export const findRecentUserSession = async (
+  sessionId: string,
+  userId: string,
+  authenticatedAfter: Date,
+  now: Date,
+  executor: DbExecutor
+) =>
+  executor
+    .selectFrom('sessions')
+    .select('id')
+    .where('id', '=', sessionId)
+    .where('user_id', '=', userId)
+    .where('created_at', '>=', authenticatedAfter)
+    .where('expires_at', '>', now)
+    .where('revoked_at', 'is', null)
+    .executeTakeFirst()
+
+export const hasUsableOidcLink = async (
+  membershipId: string,
+  organizationId: string,
+  executor: DbExecutor
+) => {
+  const link = await executor
+    .selectFrom('organization_member_oidc_identities as link')
+    .innerJoin(
+      'organization_oidc_providers as provider',
+      'provider.id',
+      'link.organization_oidc_provider_id'
+    )
+    .innerJoin(
+      'organization_auth_settings as settings',
+      'settings.organization_id',
+      'link.organization_id'
+    )
+    .select('link.id')
+    .where('link.membership_id', '=', membershipId)
+    .where('link.organization_id', '=', organizationId)
+    .where('link.revoked_at', 'is', null)
+    .where('provider.enabled', '=', true)
+    .where('settings.oidc_auth_enabled', '=', true)
+    .executeTakeFirst()
+  return link !== undefined
+}
+
+export const findEnabledLocalCredentialByNormalizedEmail = async (
+  organizationId: string,
+  normalizedLoginEmail: string,
+  excludedCredentialId: string | undefined,
+  executor: DbExecutor
+) => {
+  let query = executor
+    .selectFrom('organization_local_credentials')
+    .select('id')
+    .where('organization_id', '=', organizationId)
+    .where('normalized_login_email', '=', normalizedLoginEmail)
+    .where('enabled', '=', true)
+
+  if (excludedCredentialId) query = query.where('id', '!=', excludedCredentialId)
+  return query.executeTakeFirst()
+}
+
+export const insertManagedLocalCredential = async (
+  credential: Insertable<OrganizationLocalCredentials>,
+  executor: DbExecutor
+) =>
+  executor
+    .insertInto('organization_local_credentials')
+    .values(credential)
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+export const updateManagedLocalCredential = async (
+  credentialId: string,
+  values: Updateable<OrganizationLocalCredentials>,
+  executor: DbExecutor
+) =>
+  executor
+    .updateTable('organization_local_credentials')
+    .set(values)
+    .where('id', '=', credentialId)
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+export const revokeGrantsFromLocalCredential = async (
+  credentialId: string,
+  revokedAt: Date,
+  executor: DbExecutor
+) =>
+  executor
+    .updateTable('session_membership_authentications')
+    .set({ revoked_at: revokedAt, updated_at: revokedAt })
+    .where('local_credential_id', '=', credentialId)
+    .where('auth_method', '=', 'local')
+    .where('revoked_at', 'is', null)
+    .executeTakeFirst()
+
+export const insertLocalCredentialAuditEvent = async (
+  event: Insertable<AuditEvents>,
+  executor: DbExecutor
+) => executor.insertInto('audit_events').values(event).executeTakeFirst()

--- a/apps/kaede/src/usecases/organization-local-credentials/index.ts
+++ b/apps/kaede/src/usecases/organization-local-credentials/index.ts
@@ -1,0 +1,339 @@
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import type {
+  DisableOrganizationLocalCredentialRequest,
+  PutOrganizationLocalCredentialRequest,
+} from '../../schemas/organization-local-credentials.js'
+import { hashPassword, verifyPassword } from '../../services/auth/index.js'
+import type { Json } from '../../services/db/index.js'
+import { db } from '../../services/db/index.js'
+import type { DbExecutor } from '../../services/executor.js'
+import { normalizeLocalLoginEmail } from '../../services/organization-local-auth/index.js'
+import {
+  findEnabledLocalCredentialByNormalizedEmail,
+  findLocalCredentialByMembership,
+  findLocalCredentialMembershipContext,
+  findRecentCredentialManagementGrant,
+  findRecentUserSession,
+  hasUsableOidcLink,
+  insertLocalCredentialAuditEvent,
+  insertManagedLocalCredential,
+  revokeGrantsFromLocalCredential,
+  updateManagedLocalCredential,
+} from '../../services/organization-local-credentials/index.js'
+
+export type OrganizationLocalCredentialManagementError =
+  | { type: 'AUTH_UNAUTHENTICATED' }
+  | { type: 'AUTH_ORGANIZATION_FORBIDDEN' }
+  | { type: 'AUTH_METHOD_NOT_ALLOWED' }
+  | { type: 'AUTH_MEMBERSHIP_REAUTHENTICATION_REQUIRED' }
+  | { type: 'AUTH_INVALID_CREDENTIALS' }
+  | { type: 'LOCAL_CREDENTIAL_NOT_FOUND' }
+  | { type: 'LOCAL_CREDENTIAL_LAST_AUTH_METHOD' }
+  | { type: 'LOCAL_LOGIN_EMAIL_CONFLICT' }
+
+type Result<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: OrganizationLocalCredentialManagementError }
+
+export interface LocalCredentialManagementMetadata {
+  requestId?: string
+  userAgent?: string
+}
+
+type CredentialMetadata =
+  | {
+      organization_id: string
+      membership_id: string
+      configured: false
+    }
+  | {
+      organization_id: string
+      membership_id: string
+      configured: true
+      login_email: string
+      enabled: boolean
+      password_changed_at: string
+      updated_at: string
+    }
+
+const runInTransaction = async <T>(
+  executor: DbExecutor | undefined,
+  callback: (trx: DbExecutor) => Promise<T>
+) => {
+  const base = executor ?? db
+  return 'transaction' in base ? base.transaction().execute(callback) : callback(base)
+}
+
+const userIdFromActor = (actor: RequestActor) => (actor.type === 'user' ? actor.user_id : undefined)
+
+const toMetadata = (
+  organizationId: string,
+  membershipId: string,
+  credential: Awaited<ReturnType<typeof findLocalCredentialByMembership>>
+): CredentialMetadata =>
+  credential
+    ? {
+        organization_id: organizationId,
+        membership_id: membershipId,
+        configured: true,
+        login_email: credential.login_email,
+        enabled: credential.enabled,
+        password_changed_at: credential.password_changed_at.toISOString(),
+        updated_at: credential.updated_at.toISOString(),
+      }
+    : { organization_id: organizationId, membership_id: membershipId, configured: false }
+
+const authorizeSensitiveChange = async (
+  currentPassword: string | undefined,
+  credential: Awaited<ReturnType<typeof findLocalCredentialByMembership>>,
+  context: NonNullable<Awaited<ReturnType<typeof findLocalCredentialMembershipContext>>>,
+  sessionId: string,
+  now: Date,
+  executor: DbExecutor
+): Promise<Result<true>> => {
+  const recentAfter = new Date(now.getTime() - context.reauthentication_interval_seconds * 1000)
+  if (!credential) {
+    const recentSession = await findRecentUserSession(
+      sessionId,
+      context.user_id,
+      recentAfter,
+      now,
+      executor
+    )
+    return recentSession
+      ? { ok: true, value: true }
+      : { ok: false, error: { type: 'AUTH_MEMBERSHIP_REAUTHENTICATION_REQUIRED' } }
+  }
+
+  if (currentPassword !== undefined) {
+    if (!(await verifyPassword(credential.password_hash, currentPassword))) {
+      return { ok: false, error: { type: 'AUTH_INVALID_CREDENTIALS' } }
+    }
+    return { ok: true, value: true }
+  }
+
+  const grant = await findRecentCredentialManagementGrant(
+    sessionId,
+    context.membership_id,
+    context.user_id,
+    context.policy_version,
+    recentAfter,
+    now,
+    executor
+  )
+  return grant
+    ? { ok: true, value: true }
+    : { ok: false, error: { type: 'AUTH_MEMBERSHIP_REAUTHENTICATION_REQUIRED' } }
+}
+
+const isLocalLoginEmailConflict = (error: unknown) => {
+  if (!error || typeof error !== 'object') return false
+  const databaseError = error as { code?: string; constraint?: string }
+  return (
+    databaseError.code === '23505' &&
+    databaseError.constraint === 'organization_local_credentials_active_email_key'
+  )
+}
+
+export const getMyOrganizationLocalCredential = async (
+  actor: RequestActor,
+  organizationId: string,
+  executor: DbExecutor = db
+): Promise<Result<CredentialMetadata>> => {
+  const userId = userIdFromActor(actor)
+  if (!userId) return { ok: false, error: { type: 'AUTH_UNAUTHENTICATED' } }
+
+  const context = await findLocalCredentialMembershipContext(organizationId, userId, executor)
+  if (!context) return { ok: false, error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' } }
+  const credential = await findLocalCredentialByMembership(context.membership_id, executor)
+  return {
+    ok: true,
+    value: toMetadata(context.organization_id, context.membership_id, credential),
+  }
+}
+
+export const putMyOrganizationLocalCredential = async (
+  actor: RequestActor,
+  sessionId: string | undefined,
+  organizationId: string,
+  payload: PutOrganizationLocalCredentialRequest,
+  metadata: LocalCredentialManagementMetadata = {},
+  now = new Date(),
+  executor?: DbExecutor
+): Promise<Result<CredentialMetadata>> => {
+  const userId = userIdFromActor(actor)
+  if (!userId || !sessionId) return { ok: false, error: { type: 'AUTH_UNAUTHENTICATED' } }
+
+  const prechecked = await findLocalCredentialMembershipContext(
+    organizationId,
+    userId,
+    executor ?? db
+  )
+  if (!prechecked) return { ok: false, error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' } }
+  if (!prechecked.local_auth_enabled) {
+    return { ok: false, error: { type: 'AUTH_METHOD_NOT_ALLOWED' } }
+  }
+
+  const passwordHash = await hashPassword(payload.new_password)
+  const normalizedLoginEmail = normalizeLocalLoginEmail(payload.login_email)
+
+  try {
+    return await runInTransaction(executor, async (trx) => {
+      const context = await findLocalCredentialMembershipContext(organizationId, userId, trx, true)
+      if (!context) return { ok: false, error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' } }
+      if (!context.local_auth_enabled) {
+        return { ok: false, error: { type: 'AUTH_METHOD_NOT_ALLOWED' } }
+      }
+
+      const current = await findLocalCredentialByMembership(context.membership_id, trx, true)
+      const authorized = await authorizeSensitiveChange(
+        payload.current_password,
+        current,
+        context,
+        sessionId,
+        now,
+        trx
+      )
+      if (!authorized.ok) return authorized
+
+      if (
+        await findEnabledLocalCredentialByNormalizedEmail(
+          organizationId,
+          normalizedLoginEmail,
+          current?.id,
+          trx
+        )
+      ) {
+        return { ok: false, error: { type: 'LOCAL_LOGIN_EMAIL_CONFLICT' } }
+      }
+
+      const credential = current
+        ? await updateManagedLocalCredential(
+            current.id,
+            {
+              login_email: payload.login_email.trim(),
+              normalized_login_email: normalizedLoginEmail,
+              password_hash: passwordHash,
+              password_changed_at: now,
+              failed_login_attempts: 0,
+              locked_until: null,
+              enabled: true,
+            },
+            trx
+          )
+        : await insertManagedLocalCredential(
+            {
+              membership_id: context.membership_id,
+              organization_id: context.organization_id,
+              login_email: payload.login_email.trim(),
+              normalized_login_email: normalizedLoginEmail,
+              password_hash: passwordHash,
+              password_changed_at: now,
+              failed_login_attempts: 0,
+              locked_until: null,
+              enabled: true,
+            },
+            trx
+          )
+
+      if (current) await revokeGrantsFromLocalCredential(current.id, now, trx)
+      const changedFields = current
+        ? [
+            ...(current.login_email !== credential.login_email ? ['login_email'] : []),
+            'password',
+            ...(current.enabled ? [] : ['enabled']),
+          ]
+        : ['login_email', 'password', 'enabled']
+      await insertLocalCredentialAuditEvent(
+        {
+          actor_user_id: userId,
+          actor_membership_id: context.membership_id,
+          organization_id: organizationId,
+          target_type: 'organization_local_credential',
+          target_id: credential.id,
+          action: current ? 'update' : 'create',
+          changed_fields: changedFields,
+          before_values: current
+            ? ({ login_email: current.login_email, enabled: current.enabled } as Json)
+            : null,
+          after_values: {
+            login_email: credential.login_email,
+            enabled: credential.enabled,
+          } as Json,
+          request_id: metadata.requestId ?? null,
+        },
+        trx
+      )
+      return {
+        ok: true,
+        value: toMetadata(context.organization_id, context.membership_id, credential),
+      }
+    })
+  } catch (error) {
+    if (isLocalLoginEmailConflict(error)) {
+      return { ok: false, error: { type: 'LOCAL_LOGIN_EMAIL_CONFLICT' } }
+    }
+    throw error
+  }
+}
+
+export const disableMyOrganizationLocalCredential = async (
+  actor: RequestActor,
+  sessionId: string | undefined,
+  organizationId: string,
+  payload: DisableOrganizationLocalCredentialRequest,
+  metadata: LocalCredentialManagementMetadata = {},
+  now = new Date(),
+  executor?: DbExecutor
+): Promise<Result<CredentialMetadata>> => {
+  const userId = userIdFromActor(actor)
+  if (!userId || !sessionId) return { ok: false, error: { type: 'AUTH_UNAUTHENTICATED' } }
+
+  return runInTransaction(executor, async (trx) => {
+    const context = await findLocalCredentialMembershipContext(organizationId, userId, trx, true)
+    if (!context) return { ok: false, error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' } }
+    const current = await findLocalCredentialByMembership(context.membership_id, trx, true)
+    if (!current) return { ok: false, error: { type: 'LOCAL_CREDENTIAL_NOT_FOUND' } }
+
+    const authorized = await authorizeSensitiveChange(
+      payload.current_password,
+      current,
+      context,
+      sessionId,
+      now,
+      trx
+    )
+    if (!authorized.ok) return authorized
+    if (!current.enabled) {
+      return {
+        ok: true,
+        value: toMetadata(context.organization_id, context.membership_id, current),
+      }
+    }
+    if (!(await hasUsableOidcLink(context.membership_id, organizationId, trx))) {
+      return { ok: false, error: { type: 'LOCAL_CREDENTIAL_LAST_AUTH_METHOD' } }
+    }
+
+    const credential = await updateManagedLocalCredential(current.id, { enabled: false }, trx)
+    await revokeGrantsFromLocalCredential(current.id, now, trx)
+    await insertLocalCredentialAuditEvent(
+      {
+        actor_user_id: userId,
+        actor_membership_id: context.membership_id,
+        organization_id: organizationId,
+        target_type: 'organization_local_credential',
+        target_id: credential.id,
+        action: 'disable',
+        changed_fields: ['enabled'],
+        before_values: { login_email: current.login_email, enabled: true } as Json,
+        after_values: { login_email: credential.login_email, enabled: false } as Json,
+        request_id: metadata.requestId ?? null,
+      },
+      trx
+    )
+    return {
+      ok: true,
+      value: toMetadata(context.organization_id, context.membership_id, credential),
+    }
+  })
+}

--- a/apps/kaede/tests/services/auth/organization-local-credential-management.test.ts
+++ b/apps/kaede/tests/services/auth/organization-local-credential-management.test.ts
@@ -1,0 +1,211 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import type { RequestActor } from '../../../src/middleware/request-actor-context.js'
+import { createSession, hashPassword } from '../../../src/services/auth/index.js'
+import { createDb } from '../../../src/services/db/client.js'
+import {
+  disableMyOrganizationLocalCredential,
+  getMyOrganizationLocalCredential,
+  putMyOrganizationLocalCredential,
+} from '../../../src/usecases/organization-local-credentials/index.js'
+import { resetDatabase } from '../../db/helpers.js'
+
+const db = createDb()
+const now = new Date('2026-08-11T12:00:00.000Z')
+
+const createFixture = async () => {
+  const user = await db
+    .insertInto('users')
+    .values({
+      email: 'global@example.test',
+      display_name: 'Local Credential User',
+      global_role: 'none',
+      status: 'active',
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const organization = await db
+    .insertInto('organizations')
+    .values({ name: 'Credential Organization', slug: 'credential-organization' })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  await db
+    .insertInto('organization_auth_settings')
+    .values({
+      organization_id: organization.id,
+      local_auth_enabled: true,
+      oidc_auth_enabled: false,
+      membership_grant_ttl_seconds: 28_800,
+      reauthentication_interval_seconds: 14_400,
+    })
+    .execute()
+  const membership = await db
+    .insertInto('organization_memberships')
+    .values({ organization_id: organization.id, user_id: user.id, role: 'member' })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const { session } = await createSession({ userId: user.id, now }, db)
+  const actor = {
+    type: 'user',
+    user_id: user.id,
+    email: user.email,
+    global_role: 'none',
+    account_state: 'active',
+    memberships: [
+      { organization_id: organization.id, organization_name: organization.name, role: 'member' },
+    ],
+  } satisfies RequestActor
+  return { actor, membership, organization, session, user }
+}
+
+describe('organization local credential management', () => {
+  beforeEach(async () => resetDatabase(db))
+  afterAll(async () => db.destroy())
+
+  it('recentなUser Sessionで初回Credentialを設定し、secretを返さない', async () => {
+    const fixture = await createFixture()
+    const result = await putMyOrganizationLocalCredential(
+      fixture.actor,
+      fixture.session.id,
+      fixture.organization.id,
+      { login_email: ' Login@Example.Test ', new_password: 'new-password' },
+      {},
+      now,
+      db
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        configured: true,
+        login_email: 'Login@Example.Test',
+        enabled: true,
+      },
+    })
+    if (!result.ok) return
+    expect(result.value).not.toHaveProperty('password_hash')
+    expect(JSON.stringify(result.value)).not.toContain('new-password')
+    const stored = await db
+      .selectFrom('organization_local_credentials')
+      .select(['normalized_login_email', 'password_hash'])
+      .where('membership_id', '=', fixture.membership.id)
+      .executeTakeFirstOrThrow()
+    expect(stored.normalized_login_email).toBe('login@example.test')
+    expect(stored.password_hash).not.toBe('new-password')
+    await expect(
+      getMyOrganizationLocalCredential(fixture.actor, fixture.organization.id, db)
+    ).resolves.toMatchObject({ ok: true, value: { configured: true } })
+  })
+
+  it('現在passwordで変更し、そのCredential由来Grantだけをrevokeする', async () => {
+    const fixture = await createFixture()
+    const credential = await db
+      .insertInto('organization_local_credentials')
+      .values({
+        membership_id: fixture.membership.id,
+        organization_id: fixture.organization.id,
+        login_email: 'old@example.test',
+        normalized_login_email: 'old@example.test',
+        password_hash: await hashPassword('current-password'),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    await db
+      .insertInto('session_membership_authentications')
+      .values({
+        session_id: fixture.session.id,
+        membership_id: fixture.membership.id,
+        user_id: fixture.user.id,
+        auth_method: 'local',
+        policy_version: 1,
+        local_credential_id: credential.id,
+        authenticated_at: now,
+        expires_at: new Date(now.getTime() + 3_600_000),
+      })
+      .execute()
+
+    const result = await putMyOrganizationLocalCredential(
+      fixture.actor,
+      fixture.session.id,
+      fixture.organization.id,
+      {
+        login_email: 'changed@example.test',
+        current_password: 'current-password',
+        new_password: 'changed-password',
+      },
+      {},
+      now,
+      db
+    )
+
+    expect(result).toMatchObject({ ok: true, value: { login_email: 'changed@example.test' } })
+    await expect(
+      db
+        .selectFrom('session_membership_authentications')
+        .select('revoked_at')
+        .where('local_credential_id', '=', credential.id)
+        .executeTakeFirstOrThrow()
+    ).resolves.toEqual({ revoked_at: now })
+  })
+
+  it('Organization内のnormalized login email重複を拒否する', async () => {
+    const fixture = await createFixture()
+    const otherUser = await db
+      .insertInto('users')
+      .values({ email: 'other@example.test', display_name: 'Other', status: 'active' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const otherMembership = await db
+      .insertInto('organization_memberships')
+      .values({ organization_id: fixture.organization.id, user_id: otherUser.id, role: 'member' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    await db
+      .insertInto('organization_local_credentials')
+      .values({
+        membership_id: otherMembership.id,
+        organization_id: fixture.organization.id,
+        login_email: 'used@example.test',
+        normalized_login_email: 'used@example.test',
+        password_hash: await hashPassword('other-password'),
+      })
+      .execute()
+
+    await expect(
+      putMyOrganizationLocalCredential(
+        fixture.actor,
+        fixture.session.id,
+        fixture.organization.id,
+        { login_email: ' USED@example.test ', new_password: 'new-password' },
+        {},
+        now,
+        db
+      )
+    ).resolves.toEqual({ ok: false, error: { type: 'LOCAL_LOGIN_EMAIL_CONFLICT' } })
+  })
+
+  it('利用可能なOIDC Linkがない場合は最後の認証方式を無効化しない', async () => {
+    const fixture = await createFixture()
+    await db
+      .insertInto('organization_local_credentials')
+      .values({
+        membership_id: fixture.membership.id,
+        organization_id: fixture.organization.id,
+        login_email: 'only@example.test',
+        normalized_login_email: 'only@example.test',
+        password_hash: await hashPassword('current-password'),
+      })
+      .execute()
+
+    await expect(
+      disableMyOrganizationLocalCredential(
+        fixture.actor,
+        fixture.session.id,
+        fixture.organization.id,
+        { current_password: 'current-password' },
+        {},
+        now,
+        db
+      )
+    ).resolves.toEqual({ ok: false, error: { type: 'LOCAL_CREDENTIAL_LAST_AUTH_METHOD' } })
+  })
+})


### PR DESCRIPTION
## 概要
本人がOrganizationごとのLocal login email/passwordを安全に設定・変更・無効化できるAPIを追加します。

## 変更内容
- GET/PUT/DELETE `/api/organizations/{organizationId}/members/me/local-credential`
- secret/password hashを返さないmetadata response
- 初回設定は直近User Session、変更は現在passwordまたは直近Membership認証を要求
- Organization内normalized login email一意性を検証
- 変更/無効化時は対象Credential由来のLocal Grantだけrevoke
- usable OIDC Linkがない場合は最後のLocal認証方式の無効化を拒否
- security Audit Eventを記録

## 検証
- lint / typecheck 成功
- Unit 525件成功
- 対象DB integration 4件成功

Refs #219