### PR TITLE
feat(kaede): Membership OIDC Link管理APIを追加する

### DIFF
--- a/apps/kaede/src/routes/organizations/index.ts
+++ b/apps/kaede/src/routes/organizations/index.ts
@@ -20,6 +20,7 @@ import { registerListOrganizationUsersRoute } from './list-organization-users.js
 import { registerListOrganizationsRoute } from './list-organizations.js'
 import { registerOrganizationMemberProfileRoutes } from './member-profiles.js'
 import { registerMembershipAdministrationRoutes } from './membership-administration.js'
+import { registerOrganizationOidcLinkRoutes } from './oidc-links.js'
 import { registerOrganizationOidcProviderRoutes } from './oidc-providers.js'
 
 export const organizationsRoutes = new OpenAPIHono()
@@ -44,5 +45,6 @@ registerAnalysisRunRoutes(organizationsRoutes)
 registerOrganizationAuthSettingsRoutes(organizationsRoutes)
 registerOrganizationMemberProfileRoutes(organizationsRoutes)
 registerMembershipAdministrationRoutes(organizationsRoutes)
+registerOrganizationOidcLinkRoutes(organizationsRoutes)
 registerOrganizationOidcProviderRoutes(organizationsRoutes)
 registerOrganizationInviteRoutes(organizationsRoutes)

--- a/apps/kaede/src/routes/organizations/oidc-links.ts
+++ b/apps/kaede/src/routes/organizations/oidc-links.ts
@@ -1,0 +1,121 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { requireRequestActor } from '../../middleware/request-actor-context.js'
+import type { RequestActorContext } from '../../middleware/request-actor-context.js'
+import { authOkResponseSchema } from '../../schemas/auth.js'
+import { authErrorResponseSchema } from '../../schemas/common.js'
+import {
+  organizationOidcLinkErrorResponseSchema,
+  organizationOidcLinkParamsSchema,
+  organizationOidcLinksResponseSchema,
+} from '../../schemas/organization-oidc-links.js'
+import { organizationIdParamsSchema } from '../../schemas/organizations.js'
+import {
+  getMyOrganizationOidcLinks,
+  unlinkMyOrganizationOidcIdentity,
+} from '../../usecases/organization-oidc-links/index.js'
+
+const authErrors = {
+  401: {
+    description: 'login required',
+    content: { 'application/json': { schema: authErrorResponseSchema } },
+  },
+  403: {
+    description: 'active membership and grant required',
+    content: { 'application/json': { schema: authErrorResponseSchema } },
+  },
+} as const
+
+export const registerOrganizationOidcLinkRoutes = (app: OpenAPIHono) => {
+  const listRoute = createRoute({
+    method: 'get',
+    path: '/{organizationId}/members/me/oidc-links',
+    tags: ['Organization OIDC Links'],
+    description: '本人Membershipのactive OIDC LinkとProvider表示情報を取得する',
+    request: { params: organizationIdParamsSchema },
+    responses: {
+      200: {
+        description: 'active OIDC links',
+        content: { 'application/json': { schema: organizationOidcLinksResponseSchema } },
+      },
+      401: authErrors[401],
+      403: authErrors[403],
+    },
+  })
+
+  app.openapi(listRoute, async (c) => {
+    const result = await getMyOrganizationOidcLinks(
+      requireRequestActor(c as RequestActorContext),
+      c.req.valid('param').organizationId
+    )
+    if (!result.ok) {
+      return c.json(
+        {
+          error_code: 'AUTH_ORGANIZATION_FORBIDDEN' as const,
+          error_message: 'organization membership access is required',
+        },
+        403
+      )
+    }
+    return c.json(result.value, 200)
+  })
+
+  const unlinkRoute = createRoute({
+    method: 'delete',
+    path: '/{organizationId}/members/me/oidc-links/{linkId}',
+    tags: ['Organization OIDC Links'],
+    description:
+      '本人がOIDC Linkを明示的にunlinkする。canonical Identityは維持し、対象Link由来のGrantだけをrevokeする',
+    request: { params: organizationOidcLinkParamsSchema },
+    responses: {
+      200: {
+        description: 'OIDC link unlinked',
+        content: { 'application/json': { schema: authOkResponseSchema } },
+      },
+      401: authErrors[401],
+      403: authErrors[403],
+      404: {
+        description: 'active OIDC link not found',
+        content: { 'application/json': { schema: organizationOidcLinkErrorResponseSchema } },
+      },
+      409: {
+        description: 'unlink would remove the last usable authentication method',
+        content: { 'application/json': { schema: organizationOidcLinkErrorResponseSchema } },
+      },
+    },
+  })
+
+  app.openapi(unlinkRoute, async (c) => {
+    const { organizationId, linkId } = c.req.valid('param')
+    const result = await unlinkMyOrganizationOidcIdentity(
+      requireRequestActor(c as RequestActorContext),
+      organizationId,
+      linkId
+    )
+    if (!result.ok) {
+      if (result.error.type === 'AUTH_ORGANIZATION_FORBIDDEN') {
+        return c.json(
+          {
+            error_code: result.error.type,
+            error_message: 'organization membership access is required',
+          },
+          403
+        )
+      }
+      if (result.error.type === 'OIDC_MEMBERSHIP_LINK_NOT_FOUND') {
+        return c.json(
+          { error_code: result.error.type, error_message: 'active OIDC link not found' },
+          404
+        )
+      }
+      return c.json(
+        {
+          error_code: result.error.type,
+          error_message: 'the last usable authentication method cannot be removed',
+        },
+        409
+      )
+    }
+    return c.json(result.value, 200)
+  })
+}

