### PR TITLE
feat: migrate multi-org auth data in one cutover

### DIFF
--- a/apps/kaede/src/cli/multi-org-auth-backfill.test.ts
+++ b/apps/kaede/src/cli/multi-org-auth-backfill.test.ts
@@ -16,6 +16,13 @@ describe('multi-org-auth-backfill options', () => {
     })
   })
 
+  it('accepts the one-shot cutover command', () => {
+    expect(parseOptions(['cutover', '--batch-size', '1000'])).toEqual({
+      batchSize: 1000,
+      command: 'cutover',
+    })
+  })
+
   it.each(['0', '-1', '1.5', '10001', 'not-a-number'])('rejects invalid batch size %s', (value) => {
     expect(() => parseOptions(['verify', '--batch-size', value])).toThrow('usage:')
   })

--- a/apps/kaede/src/cli/multi-org-auth-backfill.ts
+++ b/apps/kaede/src/cli/multi-org-auth-backfill.ts
@@ -1,17 +1,18 @@
 interface Options {
   batchSize: number
-  command: 'preflight' | 'backfill-core' | 'backfill-auth' | 'verify' | 'validate'
+  command: 'cutover' | 'preflight' | 'backfill-core' | 'backfill-auth' | 'verify' | 'validate'
 }
 
 const usage = (): never => {
   throw new Error(
-    'usage: multi-org-auth-backfill <preflight|backfill-core|backfill-auth|verify|validate> [--batch-size POSITIVE_INTEGER]'
+    'usage: multi-org-auth-backfill <cutover|preflight|backfill-core|backfill-auth|verify|validate> [--batch-size POSITIVE_INTEGER]'
   )
 }
 
 export const parseOptions = (argv: string[]): Options => {
   const command = argv.shift()
   if (
+    command !== 'cutover' &&
     command !== 'preflight' &&
     command !== 'backfill-core' &&
     command !== 'backfill-auth' &&
@@ -38,10 +39,17 @@ export const main = async (argv = process.argv.slice(2)) => {
   const {
     backfillMultiOrgAuthCore,
     backfillMultiOrgAuthCredentials,
+    executeOneShotMultiOrgAuthCutover,
     getMultiOrgAuthPreflightReport,
     validateMultiOrgAuthExpandConstraints,
     verifyMultiOrgAuthCoreBackfill,
   } = await import('../services/migrations/multi-org-auth-backfill.js')
+
+  if (options.command === 'cutover') {
+    const result = await executeOneShotMultiOrgAuthCutover(options.batchSize)
+    process.stdout.write(`${JSON.stringify(result)}\n`)
+    return
+  }
 
   if (options.command === 'preflight') {
     const report = await getMultiOrgAuthPreflightReport()

--- a/apps/kaede/src/services/migrations/multi-org-auth-backfill.ts
+++ b/apps/kaede/src/services/migrations/multi-org-auth-backfill.ts
@@ -1,6 +1,7 @@
 import { sql } from 'kysely'
-import type { RawBuilder } from 'kysely'
+import type { Kysely, RawBuilder } from 'kysely'
 import { db } from '../db/index.js'
+import type { DB } from '../db/index.js'
 import type { DbExecutor } from '../executor.js'
 
 export const canonicalGoogleIssuer = 'https://accounts.google.com'
@@ -40,6 +41,13 @@ export interface BackfillResult {
   organizations: number
   pedestrian_memberships: number
   user_profiles: number
+}
+
+export interface OneShotCutoverResult {
+  auth: BackfillResult
+  core: BackfillResult
+  revoked_sessions: number
+  validated: true
 }
 
 const emptyResult = (): BackfillResult => ({
@@ -789,3 +797,61 @@ export const validateMultiOrgAuthExpandConstraints = async (
     )
     .execute(executor)
 }
+
+/**
+ * Migrates all legacy authentication data during a single maintenance window.
+ *
+ * The application must remain stopped until this transaction and the following
+ * membership primary-key/contract migrations have completed. A failed run rolls
+ * back every data write and session revocation performed here; the application
+ * must never restart against a partially migrated database.
+ */
+export const executeOneShotMultiOrgAuthCutover = async (
+  batchSize: number,
+  database: Kysely<DB> = db
+): Promise<OneShotCutoverResult> =>
+  database.transaction().execute(async (trx) => {
+    const preflight = await getMultiOrgAuthPreflightReport(trx)
+    if (preflight.blocking) {
+      throw new Error(
+        `one-shot cutover blocked: ${preflight.issues
+          .filter((issue) => issue.blocking)
+          .map((issue) => issue.code)
+          .join(', ')}`
+      )
+    }
+
+    const core = await backfillMultiOrgAuthCore(batchSize, trx)
+    const auth = await backfillMultiOrgAuthCredentials(batchSize, trx)
+    const verification = await verifyMultiOrgAuthCoreBackfill(trx)
+    if (Object.values(verification).some((count) => count > 0)) {
+      throw new Error(`one-shot cutover verification failed: ${JSON.stringify(verification)}`)
+    }
+
+    // A second pass must be a no-op. This detects incomplete batch predicates
+    // before the old application/data contract is removed.
+    const authVerification = await backfillMultiOrgAuthCredentials(batchSize, trx)
+    if (
+      authVerification.local_credentials > 0 ||
+      authVerification.oidc_identities > 0 ||
+      authVerification.oidc_links > 0
+    ) {
+      throw new Error(`one-shot auth verification failed: ${JSON.stringify(authVerification)}`)
+    }
+
+    await validateMultiOrgAuthExpandConstraints(trx)
+
+    const revokedSessions = await sql<{ id: string }>`
+      UPDATE sessions
+      SET revoked_at = COALESCE(revoked_at, now())
+      WHERE revoked_at IS NULL
+      RETURNING id
+    `.execute(trx)
+
+    return {
+      auth,
+      core,
+      revoked_sessions: revokedSessions.rows.length,
+      validated: true,
+    }
+  })

--- a/apps/kaede/src/services/profiles/profile-repository.ts
+++ b/apps/kaede/src/services/profiles/profile-repository.ts
@@ -10,12 +10,10 @@ export type OrganizationMemberProfileUpdate = Updateable<OrganizationMemberProfi
 
 export interface UserProfileContext {
   user_id: string
-  legacy_display_name: string
-  legacy_updated_at: Date
-  display_name: string | null
-  locale: string | null
-  timezone: string | null
-  profile_updated_at: Date | null
+  display_name: string
+  locale: string
+  timezone: string
+  profile_updated_at: Date
 }
 
 export interface MemberProfileContext extends UserProfileContext {
@@ -33,11 +31,9 @@ export interface MemberProfileContext extends UserProfileContext {
 const userProfileContextQuery = (executor: DbExecutor) =>
   executor
     .selectFrom('users as user')
-    .leftJoin('user_profiles as profile', 'profile.user_id', 'user.id')
+    .innerJoin('user_profiles as profile', 'profile.user_id', 'user.id')
     .select([
       'user.id as user_id',
-      'user.display_name as legacy_display_name',
-      'user.updated_at as legacy_updated_at',
       'profile.display_name as display_name',
       'profile.locale as locale',
       'profile.timezone as timezone',
@@ -55,7 +51,7 @@ const memberProfileContextQuery = (executor: DbExecutor) =>
   executor
     .selectFrom('organization_memberships as membership')
     .innerJoin('users as user', 'user.id', 'membership.user_id')
-    .leftJoin('user_profiles as user_profile', 'user_profile.user_id', 'user.id')
+    .innerJoin('user_profiles as user_profile', 'user_profile.user_id', 'user.id')
     .leftJoin('organization_member_profiles as member_profile', (join) =>
       join.onRef('member_profile.membership_id', '=', 'membership.id')
     )
@@ -66,8 +62,6 @@ const memberProfileContextQuery = (executor: DbExecutor) =>
       'membership.role as role',
       'membership.status as status',
       'user.id as user_id',
-      'user.display_name as legacy_display_name',
-      'user.updated_at as legacy_updated_at',
       'user_profile.display_name as display_name',
       'user_profile.locale as locale',
       'user_profile.timezone as timezone',

--- a/apps/kaede/src/usecases/profiles/index.test.ts
+++ b/apps/kaede/src/usecases/profiles/index.test.ts
@@ -65,7 +65,6 @@ const memberContext = ({
   role,
   status,
   user_id: userId,
-  legacy_display_name: 'Legacy Name',
   display_name: 'Global Name',
   locale: 'ja-JP',
   timezone: 'Asia/Tokyo',
@@ -81,25 +80,23 @@ describe('profile usecases', () => {
     vi.clearAllMocks()
   })
 
-  it('User Profile未作成時はlegacy display nameとdefault preferenceへfallbackする', async () => {
+  it('移行済みUser Profileを返す', async () => {
     mocks.findUserProfileContext.mockResolvedValue({
       user_id: actorUserId,
-      legacy_display_name: 'Legacy Name',
-      legacy_updated_at: new Date('2026-08-10T00:00:00.000Z'),
-      display_name: null,
-      locale: null,
-      timezone: null,
-      profile_updated_at: null,
+      display_name: 'Global Name',
+      locale: 'ja-JP',
+      timezone: 'Asia/Tokyo',
+      profile_updated_at: new Date('2026-08-11T00:00:00.000Z'),
     })
 
     await expect(getMyUserProfile(userActor(), executor)).resolves.toEqual({
       ok: true,
       value: {
         user_id: actorUserId,
-        display_name: 'Legacy Name',
+        display_name: 'Global Name',
         locale: 'ja-JP',
         timezone: 'Asia/Tokyo',
-        updated_at: '2026-08-10T00:00:00.000Z',
+        updated_at: '2026-08-11T00:00:00.000Z',
       },
     })
   })

--- a/apps/kaede/src/usecases/profiles/index.ts
+++ b/apps/kaede/src/usecases/profiles/index.ts
@@ -21,9 +21,6 @@ import {
 import type { MemberProfileContext, UserProfileContext } from '../../services/profiles/index.js'
 import type { AuthorizationError } from '../authorization.js'
 
-const defaultLocale = 'ja-JP'
-const defaultTimezone = 'Asia/Tokyo'
-
 export type ProfileError =
   | AuthorizationError
   | { type: 'USER_NOT_FOUND' }
@@ -60,10 +57,10 @@ const requireUserActor = (
 
 const toUserProfileResponse = (context: UserProfileContext): UserProfileResponse => ({
   user_id: context.user_id,
-  display_name: context.display_name ?? context.legacy_display_name,
-  locale: context.locale ?? defaultLocale,
-  timezone: context.timezone ?? defaultTimezone,
-  updated_at: (context.profile_updated_at ?? context.legacy_updated_at).toISOString(),
+  display_name: context.display_name,
+  locale: context.locale,
+  timezone: context.timezone,
+  updated_at: context.profile_updated_at.toISOString(),
 })
 
 const toMemberProfileResponse = (
@@ -73,7 +70,7 @@ const toMemberProfileResponse = (
     throw new Error('membership id is not available')
   }
 
-  const globalDisplayName = context.display_name ?? context.legacy_display_name
+  const globalDisplayName = context.display_name
 
   return {
     organization_id: context.organization_id,
@@ -151,9 +148,9 @@ export const updateMyUserProfile = async (
     if (!current) return { ok: false, error: { type: 'USER_NOT_FOUND' } }
 
     const next = {
-      display_name: payload.display_name ?? current.display_name ?? current.legacy_display_name,
-      locale: payload.locale ?? current.locale ?? defaultLocale,
-      timezone: payload.timezone ?? current.timezone ?? defaultTimezone,
+      display_name: payload.display_name ?? current.display_name,
+      locale: payload.locale ?? current.locale,
+      timezone: payload.timezone ?? current.timezone,
     }
 
     const profile = await upsertUserProfile(

--- a/apps/kaede/tests/services/db/multi-org-auth-backfill.test.ts
+++ b/apps/kaede/tests/services/db/multi-org-auth-backfill.test.ts
@@ -5,6 +5,7 @@ import {
   backfillMultiOrgAuthCore,
   backfillMultiOrgAuthCredentials,
   canonicalGoogleIssuer,
+  executeOneShotMultiOrgAuthCutover,
   getMultiOrgAuthPreflightReport,
   validateMultiOrgAuthExpandConstraints,
   verifyMultiOrgAuthCoreBackfill,
@@ -399,5 +400,42 @@ describe('multi organization auth backfill', () => {
           throw error
         }
       })
+  })
+
+  it('migrates all rows and revokes legacy sessions in one cutover transaction', async () => {
+    const { organization, user } = await createLegacyUserAndMembership('one-shot')
+    await db
+      .insertInto('organization_auth_settings')
+      .values({
+        local_auth_enabled: true,
+        membership_grant_ttl_seconds: 3600,
+        oidc_auth_enabled: false,
+        organization_id: organization.id,
+        reauthentication_interval_seconds: 1800,
+      })
+      .execute()
+    await db
+      .insertInto('sessions')
+      .values({
+        expires_at: new Date('2026-08-20T00:00:00.000Z'),
+        session_hash: 'legacy-session-hash',
+        user_id: user.id,
+      })
+      .execute()
+
+    const result = await executeOneShotMultiOrgAuthCutover(1, db)
+
+    expect(result).toMatchObject({
+      auth: { local_credentials: 1 },
+      core: { memberships: 1, user_profiles: 1 },
+      revoked_sessions: 1,
+      validated: true,
+    })
+    await expect(
+      db.selectFrom('sessions').select('revoked_at').executeTakeFirstOrThrow()
+    ).resolves.toEqual({ revoked_at: expect.any(Date) })
+    await expect(
+      db.selectFrom('organization_local_credentials').select('id').executeTakeFirstOrThrow()
+    ).resolves.toEqual({ id: expect.any(String) })
   })
 })

--- a/apps/kaede/tests/services/profiles/profiles.test.ts
+++ b/apps/kaede/tests/services/profiles/profiles.test.ts
@@ -171,6 +171,15 @@ describe('profile usecases with database', () => {
       .values({ name: 'Rejoined Profile Organization' })
       .returningAll()
       .executeTakeFirstOrThrow()
+    await db
+      .insertInto('user_profiles')
+      .values({
+        user_id: user.id,
+        display_name: 'Rejoined Member',
+        locale: 'ja-JP',
+        timezone: 'Asia/Tokyo',
+      })
+      .execute()
 
     await db
       .transaction()

--- a/db/multi-organization-auth-backfill.md
+++ b/db/multi-organization-auth-backfill.md
@@ -1,103 +1,102 @@
-# Multi-Organization Auth Backfill Runbook
+# Multi-Organization Auth One-shot Cutover Runbook
 
-この手順は、multi-organization authのExpand schema適用後に既存データを移行するためのものです。
-旧column/API/sessionはこの手順では削除・切替しません。
+この手順は、multi-organization authの旧データを1回のメンテナンス時間内で新形式へ全件移行するためのものです。
+新旧Applicationや新旧認証データを並行運用しません。Applicationを停止してからSchema追加、全件移行、検証、
+Membership主キー昇格、旧契約削除までを完了し、新Applicationだけを起動します。
 
-## 安全原則
+## 原則
 
-- 本番と同等のsnapshotで事前リハーサルする。
-- `preflight` のblocking issueを手動で解消し、データを推測で修正しない。
-- backfillはbatch実行し、再実行可能であることを確認する。
-- Organizationの認証方式はglobal runtime設定から推測しない。各Organizationについて明示的に決定する。
-- 既存Sessionのrevoke、auth cutover、旧column削除、Membership PK切替は後続PRで行う。
+- 本番相当snapshotで同じ手順を事前にrehearsalする。
+- 開始前に書込みとbackground workerをすべて停止する。
+- `preflight`のblocking issueを事前に解消し、値を推測して自動修正しない。
+- 移行中に旧Applicationを再起動しない。
+- 既存SessionからMembership Grantを推測せず、全Sessionをrevokeする。
+- 失敗時は新旧混在状態でサービスを再開せず、切替前backupへDatabase全体をrestoreする。
+- 成功後は新構造だけをsource of truthとし、旧Columnへのread/writeやdual-writeを行わない。
 
-## 測定値の正規化
+## 事前準備
 
-`pedestrians.height` と `pedestrians.stride_length` は現行APIと同じくmeterとして扱う。
-値の大きさからcentimeterと推測して自動変換しない。
+1. 本番snapshotで所要時間、WAL量、必要disk容量、restore時間を計測する。
+2. `pnpm multi-org-auth-backfill preflight`を実行する。
+3. 次のblocking issueをすべて解消する。
+   - `LOCAL_LOGIN_EMAIL_COLLISION`
+   - `MISSING_ORGANIZATION_AUTH_POLICY`
+   - `OIDC_PROVIDER_MAPPING_MISSING_OR_AMBIGUOUS`
+   - `OIDC_IDENTITY_OWNER_CONFLICT`
+   - `PEDESTRIAN_MEMBERSHIP_NOT_FOUND`
+   - `PEDESTRIAN_MEASUREMENT_OUT_OF_RANGE`
+   - `INVITE_CREATOR_MEMBERSHIP_NOT_FOUND`
+   - `LEGACY_MULTI_USE_INVITE`
+   - `PENDING_ACTIVATION_USER`
+4. Organizationごとの認証PolicyとOIDC Providerを明示的に決定する。email domainやglobal設定から推測しない。
+5. Database backupを取得し、restoreできることを確認する。
 
-| 既存値                      | 判定             | 保存値                         |
-| --------------------------- | ---------------- | ------------------------------ |
-| `NULL`                      | 未設定           | `NULL`                         |
-| `0 < value <= 3`            | meter            | 小数第3位へ丸める              |
-| `value > 3`                 | 単位不一致の疑い | blocking issue。自動変換しない |
-| 上記以外、または丸め後に`0` | 不正             | blocking issue。自動修正しない |
+`pedestrians.height`と`stride_length`はmeterとして扱います。`0 < value <= 3`以外はblocking issueとし、
+centimeterと推測して変換しません。
 
-`preflight` は `valid_meters / invalid` の値数を返す。`backfill-core`も実際に書き込んだ
-`measurement_values_copied_meters`を返す。
+## Cutover手順
 
-## 実行コマンド
-
-Kaede directoryで実行する。
+Kaede directoryで実行します。
 
 ```sh
+# 1. maintenance modeへ切り替え、Kaede/Mio/workerからの全書込みを停止
+
+# 2. 新Table・Columnを追加するmigrationを適用
+make db-up ENV=production
+
+# 3. OrganizationごとのAuth Settings / OIDC Providerを確定・登録
+
+# 4. 最終preflight
 pnpm multi-org-auth-backfill preflight
-pnpm multi-org-auth-backfill backfill-core --batch-size 500
-pnpm multi-org-auth-backfill verify
+
+# 5. 全データを1 transactionで移行・検証し、全Sessionをrevoke
+pnpm multi-org-auth-backfill cutover --batch-size 500
+
+# 6. Membership UUID primary key昇格と同時リリース対象のContract migrationを適用
+make db-up ENV=production
+
+# 7. 新Kaedeを起動し、smoke test後に新Mioを公開
 ```
 
-`backfill-core`の対象は次の通り。
+`cutover`は次を単一transactionで実行します。
 
-- Organization status
-- Membership UUID/status/joined_at（`joined_at`は旧Membershipの`created_at`を使用）
-- User contact emailと共通Profile
-- PedestrianとMembershipの関連
-- Organization member profile（表示名override、meterの身長・歩幅）
-- Invite creator Membership
+1. 全scopeのpreflightを再検証する。
+2. Organization、Membership、contact email、User Profile、Member Profile、Pedestrian、Invite creatorを全件移行する。
+3. Membership単位Local Credential、canonical OIDC Identity、Membership OIDC Linkを全件移行する。
+4. core migrationの未移行件数がすべて0であることを検証する。
+5. auth backfillを再実行し、追加行が0であることを検証する。
+6. FK/CHECK/NOT NULL制約をvalidateする。
+7. 既存Sessionをすべてrevokeする。
 
-## 認証設定とCredential移行
+途中で失敗した場合はtransaction全体がrollbackされます。原因を修正して最初から再実行します。
 
-先に各Organizationの`organization_auth_settings`を運用者が明示的に登録する。OIDCを有効にする場合は、
-そのOrganizationにcanonical issuer `https://accounts.google.com`を持つ有効なProviderを1件登録する。
-作成者のemail domainやglobal環境変数からpolicy/hosted domainを自動設定しない。
+## 移行内容
 
-設定後に再度preflightを実行する。
+- `users.email`を`users.contact_email`へ移す。contact emailはLocal login keyにしない。
+- `users.display_name`を`user_profiles.display_name`へ移す。
+- MembershipにUUID、status、joined_atを設定する。
+- Pedestrianを対応するMembershipへ関連付ける。
+- 身長・歩幅をmeterのままOrganization Member Profileへ移す。
+- Local auth有効Organizationでは、現在Membershipごとにlegacy password hashをLocal Credentialへ複製する。
+- Google Identityはcanonical issuer `https://accounts.google.com`と`subject`で移す。
+- OIDC auth有効Organizationでは、ProviderとMembership Identity Linkを作る。
+- 旧multi-use Inviteとpending activationは自動変換せず、事前に失効・解消して新Inviteを発行する。
 
-```sh
-pnpm multi-org-auth-backfill preflight
-pnpm multi-org-auth-backfill backfill-auth --batch-size 500
-```
+## 成功判定
 
-`backfill-auth`は次を行う。
+- `cutover`が`validated: true`を返す。
+- coreのpending件数がすべて0である。
+- authの2回目backfillが0件である。
+- 全旧Sessionがrevoke済みである。
+- Membership UUID primary key migrationが成功する。
+- 新しいLocal/OIDC login、Organization切替、Invite受領、Profile取得が成功する。
+- 旧endpointと旧ColumnへのApplication read/writeが存在しない。
 
-- Local auth有効Organizationだけ、現在Membershipとlegacy passwordからLocal Credentialを作る。
-- login emailは`lower(btrim(email))`で正規化し、Organization内collisionがあれば全auth backfillを停止する。
-- legacy Google Identityをcanonical `issuer + subject`へ移す。emailはIdentity keyにしない。
-- OIDC auth有効かつGoogle Providerが一意に決まるOrganizationだけMembership Linkを作る。
+## Rollback
 
-認証policy不足、Providerの不足/複数候補、Identity owner conflictがある場合は何も自動修正せず停止する。
+一括Cutover後に旧Applicationだけを再起動してはいけません。新Credentialの変更を旧`users.password_hash`へ
+逆同期しないため、Application rollbackだけでは認証データが一致しません。
 
-## Constraint validation
-
-core verifyが全て0になった後だけ実行する。
-
-```sh
-pnpm multi-org-auth-backfill validate
-```
-
-これはExpandで`NOT VALID`として追加した、今回のbackfillで安全に検証できるconstraintを`VALIDATE`し、
-Organization statusとMembership UUID/status/joined_atを`NOT NULL`へ昇格する。
-NOT NULL昇格では短い`lock_timeout`と一時的な`NOT VALID` CHECKの事前検証を利用し、長時間のlockと再scanを避ける。
-
-全件が検証済みになった後、Membership Lifecycle migrationを適用する。このmigrationはcurrent Membership用の
-partial unique indexを先に作成してから、旧`(organization_id, user_id)` primary keyをUUID `id` primary keyへ
-切り替える。これ以降、`left` Membershipは履歴として残し、再参加時は新しいMembership IDを作成できる。
-
-```sh
-make db-up ENV=local
-```
-
-UUID primary key切替migrationは未backfill行がある場合に停止する。再参加後は旧primary keyへ戻せないため、
-本番運用はroll-forwardを基本とする。
-
-## blocking issueの扱い
-
-- `LOCAL_LOGIN_EMAIL_COLLISION`: 対象のlogin emailを運用判断で変更してから再実行する。
-- `MISSING_ORGANIZATION_AUTH_POLICY`: OrganizationごとのLocal/OIDC policyを明示する。
-- `OIDC_PROVIDER_MAPPING_MISSING_OR_AMBIGUOUS`: Providerを一意に確定する。
-- `OIDC_IDENTITY_OWNER_CONFLICT`: account linkを自動統合せず、本人確認を伴う別手順で解消する。
-- `PEDESTRIAN_MEMBERSHIP_NOT_FOUND`: Membershipとの対応を確認する。
-- `PEDESTRIAN_MEASUREMENT_OUT_OF_RANGE`: 元データの単位・値を確認して修正する。
-- `INVITE_CREATOR_MEMBERSHIP_NOT_FOUND`: 発行者Membershipを確認する。
-- `LEGACY_MULTI_USE_INVITE`: 権限を持つmanager/ownerが新しいsingle-use Inviteを発行する。
-- `PENDING_ACTIVATION_USER`: cutover前にactivation状態を運用判断する。
+サービス再開前に失敗した場合はtransaction rollbackまたは切替前backup restoreを行います。サービス再開後に
+重大障害が見つかった場合も、旧形式へ部分的に戻さず、DatabaseとApplicationを同じ時点へ全体restoreするか、
+新形式のままroll-forwardします。


### PR DESCRIPTION
Parent: #219

## 変更内容
- 新旧認証形式を共存させず、maintenance window内で全件移行する `cutover` commandを追加
- core/auth backfill、検証、constraint validation、既存Session全失効を1 transactionで実行
- User Profileのlegacy `users.display_name` fallbackを削除
- one-shot Cutover Runbookへ更新

## 移行方針
Application/workerの書込みを停止し、全件移行と検証が完了するまで新旧Applicationを起動しません。失敗時はtransaction rollbackまたは切替前backupからDatabase全体をrestoreします。

## Test
- TypeScript typecheck: pass
- ESLint: pass
- Unit: 533 pass
- DB testを追加（localはcontainer runtimeなしのためGitHub CIで実行）

## Scope外
- `origin/main`へのmerge
- Production migration実行
- Pedestrian旧columnの削除