### PR TITLE
feat(kaede): InviteのOIDC受領contextを公開する

### DIFF
--- a/apps/kaede/src/routes/organization-invites/public.test.ts
+++ b/apps/kaede/src/routes/organization-invites/public.test.ts
@@ -32,10 +32,20 @@ describe('public organization invite routes', () => {
     usecases.verifyOrganizationInvite.mockResolvedValue({
       ok: true,
       value: {
-        organization: { name: 'Example' },
+        organization: {
+          id: '11111111-1111-4111-8111-111111111111',
+          name: 'Example',
+          slug: 'example',
+        },
         role: 'member',
         expires_at: '2026-08-18T10:00:00.000Z',
         authentication_methods: { local: true, oidc: true },
+        oidc_providers: [
+          {
+            id: '22222222-2222-4222-8222-222222222222',
+            display_name: 'Google',
+          },
+        ],
       },
     })
     const response = await app().request('/api/invites/verify', {

--- a/apps/kaede/src/schemas/organization-invites.ts
+++ b/apps/kaede/src/schemas/organization-invites.ts
@@ -1,5 +1,6 @@
 import { z } from '@hono/zod-openapi'
 import { isoDatetimeSchema, uuidSchema } from './common.js'
+import { organizationSlugSchema } from './organizations.js'
 import { displayNameSchema, localeSchema, timezoneSchema } from './profiles.js'
 
 export const inviteRoleSchema = z.enum(['member', 'manager'])
@@ -39,13 +40,23 @@ export const verifyOrganizationInviteRequestSchema = z.object({
 
 export const verifyOrganizationInviteResponseSchema = z
   .object({
-    organization: z.object({ name: z.string().min(1) }),
+    organization: z.object({
+      id: uuidSchema,
+      name: z.string().min(1),
+      slug: organizationSlugSchema,
+    }),
     role: inviteRoleSchema,
     expires_at: isoDatetimeSchema,
     authentication_methods: z.object({
       local: z.boolean(),
       oidc: z.boolean(),
     }),
+    oidc_providers: z.array(
+      z.object({
+        id: uuidSchema,
+        display_name: z.string().min(1).max(255),
+      })
+    ),
   })
   .openapi('VerifyOrganizationInviteResponse')
 

--- a/apps/kaede/src/server.test.ts
+++ b/apps/kaede/src/server.test.ts
@@ -125,10 +125,33 @@ describe('createApp auth wiring', { timeout: 60_000 }, () => {
             },
           },
         },
+        '/api/invites/verify': {
+          post: {
+            responses: {
+              '200': {
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/VerifyOrganizationInviteResponse' },
+                  },
+                },
+              },
+            },
+          },
+        },
       },
       components: {
         schemas: {
           GlobalSessionErrorResponse: expect.any(Object),
+          VerifyOrganizationInviteResponse: {
+            properties: {
+              organization: {
+                required: ['id', 'name', 'slug'],
+              },
+              oidc_providers: {
+                type: 'array',
+              },
+            },
+          },
           OrganizationAuthorizationErrorResponse: expect.objectContaining({
             oneOf: expect.arrayContaining([
               expect.objectContaining({

--- a/apps/kaede/src/services/organization-invites/repository.ts
+++ b/apps/kaede/src/services/organization-invites/repository.ts
@@ -110,6 +110,7 @@ const inviteContextQuery = (executor: DbExecutor) =>
       'invite.revoked_at',
       'invite.redeemed_at',
       'organization.name as organization_name',
+      'organization.slug as organization_slug',
       'organization.status as organization_status',
       'auth_settings.local_auth_enabled',
       'auth_settings.oidc_auth_enabled',

--- a/apps/kaede/src/usecases/organization-invites/index.test.ts
+++ b/apps/kaede/src/usecases/organization-invites/index.test.ts
@@ -24,6 +24,17 @@ const invites = vi.hoisted(() => ({
   listOrganizationInvites: vi.fn(),
   revokeOrganizationInvite: vi.fn(),
 }))
+const oidc = vi.hoisted(() => ({
+  canonicalizeOidcIssuer: vi.fn(),
+  findOidcIdentity: vi.fn(),
+  findOrganizationOidcProviderContextById: vi.fn(),
+  insertOidcIdentity: vi.fn(),
+  listOidcProviders: vi.fn(),
+  revokeActiveOidcMembershipLink: vi.fn(),
+  updateOidcIdentityClaims: vi.fn(),
+  upsertOidcMembershipGrant: vi.fn(),
+  upsertOidcMembershipLink: vi.fn(),
+}))
 const local = vi.hoisted(() => ({
   insertAuthenticationEvent: vi.fn(),
   normalizeLocalLoginEmail: vi.fn((email: string) => email.trim().toLowerCase()),
@@ -39,6 +50,7 @@ const users = vi.hoisted(() => ({ findUserById: vi.fn(), insertUser: vi.fn() }))
 vi.mock('../../services/auth/index.js', () => auth)
 vi.mock('../../services/organization-invites/index.js', () => invites)
 vi.mock('../../services/organization-local-auth/index.js', () => local)
+vi.mock('../../services/organization-oidc-auth/index.js', () => oidc)
 vi.mock('../../services/profiles/index.js', () => profiles)
 vi.mock('../../services/users/index.js', () => users)
 vi.mock('../../services/db/index.js', () => ({ db: {} }))
@@ -86,6 +98,7 @@ const inviteContext = (overrides: Record<string, unknown> = {}) => ({
   revoked_at: null,
   redeemed_at: null,
   organization_name: 'Example',
+  organization_slug: 'example',
   organization_status: 'active',
   local_auth_enabled: true,
   oidc_auth_enabled: true,
@@ -101,6 +114,10 @@ describe('organization invite usecases', () => {
     auth.hashActivationToken.mockImplementation((token: string) => `hash:${token}`)
     auth.hashPassword.mockResolvedValue('password-hash')
     invites.findInviteContextByTokenHash.mockResolvedValue(inviteContext())
+    oidc.listOidcProviders.mockResolvedValue([
+      { id: '55555555-5555-4555-8555-555555555555', name: 'Google', enabled: true },
+      { id: '66666666-6666-4666-8666-666666666666', name: 'Disabled', enabled: false },
+    ])
     profiles.insertAuditEvent.mockResolvedValue(undefined)
   })
 
@@ -176,10 +193,11 @@ describe('organization invite usecases', () => {
     expect(result).toEqual({
       ok: true,
       value: {
-        organization: { name: 'Example' },
+        organization: { id: organizationId, name: 'Example', slug: 'example' },
         role: 'member',
         expires_at: '2026-08-18T10:00:00.000Z',
         authentication_methods: { local: true, oidc: true },
+        oidc_providers: [{ id: '55555555-5555-4555-8555-555555555555', display_name: 'Google' }],
       },
     })
     expect(JSON.stringify(result)).not.toContain('plain-token')

--- a/apps/kaede/src/usecases/organization-invites/index.ts
+++ b/apps/kaede/src/usecases/organization-invites/index.ts
@@ -45,6 +45,7 @@ import {
   updateOidcIdentityClaims,
   upsertOidcMembershipGrant,
   upsertOidcMembershipLink,
+  listOidcProviders,
 } from '../../services/organization-oidc-auth/index.js'
 import {
   insertAuditEvent,
@@ -351,16 +352,26 @@ export const verifyOrganizationInvite = async (
     now
   )
   if (!valid.ok) return valid
+  const oidcProviders = valid.context.oidc_auth_enabled
+    ? (await listOidcProviders(valid.context.organization_id, executor))
+        .filter((provider) => provider.enabled)
+        .map((provider) => ({ id: provider.id, display_name: provider.name }))
+    : []
   return {
     ok: true,
     value: {
-      organization: { name: valid.context.organization_name },
+      organization: {
+        id: valid.context.organization_id,
+        name: valid.context.organization_name,
+        slug: valid.context.organization_slug,
+      },
       role: valid.context.role as InviteRole,
       expires_at: valid.context.expires_at.toISOString(),
       authentication_methods: {
         local: valid.context.local_auth_enabled === true,
         oidc: valid.context.oidc_auth_enabled === true,
       },
+      oidc_providers: oidcProviders,
     },
   } as const
 }


### PR DESCRIPTION
## 概要
Mioがsingle-use InviteからOrganization OIDC認証を開始できるよう、Invite検証レスポンスへOrganization識別子と利用可能Providerを追加します。

## 変更内容
- organizationにid / slugを追加
- 有効なOIDC Providerのid / display_nameを追加
- OIDC policy無効時はProviderを公開しない
- OpenAPI contractとroute/usecase testを更新

## 確認
- Kaede unit: 532 tests passed
- 対象route/usecase: 26 tests passed
- typecheck / lint: passed
- DB/S3統合testは環境変数未設定のため対象外

Refs #219