--- a/apps/kaede/src/schemas/organization-oidc-links.ts
+++ b/apps/kaede/src/schemas/organization-oidc-links.ts
@@ -1,0 +1,32 @@
+import { z } from '@hono/zod-openapi'
+import { errorResponseSchema, isoDatetimeSchema, uuidSchema } from './common.js'
+import { organizationIdParamsSchema } from './organizations.js'
+
+export const organizationOidcLinkSchema = z
+  .object({
+    id: uuidSchema,
+    provider: z.object({
+      id: uuidSchema,
+      display_name: z.string().min(1),
+      enabled: z.boolean(),
+    }),
+    linked_at: isoDatetimeSchema,
+  })
+  .openapi('OrganizationOidcLink')
+
+export const organizationOidcLinksResponseSchema = z
+  .object({ links: z.array(organizationOidcLinkSchema) })
+  .openapi('OrganizationOidcLinksResponse')
+
+export const organizationOidcLinkParamsSchema = organizationIdParamsSchema.extend({
+  linkId: uuidSchema,
+})
+
+export const organizationOidcLinkErrorCodeSchema = z.enum([
+  'OIDC_MEMBERSHIP_LINK_NOT_FOUND',
+  'OIDC_LINK_LAST_USABLE_AUTH_METHOD',
+])
+
+export const organizationOidcLinkErrorResponseSchema = errorResponseSchema
+  .extend({ error_code: organizationOidcLinkErrorCodeSchema })
+  .openapi('OrganizationOidcLinkErrorResponse')

--- a/apps/kaede/src/services/organization-oidc-links/index.ts
+++ b/apps/kaede/src/services/organization-oidc-links/index.ts
@@ -1,0 +1,1 @@
+export * from './repository.js'

