### PR TITLE
feat(kaede): Organization UserへMembership IDを追加

### DIFF
--- a/apps/kaede/src/schemas/organizations.ts
+++ b/apps/kaede/src/schemas/organizations.ts
@@ -104,6 +104,7 @@ export const rejectOrganizationCreationRequestRequestSchema = z
 
 export const organizationUserSchema = z
   .object({
+    membership_id: uuidSchema,
     user_id: authUserSchema.shape.user_id,
     email: authUserSchema.shape.email,
     display_name: authUserSchema.shape.display_name,

--- a/apps/kaede/src/server.test.ts
+++ b/apps/kaede/src/server.test.ts
@@ -152,6 +152,12 @@ describe('createApp auth wiring', { timeout: 60_000 }, () => {
               },
             },
           },
+          OrganizationUser: {
+            required: expect.arrayContaining(['membership_id']),
+            properties: {
+              membership_id: expect.objectContaining({ format: 'uuid' }),
+            },
+          },
           OrganizationAuthorizationErrorResponse: expect.objectContaining({
             oneOf: expect.arrayContaining([
               expect.objectContaining({

--- a/apps/kaede/src/services/users/user-repository.ts
+++ b/apps/kaede/src/services/users/user-repository.ts
@@ -10,6 +10,7 @@ export type NewOrganizationMembership = Insertable<OrganizationMemberships>
 export type OrganizationMembership = Selectable<OrganizationMemberships>
 
 export interface OrganizationUserRow {
+  membership_id: string
   user_id: string
   email: string
   display_name: string
@@ -109,6 +110,7 @@ const organizationUsersQuery = (executor: DbExecutor) =>
     .innerJoin('users as user', 'user.id', 'membership.user_id')
     .leftJoin('pedestrians as pedestrian', 'pedestrian.user_id', 'user.id')
     .select([
+      'membership.id as membership_id',
       'user.id as user_id',
       'user.email as email',
       'user.display_name as display_name',

--- a/apps/kaede/src/usecases/organizations/index.ts
+++ b/apps/kaede/src/usecases/organizations/index.ts
@@ -144,6 +144,7 @@ const requirePedestrianOrganizationId = (
 }
 
 const toOrganizationUserResponse = (row: OrganizationUserRow): OrganizationUserResponse => ({
+  membership_id: row.membership_id,
   user_id: row.user_id,
   email: row.email,
   display_name: row.display_name,


### PR DESCRIPTION
## 概要
Mioのmanager/ownerがMembership単位のProfile・Role APIを利用できるよう、既存Organization Userレスポンスへmembership_idを追加します。

## 変更内容
- OrganizationUser schemaへmembership_idを追加
- Member一覧/詳細queryでMembership UUIDを取得
- OpenAPI contract testを追加

## 確認
- 対象route: 16 tests passed
- OpenAPI: 7 tests passed
- typecheck / lint: passed

Refs #219