--- a/apps/kaede/src/services/organization-oidc-links/repository.ts
+++ b/apps/kaede/src/services/organization-oidc-links/repository.ts
@@ -1,0 +1,162 @@
+import { sql } from 'kysely'
+import type { Insertable } from 'kysely'
+import type { AuditEvents, AuthenticationEvents } from '../db/generated.js'
+import { db } from '../db/index.js'
+import type { DbExecutor } from '../executor.js'
+
+const activeMembershipQuery = (executor: DbExecutor) =>
+  executor.selectFrom('organization_memberships').selectAll().where('status', '=', 'active')
+
+export const findActiveMembership = async (
+  organizationId: string,
+  userId: string,
+  executor: DbExecutor = db
+) =>
+  activeMembershipQuery(executor)
+    .where('organization_id', '=', organizationId)
+    .where('user_id', '=', userId)
+    .executeTakeFirst()
+
+export const findActiveMembershipForUpdate = async (
+  organizationId: string,
+  userId: string,
+  executor: DbExecutor
+) =>
+  activeMembershipQuery(executor)
+    .where('organization_id', '=', organizationId)
+    .where('user_id', '=', userId)
+    .forUpdate()
+    .executeTakeFirst()
+
+export const listActiveOrganizationOidcLinks = async (
+  membershipId: string,
+  executor: DbExecutor = db
+) =>
+  executor
+    .selectFrom('organization_member_oidc_identities as link')
+    .innerJoin(
+      'organization_oidc_providers as provider',
+      'provider.id',
+      'link.organization_oidc_provider_id'
+    )
+    .select([
+      'link.id',
+      'link.created_at as linked_at',
+      'provider.id as provider_id',
+      'provider.name as provider_name',
+      'provider.enabled as provider_enabled',
+    ])
+    .where('link.membership_id', '=', membershipId)
+    .where('link.revoked_at', 'is', null)
+    .orderBy('link.created_at', 'asc')
+    .execute()
+
+export const findOrganizationAuthSettingsForUpdate = async (
+  organizationId: string,
+  executor: DbExecutor
+) =>
+  executor
+    .selectFrom('organization_auth_settings')
+    .select(['local_auth_enabled', 'oidc_auth_enabled'])
+    .where('organization_id', '=', organizationId)
+    .forUpdate()
+    .executeTakeFirst()
+
+export const findActiveOrganizationOidcLinkForUpdate = async (
+  organizationId: string,
+  membershipId: string,
+  linkId: string,
+  executor: DbExecutor
+) =>
+  executor
+    .selectFrom('organization_member_oidc_identities as link')
+    .innerJoin(
+      'organization_oidc_providers as provider',
+      'provider.id',
+      'link.organization_oidc_provider_id'
+    )
+    .select([
+      'link.id',
+      'link.oidc_identity_id',
+      'link.organization_oidc_provider_id as provider_id',
+      'provider.enabled as provider_enabled',
+    ])
+    .where('link.id', '=', linkId)
+    .where('link.organization_id', '=', organizationId)
+    .where('link.membership_id', '=', membershipId)
+    .where('link.revoked_at', 'is', null)
+    .forUpdate('link')
+    .executeTakeFirst()
+
+export const hasEnabledLocalCredential = async (
+  membershipId: string,
+  executor: DbExecutor
+): Promise<boolean> =>
+  Boolean(
+    await executor
+      .selectFrom('organization_local_credentials')
+      .select('id')
+      .where('membership_id', '=', membershipId)
+      .where('enabled', '=', true)
+      .executeTakeFirst()
+  )
+
+export const countOtherUsableOidcLinks = async (
+  membershipId: string,
+  excludedLinkId: string,
+  executor: DbExecutor
+): Promise<number> => {
+  const result = await executor
+    .selectFrom('organization_member_oidc_identities as link')
+    .innerJoin(
+      'organization_oidc_providers as provider',
+      'provider.id',
+      'link.organization_oidc_provider_id'
+    )
+    .select(sql<number>`count(*)::integer`.as('count'))
+    .where('link.membership_id', '=', membershipId)
+    .where('link.id', '!=', excludedLinkId)
+    .where('link.revoked_at', 'is', null)
+    .where('provider.enabled', '=', true)
+    .executeTakeFirstOrThrow()
+  return result.count
+}
+
+export const revokeOrganizationOidcLink = async (
+  linkId: string,
+  revokedAt: Date,
+  executor: DbExecutor
+) =>
+  executor
+    .updateTable('organization_member_oidc_identities')
+    .set({ revoked_at: revokedAt })
+    .where('id', '=', linkId)
+    .where('revoked_at', 'is', null)
+    .returningAll()
+    .executeTakeFirst()
+
+export const revokeActiveGrantsForOidcLink = async (
+  membershipId: string,
+  linkId: string,
+  revokedAt: Date,
+  executor: DbExecutor
+) => {
+  const result = await executor
+    .updateTable('session_membership_authentications')
+    .set({ revoked_at: revokedAt, updated_at: revokedAt })
+    .where('membership_id', '=', membershipId)
+    .where('member_oidc_identity_id', '=', linkId)
+    .where('revoked_at', 'is', null)
+    .executeTakeFirst()
+  return Number(result.numUpdatedRows)
+}
+
+export const insertOidcLinkAuditEvent = async (
+  event: Insertable<AuditEvents>,
+  executor: DbExecutor
+) => executor.insertInto('audit_events').values(event).executeTakeFirst()
+
+export const insertOidcLinkAuthenticationEvent = async (
+  event: Insertable<AuthenticationEvents>,
+  executor: DbExecutor
+) => executor.insertInto('authentication_events').values(event).executeTakeFirst()

--- a/apps/kaede/src/usecases/organization-oidc-links/index.test.ts
+++ b/apps/kaede/src/usecases/organization-oidc-links/index.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import type { DbExecutor } from '../../services/executor.js'
+
+const mocks = vi.hoisted(() => ({
+  countOtherUsableOidcLinks: vi.fn(),
+  findActiveMembership: vi.fn(),
+  findActiveMembershipForUpdate: vi.fn(),
+  findActiveOrganizationOidcLinkForUpdate: vi.fn(),
+  findOrganizationAuthSettingsForUpdate: vi.fn(),
+  hasEnabledLocalCredential: vi.fn(),
+  insertOidcLinkAuditEvent: vi.fn(),
+  insertOidcLinkAuthenticationEvent: vi.fn(),
+  listActiveOrganizationOidcLinks: vi.fn(),
+  revokeActiveGrantsForOidcLink: vi.fn(),
+  revokeOrganizationOidcLink: vi.fn(),
+}))
+
+vi.mock('../../services/organization-oidc-links/index.js', () => mocks)
+vi.mock('../../services/db/index.js', () => ({ db: {} }))
+
+import { getMyOrganizationOidcLinks, unlinkMyOrganizationOidcIdentity } from './index.js'
+
+const executor = {} as DbExecutor
+const organizationId = '11111111-1111-4111-8111-111111111111'
+const userId = '22222222-2222-4222-8222-222222222222'
+const membershipId = '33333333-3333-4333-8333-333333333333'
+const linkId = '44444444-4444-4444-8444-444444444444'
+const providerId = '55555555-5555-4555-8555-555555555555'
+const identityId = '66666666-6666-4666-8666-666666666666'
+const now = new Date('2026-08-11T12:00:00.000Z')
+
+const actor: RequestActor = {
+  type: 'user',
+  user_id: userId,
+  email: 'member@example.com',
+  global_role: 'none',
+  account_state: 'active',
+  memberships: [{ organization_id: organizationId, organization_name: 'Example', role: 'member' }],
+}
+
+const membership = { id: membershipId, organization_id: organizationId, user_id: userId }
+const link = {
+  id: linkId,
+  oidc_identity_id: identityId,
+  provider_id: providerId,
+  provider_enabled: true,
+}
+
+describe('organization OIDC link usecases', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.findActiveMembership.mockResolvedValue(membership)
+    mocks.findActiveMembershipForUpdate.mockResolvedValue(membership)
+    mocks.findOrganizationAuthSettingsForUpdate.mockResolvedValue({
+      local_auth_enabled: true,
+      oidc_auth_enabled: true,
+    })
+    mocks.findActiveOrganizationOidcLinkForUpdate.mockResolvedValue(link)
+    mocks.hasEnabledLocalCredential.mockResolvedValue(true)
+    mocks.countOtherUsableOidcLinks.mockResolvedValue(0)
+    mocks.revokeOrganizationOidcLink.mockResolvedValue({ id: linkId, revoked_at: now })
+    mocks.revokeActiveGrantsForOidcLink.mockResolvedValue(2)
+    mocks.listActiveOrganizationOidcLinks.mockResolvedValue([
+      {
+        id: linkId,
+        linked_at: new Date('2026-08-10T00:00:00.000Z'),
+        provider_id: providerId,
+        provider_name: 'Google',
+        provider_enabled: true,
+      },
+    ])
+  })
+
+  it('本人Membershipのactive LinkをProvider表示情報だけで返す', async () => {
+    await expect(getMyOrganizationOidcLinks(actor, organizationId, executor)).resolves.toEqual({
+      ok: true,
+      value: {
+        links: [
+          {
+            id: linkId,
+            provider: { id: providerId, display_name: 'Google', enabled: true },
+            linked_at: '2026-08-10T00:00:00.000Z',
+          },
+        ],
+      },
+    })
+  })
+
+  it('active MembershipがなければLink一覧を返さない', async () => {
+    mocks.findActiveMembership.mockResolvedValue(undefined)
+
+    await expect(getMyOrganizationOidcLinks(actor, organizationId, executor)).resolves.toEqual({
+      ok: false,
+      error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' },
+    })
+    expect(mocks.listActiveOrganizationOidcLinks).not.toHaveBeenCalled()
+  })
+
+  it('Local Credentialが残る場合はLinkとそのLink由来GrantだけをrevokeしてEventを残す', async () => {
+    const result = await unlinkMyOrganizationOidcIdentity(actor, organizationId, linkId, {
+      now,
+      executor,
+    })
+
+    expect(result).toEqual({ ok: true, value: { ok: true } })
+    expect(mocks.revokeOrganizationOidcLink).toHaveBeenCalledWith(linkId, now, executor)
+    expect(mocks.revokeActiveGrantsForOidcLink).toHaveBeenCalledWith(
+      membershipId,
+      linkId,
+      now,
+      executor
+    )
+    expect(mocks.insertOidcLinkAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actor_user_id: userId,
+        actor_membership_id: membershipId,
+        organization_id: organizationId,
+        target_type: 'organization_member_oidc_identity',
+        target_id: linkId,
+        action: 'unlink',
+        changed_fields: ['revoked_at'],
+      }),
+      executor
+    )
+    expect(mocks.insertOidcLinkAuthenticationEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_type: 'oidc_unlink_identity',
+        outcome: 'success',
+        credential_reference_id: identityId,
+      }),
+      executor
+    )
+  })
+
+  it('利用可能な最後の認証手段になるLinkはunlinkできない', async () => {
+    mocks.findOrganizationAuthSettingsForUpdate.mockResolvedValue({
+      local_auth_enabled: false,
+      oidc_auth_enabled: true,
+    })
+    mocks.hasEnabledLocalCredential.mockResolvedValue(false)
+    mocks.countOtherUsableOidcLinks.mockResolvedValue(0)
+
+    const result = await unlinkMyOrganizationOidcIdentity(actor, organizationId, linkId, {
+      now,
+      executor,
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      error: { type: 'OIDC_LINK_LAST_USABLE_AUTH_METHOD' },
+    })
+    expect(mocks.revokeOrganizationOidcLink).not.toHaveBeenCalled()
+    expect(mocks.revokeActiveGrantsForOidcLink).not.toHaveBeenCalled()
+    expect(mocks.insertOidcLinkAuditEvent).not.toHaveBeenCalled()
+  })
+
+  it('別のenabled OIDC Linkが残ればLocal Credentialなしでもunlinkできる', async () => {
+    mocks.findOrganizationAuthSettingsForUpdate.mockResolvedValue({
+      local_auth_enabled: false,
+      oidc_auth_enabled: true,
+    })
+    mocks.hasEnabledLocalCredential.mockResolvedValue(false)
+    mocks.countOtherUsableOidcLinks.mockResolvedValue(1)
+
+    await expect(
+      unlinkMyOrganizationOidcIdentity(actor, organizationId, linkId, { now, executor })
+    ).resolves.toEqual({ ok: true, value: { ok: true } })
+  })
+
+  it('対象Providerがdisabledなら現在の利用可能手段を減らさないためunlinkできる', async () => {
+    mocks.findActiveOrganizationOidcLinkForUpdate.mockResolvedValue({
+      ...link,
+      provider_enabled: false,
+    })
+    mocks.findOrganizationAuthSettingsForUpdate.mockResolvedValue({
+      local_auth_enabled: false,
+      oidc_auth_enabled: true,
+    })
+
+    await expect(
+      unlinkMyOrganizationOidcIdentity(actor, organizationId, linkId, { now, executor })
+    ).resolves.toEqual({ ok: true, value: { ok: true } })
+    expect(mocks.hasEnabledLocalCredential).not.toHaveBeenCalled()
+    expect(mocks.countOtherUsableOidcLinks).not.toHaveBeenCalled()
+  })
+
+  it('本人のactive Linkでなければ404用errorを返す', async () => {
+    mocks.findActiveOrganizationOidcLinkForUpdate.mockResolvedValue(undefined)
+
+    await expect(
+      unlinkMyOrganizationOidcIdentity(actor, organizationId, linkId, { now, executor })
+    ).resolves.toEqual({
+      ok: false,
+      error: { type: 'OIDC_MEMBERSHIP_LINK_NOT_FOUND' },
+    })
+  })
+})

--- a/apps/kaede/src/usecases/organization-oidc-links/index.ts
+++ b/apps/kaede/src/usecases/organization-oidc-links/index.ts
@@ -1,0 +1,149 @@
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import type { Json } from '../../services/db/index.js'
+import { db } from '../../services/db/index.js'
+import type { DbExecutor } from '../../services/executor.js'
+import {
+  countOtherUsableOidcLinks,
+  findActiveMembership,
+  findActiveMembershipForUpdate,
+  findActiveOrganizationOidcLinkForUpdate,
+  findOrganizationAuthSettingsForUpdate,
+  hasEnabledLocalCredential,
+  insertOidcLinkAuditEvent,
+  insertOidcLinkAuthenticationEvent,
+  listActiveOrganizationOidcLinks,
+  revokeActiveGrantsForOidcLink,
+  revokeOrganizationOidcLink,
+} from '../../services/organization-oidc-links/index.js'
+
+export type OrganizationOidcLinkError =
+  | { type: 'AUTH_ORGANIZATION_FORBIDDEN' }
+  | { type: 'OIDC_MEMBERSHIP_LINK_NOT_FOUND' }
+  | { type: 'OIDC_LINK_LAST_USABLE_AUTH_METHOD' }
+
+type Result<T> = { ok: true; value: T } | { ok: false; error: OrganizationOidcLinkError }
+
+const runInTransaction = async <T>(
+  executor: DbExecutor | undefined,
+  callback: (trx: DbExecutor) => Promise<T>
+): Promise<T> => {
+  const base = executor ?? db
+  return 'transaction' in base ? base.transaction().execute(callback) : callback(base)
+}
+
+const userIdFromActor = (actor: RequestActor) => (actor.type === 'user' ? actor.user_id : undefined)
+
+const toLinkResponse = (link: {
+  id: string
+  linked_at: Date
+  provider_id: string
+  provider_name: string
+  provider_enabled: boolean
+}) => ({
+  id: link.id,
+  provider: {
+    id: link.provider_id,
+    display_name: link.provider_name,
+    enabled: link.provider_enabled,
+  },
+  linked_at: link.linked_at.toISOString(),
+})
+
+export const getMyOrganizationOidcLinks = async (
+  actor: RequestActor,
+  organizationId: string,
+  executor: DbExecutor = db
+): Promise<Result<{ links: ReturnType<typeof toLinkResponse>[] }>> => {
+  const userId = userIdFromActor(actor)
+  if (!userId) return { ok: false, error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' } }
+  const membership = await findActiveMembership(organizationId, userId, executor)
+  if (!membership?.id) {
+    return { ok: false, error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' } }
+  }
+  const links = await listActiveOrganizationOidcLinks(membership.id, executor)
+  return { ok: true, value: { links: links.map(toLinkResponse) } }
+}
+
+export const unlinkMyOrganizationOidcIdentity = async (
+  actor: RequestActor,
+  organizationId: string,
+  linkId: string,
+  options: { now?: Date; executor?: DbExecutor } = {}
+): Promise<Result<{ ok: true }>> => {
+  const userId = userIdFromActor(actor)
+  if (!userId) return { ok: false, error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' } }
+  const now = options.now ?? new Date()
+
+  return runInTransaction(options.executor, async (trx) => {
+    // 本人のMembershipを先にlockし、退出・suspendとunlinkを直列化する。
+    const membership = await findActiveMembershipForUpdate(organizationId, userId, trx)
+    if (!membership?.id) {
+      return { ok: false, error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' } }
+    }
+    const policy = await findOrganizationAuthSettingsForUpdate(organizationId, trx)
+    if (!policy) return { ok: false, error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' } }
+    const link = await findActiveOrganizationOidcLinkForUpdate(
+      organizationId,
+      membership.id,
+      linkId,
+      trx
+    )
+    if (!link) {
+      return { ok: false, error: { type: 'OIDC_MEMBERSHIP_LINK_NOT_FOUND' } }
+    }
+
+    const targetIsUsable = policy.oidc_auth_enabled && link.provider_enabled
+    if (targetIsUsable) {
+      const localRemains =
+        policy.local_auth_enabled && (await hasEnabledLocalCredential(membership.id, trx))
+      const oidcRemains =
+        policy.oidc_auth_enabled &&
+        (await countOtherUsableOidcLinks(membership.id, link.id, trx)) > 0
+      if (!localRemains && !oidcRemains) {
+        return { ok: false, error: { type: 'OIDC_LINK_LAST_USABLE_AUTH_METHOD' } }
+      }
+    }
+
+    const revoked = await revokeOrganizationOidcLink(link.id, now, trx)
+    if (!revoked) {
+      return { ok: false, error: { type: 'OIDC_MEMBERSHIP_LINK_NOT_FOUND' } }
+    }
+    const revokedGrantCount = await revokeActiveGrantsForOidcLink(membership.id, link.id, now, trx)
+    await insertOidcLinkAuditEvent(
+      {
+        actor_user_id: userId,
+        actor_membership_id: membership.id,
+        organization_id: organizationId,
+        target_type: 'organization_member_oidc_identity',
+        target_id: link.id,
+        action: 'unlink',
+        changed_fields: ['revoked_at'],
+        before_values: {
+          revoked_at: null,
+          provider_id: link.provider_id,
+          revoked_grant_count: 0,
+        } as Json,
+        after_values: {
+          revoked_at: now.toISOString(),
+          provider_id: link.provider_id,
+          revoked_grant_count: revokedGrantCount,
+        } as Json,
+      },
+      trx
+    )
+    await insertOidcLinkAuthenticationEvent(
+      {
+        event_type: 'oidc_unlink_identity',
+        outcome: 'success',
+        user_id: userId,
+        organization_id: organizationId,
+        membership_id: membership.id,
+        auth_method: 'oidc',
+        credential_reference_id: link.oidc_identity_id,
+      },
+      trx
+    )
+
+    return { ok: true, value: { ok: true } }
+  })
+}

--- a/apps/kaede/tests/services/auth/organization-oidc-link-management.test.ts
+++ b/apps/kaede/tests/services/auth/organization-oidc-link-management.test.ts
@@ -1,0 +1,204 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import type { RequestActor } from '../../../src/middleware/request-actor-context.js'
+import { createSession } from '../../../src/services/auth/index.js'
+import { createDb } from '../../../src/services/db/client.js'
+import {
+  getMyOrganizationOidcLinks,
+  unlinkMyOrganizationOidcIdentity,
+} from '../../../src/usecases/organization-oidc-links/index.js'
+import { resetDatabase } from '../../db/helpers.js'
+
+const db = createDb()
+const now = new Date('2026-08-11T12:00:00.000Z')
+
+const createFixture = async (withLocalCredential: boolean) => {
+  const user = await db
+    .insertInto('users')
+    .values({ email: 'oidc-link@example.test', display_name: 'OIDC Link', status: 'active' })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const organization = await db
+    .insertInto('organizations')
+    .values({ name: 'OIDC Link Organization', slug: 'oidc-link-organization' })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  await db
+    .insertInto('organization_auth_settings')
+    .values({
+      organization_id: organization.id,
+      local_auth_enabled: true,
+      oidc_auth_enabled: true,
+      membership_grant_ttl_seconds: 28_800,
+      reauthentication_interval_seconds: 14_400,
+    })
+    .execute()
+  const membership = await db
+    .insertInto('organization_memberships')
+    .values({ organization_id: organization.id, user_id: user.id, role: 'member' })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const provider = await db
+    .insertInto('organization_oidc_providers')
+    .values({
+      organization_id: organization.id,
+      name: 'Google',
+      issuer: 'https://accounts.google.com',
+      client_id: 'client-id-not-returned',
+      client_secret_ref: 'secret-ref-not-returned',
+      scopes: ['openid'],
+      allowed_hosted_domains: null,
+      enabled: true,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const identity = await db
+    .insertInto('oidc_identities')
+    .values({
+      user_id: user.id,
+      issuer: 'https://accounts.google.com',
+      subject: 'subject-not-returned',
+      last_claimed_email: user.email,
+      last_claimed_email_verified: true,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const link = await db
+    .insertInto('organization_member_oidc_identities')
+    .values({
+      membership_id: membership.id,
+      organization_id: organization.id,
+      user_id: user.id,
+      organization_oidc_provider_id: provider.id,
+      oidc_identity_id: identity.id,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const localCredential = withLocalCredential
+    ? await db
+        .insertInto('organization_local_credentials')
+        .values({
+          membership_id: membership.id,
+          organization_id: organization.id,
+          login_email: 'local@example.test',
+          normalized_login_email: 'local@example.test',
+          password_hash: 'hash-not-returned',
+        })
+        .returningAll()
+        .executeTakeFirstOrThrow()
+    : undefined
+  const actor = {
+    type: 'user',
+    user_id: user.id,
+    email: user.email,
+    global_role: 'none',
+    account_state: 'active',
+    memberships: [
+      { organization_id: organization.id, organization_name: organization.name, role: 'member' },
+    ],
+  } satisfies RequestActor
+  return { actor, identity, link, localCredential, membership, organization, provider, user }
+}
+
+describe('organization OIDC link management', () => {
+  beforeEach(async () => resetDatabase(db))
+  afterAll(async () => db.destroy())
+
+  it('本人のactive LinkをProvider表示情報だけで返す', async () => {
+    const fixture = await createFixture(false)
+    const result = await getMyOrganizationOidcLinks(fixture.actor, fixture.organization.id, db)
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        links: [
+          {
+            id: fixture.link.id,
+            provider: { id: fixture.provider.id, display_name: 'Google', enabled: true },
+            linked_at: fixture.link.created_at.toISOString(),
+          },
+        ],
+      },
+    })
+    expect(JSON.stringify(result)).not.toContain('client-id-not-returned')
+    expect(JSON.stringify(result)).not.toContain('subject-not-returned')
+  })
+
+  it('Linkを論理失効し、対象Link由来GrantだけをrevokeしてIdentityは残す', async () => {
+    const fixture = await createFixture(true)
+    const oidcSession = await createSession(
+      { userId: fixture.user.id, authMethod: 'oidc', now },
+      db
+    )
+    const localSession = await createSession({ userId: fixture.user.id, now }, db)
+    await db
+      .insertInto('session_membership_authentications')
+      .values([
+        {
+          session_id: oidcSession.session.id,
+          membership_id: fixture.membership.id,
+          user_id: fixture.user.id,
+          auth_method: 'oidc',
+          policy_version: 1,
+          member_oidc_identity_id: fixture.link.id,
+          authenticated_at: now,
+          expires_at: new Date(now.getTime() + 3_600_000),
+        },
+        {
+          session_id: localSession.session.id,
+          membership_id: fixture.membership.id,
+          user_id: fixture.user.id,
+          auth_method: 'local',
+          policy_version: 1,
+          local_credential_id: fixture.localCredential?.id,
+          authenticated_at: now,
+          expires_at: new Date(now.getTime() + 3_600_000),
+        },
+      ])
+      .execute()
+
+    await expect(
+      unlinkMyOrganizationOidcIdentity(fixture.actor, fixture.organization.id, fixture.link.id, {
+        now,
+        executor: db,
+      })
+    ).resolves.toEqual({ ok: true, value: { ok: true } })
+
+    const grants = await db
+      .selectFrom('session_membership_authentications')
+      .select(['auth_method', 'revoked_at'])
+      .orderBy('auth_method')
+      .execute()
+    expect(grants).toEqual([
+      { auth_method: 'local', revoked_at: null },
+      { auth_method: 'oidc', revoked_at: now },
+    ])
+    await expect(
+      db
+        .selectFrom('oidc_identities')
+        .select('id')
+        .where('id', '=', fixture.identity.id)
+        .executeTakeFirst()
+    ).resolves.toEqual({ id: fixture.identity.id })
+  })
+
+  it('最後の利用可能な認証方式になるLinkはunlinkしない', async () => {
+    const fixture = await createFixture(false)
+
+    await expect(
+      unlinkMyOrganizationOidcIdentity(fixture.actor, fixture.organization.id, fixture.link.id, {
+        now,
+        executor: db,
+      })
+    ).resolves.toEqual({
+      ok: false,
+      error: { type: 'OIDC_LINK_LAST_USABLE_AUTH_METHOD' },
+    })
+    await expect(
+      db
+        .selectFrom('organization_member_oidc_identities')
+        .select('revoked_at')
+        .where('id', '=', fixture.link.id)
+        .executeTakeFirstOrThrow()
+    ).resolves.toEqual({ revoked_at: null })
+  })
+})


### PR DESCRIPTION
## 概要
本人がOrganization Membershipに紐づくOIDC Linkを確認・unlinkできるAPIを追加します。

## 変更内容
- GET `/api/organizations/{organizationId}/members/me/oidc-links`
- DELETE `/api/organizations/{organizationId}/members/me/oidc-links/{linkId}`
- Provider表示情報だけを返し、issuer/client/subject/secretを非開示
- unlinkはLinkを論理失効しcanonical OIDC Identityを保持
- 対象Link由来のOIDC Grantだけrevoke
- Local Credentialまたは別OIDC Linkがない場合は最後の認証方式の削除を拒否
- Audit/Authentication Eventを記録

## 検証
- lint / typecheck 成功
- Unit 532件成功
- 対象DB integration 3件成功

Refs #219