### PR TITLE
feat: support multi-organization authentication and settings

### DIFF
--- a/.github/workflows/kaede-ci.yml
+++ b/.github/workflows/kaede-ci.yml
@@ -9,7 +9,7 @@ on:
       - ".github/workflows/kaede-db-ci.yml"
       - ".github/workflows/kaede-s3-ci.yml"
   pull_request:
-    branches: [main]
+    branches: [main, 219/main]
     paths:
       - "apps/kaede/**"
       - ".github/workflows/kaede-ci.yml"

--- a/.github/workflows/kaede-db-ci.yml
+++ b/.github/workflows/kaede-db-ci.yml
@@ -7,7 +7,7 @@ on:
       - "apps/kaede/**"
       - ".github/workflows/kaede-db-ci.yml"
   pull_request:
-    branches: [main]
+    branches: [main, 219/main]
     paths:
       - "apps/kaede/**"
       - ".github/workflows/kaede-db-ci.yml"

--- a/.github/workflows/kaede-s3-ci.yml
+++ b/.github/workflows/kaede-s3-ci.yml
@@ -7,7 +7,7 @@ on:
       - "apps/kaede/**"
       - ".github/workflows/kaede-s3-ci.yml"
   pull_request:
-    branches: [main]
+    branches: [main, 219/main]
     paths:
       - "apps/kaede/**"
       - ".github/workflows/kaede-s3-ci.yml"

--- a/.github/workflows/nozomi-ci.yml
+++ b/.github/workflows/nozomi-ci.yml
@@ -7,7 +7,7 @@ on:
       - "apps/nozomi/**"
       - ".github/workflows/nozomi-ci.yml"
   pull_request:
-    branches: [main]
+    branches: [main, 219/main]
     paths:
       - "apps/nozomi/**"
       - ".github/workflows/nozomi-ci.yml"

--- a/apps/kaede/package.json
+++ b/apps/kaede/package.json
@@ -16,7 +16,8 @@
     "format": "prettier --write .",
     "typecheck": "tsc --noEmit",
     "storage-prefix-migration": "tsx src/cli/storage-prefix-migration.ts",
-    "floor-map-dimension-backfill": "tsx src/cli/floor-map-dimension-backfill.ts"
+    "floor-map-dimension-backfill": "tsx src/cli/floor-map-dimension-backfill.ts",
+    "multi-org-auth-backfill": "tsx src/cli/multi-org-auth-backfill.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1045.0",

--- a/apps/kaede/src/cli/multi-org-auth-backfill.test.ts
+++ b/apps/kaede/src/cli/multi-org-auth-backfill.test.ts
@@ -16,6 +16,13 @@ describe('multi-org-auth-backfill options', () => {
     })
   })
 
+  it('accepts the one-shot cutover command', () => {
+    expect(parseOptions(['cutover', '--batch-size', '1000'])).toEqual({
+      batchSize: 1000,
+      command: 'cutover',
+    })
+  })
+
   it.each(['0', '-1', '1.5', '10001', 'not-a-number'])('rejects invalid batch size %s', (value) => {
     expect(() => parseOptions(['verify', '--batch-size', value])).toThrow('usage:')
   })

--- a/apps/kaede/src/cli/multi-org-auth-backfill.test.ts
+++ b/apps/kaede/src/cli/multi-org-auth-backfill.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { parseOptions } from './multi-org-auth-backfill.js'
+
+describe('multi-org-auth-backfill options', () => {
+  it('uses a bounded default batch size', () => {
+    expect(parseOptions(['backfill-core'])).toEqual({
+      batchSize: 500,
+      command: 'backfill-core',
+    })
+  })
+
+  it('accepts an explicit batch size', () => {
+    expect(parseOptions(['backfill-auth', '--batch-size', '25'])).toEqual({
+      batchSize: 25,
+      command: 'backfill-auth',
+    })
+  })
+
+  it.each(['0', '-1', '1.5', '10001', 'not-a-number'])('rejects invalid batch size %s', (value) => {
+    expect(() => parseOptions(['verify', '--batch-size', value])).toThrow('usage:')
+  })
+})

--- a/apps/kaede/src/cli/multi-org-auth-backfill.ts
+++ b/apps/kaede/src/cli/multi-org-auth-backfill.ts
@@ -1,0 +1,84 @@
+import {
+  backfillMultiOrgAuthCore,
+  backfillMultiOrgAuthCredentials,
+  getMultiOrgAuthPreflightReport,
+  validateMultiOrgAuthExpandConstraints,
+  verifyMultiOrgAuthCoreBackfill,
+} from '../services/migrations/multi-org-auth-backfill.js'
+
+interface Options {
+  batchSize: number
+  command: 'preflight' | 'backfill-core' | 'backfill-auth' | 'verify' | 'validate'
+}
+
+const usage = (): never => {
+  throw new Error(
+    'usage: multi-org-auth-backfill <preflight|backfill-core|backfill-auth|verify|validate> [--batch-size POSITIVE_INTEGER]'
+  )
+}
+
+export const parseOptions = (argv: string[]): Options => {
+  const command = argv.shift()
+  if (
+    command !== 'preflight' &&
+    command !== 'backfill-core' &&
+    command !== 'backfill-auth' &&
+    command !== 'verify' &&
+    command !== 'validate'
+  ) {
+    usage()
+  }
+
+  let batchSize = 500
+  while (argv.length > 0) {
+    const flag = argv.shift()
+    if (flag !== '--batch-size') usage()
+    const value = argv.shift() ?? usage()
+    batchSize = Number(value)
+    if (!Number.isSafeInteger(batchSize) || batchSize <= 0 || batchSize > 10_000) usage()
+  }
+
+  return { batchSize, command: command as Options['command'] }
+}
+
+export const main = async (argv = process.argv.slice(2)) => {
+  const options = parseOptions([...argv])
+
+  if (options.command === 'preflight') {
+    const report = await getMultiOrgAuthPreflightReport()
+    process.stdout.write(`${JSON.stringify(report)}\n`)
+    if (report.blocking) throw new Error('multi-organization auth preflight has blocking issues')
+    return
+  }
+
+  if (options.command === 'backfill-core') {
+    const result = await backfillMultiOrgAuthCore(options.batchSize)
+    process.stdout.write(`${JSON.stringify(result)}\n`)
+    return
+  }
+
+  if (options.command === 'backfill-auth') {
+    const result = await backfillMultiOrgAuthCredentials(options.batchSize)
+    process.stdout.write(`${JSON.stringify(result)}\n`)
+    return
+  }
+
+  if (options.command === 'verify') {
+    const result = await verifyMultiOrgAuthCoreBackfill()
+    process.stdout.write(`${JSON.stringify(result)}\n`)
+    if (Object.values(result).some((count) => count > 0)) {
+      throw new Error('multi-organization auth core backfill is incomplete')
+    }
+    return
+  }
+
+  await validateMultiOrgAuthExpandConstraints()
+  process.stdout.write(`${JSON.stringify({ validated: true })}\n`)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error: unknown) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+    process.exitCode = 1
+  })
+}

--- a/apps/kaede/src/cli/multi-org-auth-backfill.ts
+++ b/apps/kaede/src/cli/multi-org-auth-backfill.ts
@@ -1,17 +1,18 @@
 interface Options {
   batchSize: number
-  command: 'preflight' | 'backfill-core' | 'backfill-auth' | 'verify' | 'validate'
+  command: 'cutover' | 'preflight' | 'backfill-core' | 'backfill-auth' | 'verify' | 'validate'
 }
 
 const usage = (): never => {
   throw new Error(
-    'usage: multi-org-auth-backfill <preflight|backfill-core|backfill-auth|verify|validate> [--batch-size POSITIVE_INTEGER]'
+    'usage: multi-org-auth-backfill <cutover|preflight|backfill-core|backfill-auth|verify|validate> [--batch-size POSITIVE_INTEGER]'
   )
 }
 
 export const parseOptions = (argv: string[]): Options => {
   const command = argv.shift()
   if (
+    command !== 'cutover' &&
     command !== 'preflight' &&
     command !== 'backfill-core' &&
     command !== 'backfill-auth' &&
@@ -38,10 +39,17 @@ export const main = async (argv = process.argv.slice(2)) => {
   const {
     backfillMultiOrgAuthCore,
     backfillMultiOrgAuthCredentials,
+    executeOneShotMultiOrgAuthCutover,
     getMultiOrgAuthPreflightReport,
     validateMultiOrgAuthExpandConstraints,
     verifyMultiOrgAuthCoreBackfill,
   } = await import('../services/migrations/multi-org-auth-backfill.js')
+
+  if (options.command === 'cutover') {
+    const result = await executeOneShotMultiOrgAuthCutover(options.batchSize)
+    process.stdout.write(`${JSON.stringify(result)}\n`)
+    return
+  }
 
   if (options.command === 'preflight') {
     const report = await getMultiOrgAuthPreflightReport()

--- a/apps/kaede/src/cli/multi-org-auth-backfill.ts
+++ b/apps/kaede/src/cli/multi-org-auth-backfill.ts
@@ -1,11 +1,3 @@
-import {
-  backfillMultiOrgAuthCore,
-  backfillMultiOrgAuthCredentials,
-  getMultiOrgAuthPreflightReport,
-  validateMultiOrgAuthExpandConstraints,
-  verifyMultiOrgAuthCoreBackfill,
-} from '../services/migrations/multi-org-auth-backfill.js'
-
 interface Options {
   batchSize: number
   command: 'preflight' | 'backfill-core' | 'backfill-auth' | 'verify' | 'validate'
@@ -43,6 +35,13 @@ export const parseOptions = (argv: string[]): Options => {
 
 export const main = async (argv = process.argv.slice(2)) => {
   const options = parseOptions([...argv])
+  const {
+    backfillMultiOrgAuthCore,
+    backfillMultiOrgAuthCredentials,
+    getMultiOrgAuthPreflightReport,
+    validateMultiOrgAuthExpandConstraints,
+    verifyMultiOrgAuthCoreBackfill,
+  } = await import('../services/migrations/multi-org-auth-backfill.js')
 
   if (options.command === 'preflight') {
     const report = await getMultiOrgAuthPreflightReport()

--- a/apps/kaede/src/cli/multi-org-auth-backfill.ts
+++ b/apps/kaede/src/cli/multi-org-auth-backfill.ts
@@ -46,7 +46,13 @@ export const main = async (argv = process.argv.slice(2)) => {
   } = await import('../services/migrations/multi-org-auth-backfill.js')
 
   if (options.command === 'cutover') {
-    const result = await executeOneShotMultiOrgAuthCutover(options.batchSize)
+    const { getOidcRuntimeConfig } = await import('../config/runtime.js')
+    const config = getOidcRuntimeConfig()
+    const result = await executeOneShotMultiOrgAuthCutover(options.batchSize, undefined, {
+      google_client_id: config.googleClientId,
+      local_auth_enabled: config.passwordLoginEnabled,
+      oidc_auth_enabled: config.enabled,
+    })
     process.stdout.write(`${JSON.stringify(result)}\n`)
     return
   }

--- a/apps/kaede/src/middleware/organization-authorization.test.ts
+++ b/apps/kaede/src/middleware/organization-authorization.test.ts
@@ -1,0 +1,194 @@
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { evaluateMembershipGrant } from '../services/organization-authorization/authorization.js'
+import { organizationAuthorizationMiddleware } from './organization-authorization.js'
+import type { RequestActorHonoEnv } from './request-actor-context.js'
+
+const { findMembershipGrantContextMock } = vi.hoisted(() => ({
+  findMembershipGrantContextMock: vi.fn(),
+}))
+
+vi.mock('../services/organization-authorization/index.js', () => ({
+  findMembershipGrantContext: findMembershipGrantContextMock,
+}))
+
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const membershipId = '33333333-3333-4333-8333-333333333333'
+const userId = '11111111-1111-4111-8111-111111111111'
+const now = new Date('2026-08-11T12:00:00.000Z')
+
+const activeContext = {
+  organization_id: organizationId,
+  membership_id: membershipId,
+  membership_role: 'manager',
+  membership_status: 'active',
+  membership_left_at: null,
+  organization_status: 'active',
+  local_auth_enabled: true,
+  oidc_auth_enabled: true,
+  current_policy_version: '2',
+  reauthentication_interval_seconds: 7200,
+  grant_auth_method: 'local',
+  grant_policy_version: '2',
+  grant_authenticated_at: new Date('2026-08-11T11:00:00.000Z'),
+  grant_expires_at: new Date('2026-08-11T13:00:00.000Z'),
+  grant_revoked_at: null,
+  local_credential_enabled: true,
+  oidc_identity_revoked_at: null,
+  oidc_provider_enabled: null,
+}
+
+const createApp = (withActor = true) => {
+  const app = new Hono<RequestActorHonoEnv>()
+  if (withActor) {
+    app.use('/api/*', async (c, next) => {
+      c.set('requestActor', {
+        type: 'user',
+        user_id: userId,
+        email: 'member@example.com',
+        global_role: 'none',
+        account_state: 'active',
+        memberships: [
+          { organization_id: organizationId, organization_name: 'Example', role: 'manager' },
+        ],
+      })
+      c.set('requestSessionId', 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa')
+      await next()
+    })
+  }
+  app.use(
+    '/api/organizations/:organizationId/*',
+    organizationAuthorizationMiddleware({ now: () => now })
+  )
+  app.get('/api/organizations/:organizationId', (c) => c.json({ ok: true }))
+  app.get('/api/organizations/:organizationId/resource', (c) => c.json({ ok: true }))
+  return app
+}
+
+describe('evaluateMembershipGrant', () => {
+  it.each([
+    ['grant_missing', { grant_auth_method: null }],
+    ['grant_revoked', { grant_revoked_at: new Date('2026-08-11T11:30:00.000Z') }],
+    ['grant_expired', { grant_expires_at: now }],
+    ['reauthentication_interval_elapsed', { reauthentication_interval_seconds: 3600 }],
+    ['policy_changed', { grant_policy_version: '1' }],
+    ['auth_method_not_allowed', { local_auth_enabled: false }],
+  ] as const)('%s を安定した再認証理由として返す', (reason, override) => {
+    const result = evaluateMembershipGrant({ ...activeContext, ...override }, 'member', now)
+
+    expect(result).toMatchObject({
+      ok: false,
+      type: 'reauthentication_required',
+      membershipId,
+      reason,
+    })
+  })
+
+  it('active grantの確認後にroleを認可する', () => {
+    expect(evaluateMembershipGrant(activeContext, 'manager', now)).toMatchObject({
+      ok: true,
+      membershipId,
+      role: 'manager',
+    })
+    expect(evaluateMembershipGrant(activeContext, 'owner', now)).toEqual({
+      ok: false,
+      type: 'role_forbidden',
+      membershipId,
+    })
+  })
+
+  it('reauthentication intervalの直前は許可し、境界時刻で再認証を要求する', () => {
+    const context = { ...activeContext, reauthentication_interval_seconds: 3600 }
+
+    expect(
+      evaluateMembershipGrant(context, 'member', new Date('2026-08-11T11:59:59.999Z'))
+    ).toMatchObject({ ok: true })
+    expect(evaluateMembershipGrant(context, 'member', now)).toMatchObject({
+      ok: false,
+      type: 'reauthentication_required',
+      reason: 'reauthentication_interval_elapsed',
+    })
+  })
+
+  it('別userやinactive Membershipをquery結果なし/forbiddenとして扱う', () => {
+    expect(evaluateMembershipGrant(undefined, 'member', now)).toEqual({
+      ok: false,
+      type: 'organization_forbidden',
+    })
+    expect(
+      evaluateMembershipGrant({ ...activeContext, membership_status: 'suspended' }, 'member', now)
+    ).toEqual({ ok: false, type: 'organization_forbidden' })
+  })
+})
+
+describe('organizationAuthorizationMiddleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('有効なsessionとMembership grantならorganization routeへ進む', async () => {
+    findMembershipGrantContextMock.mockResolvedValue(activeContext)
+    const response = await createApp().request(`/api/organizations/${organizationId}/resource`)
+
+    expect(response.status).toBe(200)
+    expect(findMembershipGrantContextMock).toHaveBeenCalledWith(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      userId,
+      organizationId
+    )
+  })
+
+  it('organization直下のrouteも認可対象にできる', async () => {
+    findMembershipGrantContextMock.mockResolvedValue(activeContext)
+    const app = new Hono<RequestActorHonoEnv>()
+    app.use('/api/*', async (c, next) => {
+      c.set('requestActor', {
+        type: 'user',
+        user_id: userId,
+        email: 'member@example.com',
+        global_role: 'none',
+        account_state: 'active',
+        memberships: [],
+      })
+      c.set('requestSessionId', 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa')
+      await next()
+    })
+    app.use(
+      '/api/organizations/:organizationId',
+      organizationAuthorizationMiddleware({ now: () => now })
+    )
+    app.get('/api/organizations/:organizationId', (c) => c.json({ ok: true }))
+
+    const response = await app.request(`/api/organizations/${organizationId}`)
+    expect(response.status).toBe(200)
+    expect(findMembershipGrantContextMock).toHaveBeenCalledOnce()
+  })
+
+  it('grant期限切れはglobal sessionを失効させず403と再認証metadataを返す', async () => {
+    findMembershipGrantContextMock.mockResolvedValue({ ...activeContext, grant_expires_at: now })
+    const response = await createApp().request(`/api/organizations/${organizationId}/resource`)
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({
+      error_code: 'AUTH_MEMBERSHIP_REAUTHENTICATION_REQUIRED',
+      error_message: 'organization membership reauthentication required',
+      details: {
+        organization_id: organizationId,
+        membership_id: membershipId,
+        reason: 'grant_expired',
+        allowed_auth_methods: ['local', 'oidc'],
+      },
+    })
+  })
+
+  it('global session contextがなければ401を返す', async () => {
+    const response = await createApp(false).request(`/api/organizations/${organizationId}/resource`)
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({
+      error_code: 'AUTH_UNAUTHENTICATED',
+      error_message: 'login required',
+    })
+    expect(findMembershipGrantContextMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/kaede/src/middleware/organization-authorization.test.ts
+++ b/apps/kaede/src/middleware/organization-authorization.test.ts
@@ -19,13 +19,17 @@ const now = new Date('2026-08-11T12:00:00.000Z')
 
 const activeContext = {
   organization_id: organizationId,
+  organization_name: 'Example',
+  organization_slug: 'example',
   membership_id: membershipId,
   membership_role: 'manager',
   membership_status: 'active',
   membership_left_at: null,
   organization_status: 'active',
+  auth_settings_available: true,
   local_auth_enabled: true,
   oidc_auth_enabled: true,
+  has_enabled_oidc_provider: true,
   current_policy_version: '2',
   reauthentication_interval_seconds: 7200,
   grant_auth_method: 'local',

--- a/apps/kaede/src/middleware/organization-authorization.ts
+++ b/apps/kaede/src/middleware/organization-authorization.ts
@@ -1,0 +1,75 @@
+import type { Context, MiddlewareHandler } from 'hono'
+import type { MembershipRole } from '../schemas/common.js'
+import { evaluateMembershipGrant } from '../services/organization-authorization/authorization.js'
+import { findMembershipGrantContext } from '../services/organization-authorization/index.js'
+import type { RequestActorHonoEnv } from './request-actor-context.js'
+import { getRequestActor, getRequestSessionId } from './request-actor-context.js'
+
+const forbidden = (c: Context<RequestActorHonoEnv>, errorCode: string, details?: object) =>
+  c.json(
+    {
+      error_code: errorCode,
+      error_message:
+        errorCode === 'AUTH_MEMBERSHIP_REAUTHENTICATION_REQUIRED'
+          ? 'organization membership reauthentication required'
+          : errorCode === 'AUTH_DASHBOARD_FORBIDDEN'
+            ? 'dashboard access forbidden'
+            : 'organization access forbidden',
+      ...(details ? { details } : {}),
+    },
+    403
+  )
+
+export interface OrganizationAuthorizationMiddlewareOptions {
+  requiredRole?: MembershipRole
+  now?: () => Date
+}
+
+export const organizationAuthorizationMiddleware = ({
+  requiredRole = 'member',
+  now = () => new Date(),
+}: OrganizationAuthorizationMiddlewareOptions = {}): MiddlewareHandler<RequestActorHonoEnv> => {
+  return async (c, next) => {
+    const actor = getRequestActor(c)
+
+    // Shared-token clients are authenticated independently and have no user Membership grant.
+    if (actor?.type === 'service_client') {
+      await next()
+      return
+    }
+
+    const sessionId = getRequestSessionId(c)
+    if (actor?.type !== 'user' || !sessionId) {
+      return c.json({ error_code: 'AUTH_UNAUTHENTICATED', error_message: 'login required' }, 401)
+    }
+
+    const organizationId = c.req.param('organizationId')
+    if (!organizationId) {
+      return forbidden(c, 'AUTH_ORGANIZATION_FORBIDDEN')
+    }
+    const context = await findMembershipGrantContext(sessionId, actor.user_id, organizationId)
+    const result = evaluateMembershipGrant(context, requiredRole, now())
+
+    if (result.ok) {
+      await next()
+      return
+    }
+    if (result.type === 'organization_forbidden') {
+      return forbidden(c, 'AUTH_ORGANIZATION_FORBIDDEN', { organization_id: organizationId })
+    }
+    if (result.type === 'role_forbidden') {
+      return forbidden(c, 'AUTH_DASHBOARD_FORBIDDEN', {
+        organization_id: organizationId,
+        membership_id: result.membershipId,
+        required_role: requiredRole,
+      })
+    }
+
+    return forbidden(c, 'AUTH_MEMBERSHIP_REAUTHENTICATION_REQUIRED', {
+      organization_id: organizationId,
+      membership_id: result.membershipId,
+      reason: result.reason,
+      allowed_auth_methods: result.allowedAuthMethods,
+    })
+  }
+}

--- a/apps/kaede/src/middleware/request-actor-context.ts
+++ b/apps/kaede/src/middleware/request-actor-context.ts
@@ -25,6 +25,7 @@ export type RequestActor = UserRequestActor | ServiceClientRequestActor
 
 export interface RequestActorVariables {
   requestActor?: RequestActor
+  requestSessionId?: string
 }
 
 export interface RequestActorHonoEnv {
@@ -34,6 +35,7 @@ export interface RequestActorHonoEnv {
 export type RequestActorContext = Context<RequestActorHonoEnv>
 
 const requestActorKey = 'requestActor' satisfies keyof RequestActorVariables
+const requestSessionIdKey = 'requestSessionId' satisfies keyof RequestActorVariables
 
 export const setRequestActor = (c: RequestActorContext, actor: RequestActor) => {
   c.set(requestActorKey, actor)
@@ -41,6 +43,14 @@ export const setRequestActor = (c: RequestActorContext, actor: RequestActor) => 
 
 export const getRequestActor = (c: RequestActorContext): RequestActor | undefined => {
   return c.get(requestActorKey)
+}
+
+export const setRequestSessionId = (c: RequestActorContext, sessionId: string) => {
+  c.set(requestSessionIdKey, sessionId)
+}
+
+export const getRequestSessionId = (c: RequestActorContext): string | undefined => {
+  return c.get(requestSessionIdKey)
 }
 
 export const requireRequestActor = (c: RequestActorContext): RequestActor => {

--- a/apps/kaede/src/middleware/request-actor.test.ts
+++ b/apps/kaede/src/middleware/request-actor.test.ts
@@ -3,15 +3,24 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { RequestActorHonoEnv } from './request-actor.js'
 import { getRequestActor, requestActorMiddleware } from './request-actor.js'
 
-const { findUserByIdMock, findValidSessionByTokenMock, listUserOrganizationMembershipsMock } =
-  vi.hoisted(() => ({
-    findUserByIdMock: vi.fn(),
-    findValidSessionByTokenMock: vi.fn(),
-    listUserOrganizationMembershipsMock: vi.fn(),
-  }))
+const {
+  findUserByIdMock,
+  findValidSessionByTokenMock,
+  hasLocalAuthenticationGrantBySessionIdMock,
+  listUserOrganizationMembershipsMock,
+} = vi.hoisted(() => ({
+  findUserByIdMock: vi.fn(),
+  findValidSessionByTokenMock: vi.fn(),
+  hasLocalAuthenticationGrantBySessionIdMock: vi.fn(),
+  listUserOrganizationMembershipsMock: vi.fn(),
+}))
 
 vi.mock('../services/auth/index.js', () => ({
   findValidSessionByToken: findValidSessionByTokenMock,
+}))
+
+vi.mock('../services/organization-local-auth/index.js', () => ({
+  hasLocalAuthenticationGrantBySessionId: hasLocalAuthenticationGrantBySessionIdMock,
 }))
 
 vi.mock('../services/users/index.js', () => ({
@@ -50,6 +59,7 @@ const mockActiveSessionUser = ({
   findValidSessionByTokenMock.mockResolvedValue({
     ok: true,
     session: {
+      id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       auth_method: authMethod,
       user_id: '11111111-1111-4111-8111-111111111111',
     },
@@ -73,6 +83,7 @@ const mockActiveSessionUser = ({
 describe('requestActorMiddleware', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    hasLocalAuthenticationGrantBySessionIdMock.mockResolvedValue(false)
   })
 
   it('正しい shared token があれば service client actor を設定する', async () => {
@@ -204,6 +215,23 @@ describe('requestActorMiddleware', () => {
     expect(response.status).toBe(200)
     const body = await response.json()
     expect(body.actor.account_state).toBe('active')
+  })
+
+  it('Membership Local Grantを持つsessionは共通password未設定でも利用できる', async () => {
+    mockActiveSessionUser({ passwordHash: null })
+    hasLocalAuthenticationGrantBySessionIdMock.mockResolvedValue(true)
+    const app = createTestApp()
+
+    const response = await app.request('/api/ping', {
+      headers: {
+        cookie: 'okarin_session=session-token',
+      },
+    })
+
+    expect(response.status).toBe(200)
+    expect(hasLocalAuthenticationGrantBySessionIdMock).toHaveBeenCalledWith(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+    )
   })
 
   it('membership がない user は pending_membership actor として設定する', async () => {

--- a/apps/kaede/src/middleware/request-actor.ts
+++ b/apps/kaede/src/middleware/request-actor.ts
@@ -8,7 +8,7 @@ import { hasLocalAuthenticationGrantBySessionId } from '../services/organization
 import { findUserById, listUserOrganizationMemberships } from '../services/users/index.js'
 import { deriveAccountState } from '../usecases/authorization.js'
 import type { RequestActorHonoEnv } from './request-actor-context.js'
-import { setRequestActor } from './request-actor-context.js'
+import { setRequestActor, setRequestSessionId } from './request-actor-context.js'
 export type {
   RequestActor,
   RequestActorHonoEnv,
@@ -17,7 +17,13 @@ export type {
   UserActorMembership,
   UserRequestActor,
 } from './request-actor-context.js'
-export { getRequestActor, requireRequestActor, setRequestActor } from './request-actor-context.js'
+export {
+  getRequestActor,
+  getRequestSessionId,
+  requireRequestActor,
+  setRequestActor,
+  setRequestSessionId,
+} from './request-actor-context.js'
 
 type RequestActorContext = Context<RequestActorHonoEnv>
 
@@ -157,6 +163,7 @@ export const requestActorMiddleware = ({
         role: membership.role as 'member' | 'manager' | 'owner',
       })),
     })
+    setRequestSessionId(c, sessionResult.session.id)
 
     await next()
   }

--- a/apps/kaede/src/middleware/request-actor.ts
+++ b/apps/kaede/src/middleware/request-actor.ts
@@ -4,6 +4,7 @@ import { timingSafeEqual } from 'node:crypto'
 import { sessionCookieName } from '../routes/auth/cookie.js'
 import { toAuthErrorResponse } from '../schemas/common.js'
 import { findValidSessionByToken } from '../services/auth/index.js'
+import { hasLocalAuthenticationGrantBySessionId } from '../services/organization-local-auth/index.js'
 import { findUserById, listUserOrganizationMemberships } from '../services/users/index.js'
 import { deriveAccountState } from '../usecases/authorization.js'
 import type { RequestActorHonoEnv } from './request-actor-context.js'
@@ -130,7 +131,12 @@ export const requestActorMiddleware = ({
     }
 
     if (sessionResult.session.auth_method === 'password' && !user.password_hash) {
-      return authError(c, 'AUTH_PASSWORD_CHANGE_REQUIRED')
+      const isMembershipLocalSession = await hasLocalAuthenticationGrantBySessionId(
+        sessionResult.session.id
+      )
+      if (!isMembershipLocalSession) {
+        return authError(c, 'AUTH_PASSWORD_CHANGE_REQUIRED')
+      }
     }
 
     const memberships = await listUserOrganizationMemberships(user.id)

--- a/apps/kaede/src/routes/auth/auth.test.ts
+++ b/apps/kaede/src/routes/auth/auth.test.ts
@@ -15,6 +15,7 @@ const {
   loginMock,
   logoutMock,
   completeOrganizationOidcMock,
+  acceptOrganizationInviteWithOidcMock,
   isOrganizationOidcTransactionStateMock,
   requireActiveSessionUserMock,
   verifyActivationTokenMock,
@@ -27,6 +28,7 @@ const {
   loginMock: vi.fn(),
   logoutMock: vi.fn(),
   completeOrganizationOidcMock: vi.fn(),
+  acceptOrganizationInviteWithOidcMock: vi.fn(),
   isOrganizationOidcTransactionStateMock: vi.fn(),
   requireActiveSessionUserMock: vi.fn(),
   verifyActivationTokenMock: vi.fn(),
@@ -35,6 +37,10 @@ const {
 vi.mock('../../usecases/organization-oidc-auth/index.js', () => ({
   completeOrganizationOidc: completeOrganizationOidcMock,
   isOrganizationOidcTransactionState: isOrganizationOidcTransactionStateMock,
+}))
+
+vi.mock('../../usecases/organization-invites/index.js', () => ({
+  acceptOrganizationInviteWithOidc: acceptOrganizationInviteWithOidcMock,
 }))
 
 vi.mock('../../services/auth/index.js', () => ({
@@ -434,7 +440,10 @@ describe('auth routes', () => {
     expect(completeOrganizationOidcMock).toHaveBeenCalledWith(
       'authorization-code',
       'organization-state',
-      expect.objectContaining({ sessionToken: undefined })
+      expect.objectContaining({
+        sessionToken: undefined,
+        completeInvite: acceptOrganizationInviteWithOidcMock,
+      })
     )
     expect(completeGoogleOidcLoginMock).not.toHaveBeenCalled()
     expect(completeGoogleOidcLinkMock).not.toHaveBeenCalled()

--- a/apps/kaede/src/routes/auth/auth.test.ts
+++ b/apps/kaede/src/routes/auth/auth.test.ts
@@ -14,6 +14,8 @@ const {
   getMeMock,
   loginMock,
   logoutMock,
+  completeOrganizationOidcMock,
+  isOrganizationOidcTransactionStateMock,
   requireActiveSessionUserMock,
   verifyActivationTokenMock,
 } = vi.hoisted(() => ({
@@ -24,8 +26,15 @@ const {
   getMeMock: vi.fn(),
   loginMock: vi.fn(),
   logoutMock: vi.fn(),
+  completeOrganizationOidcMock: vi.fn(),
+  isOrganizationOidcTransactionStateMock: vi.fn(),
   requireActiveSessionUserMock: vi.fn(),
   verifyActivationTokenMock: vi.fn(),
+}))
+
+vi.mock('../../usecases/organization-oidc-auth/index.js', () => ({
+  completeOrganizationOidc: completeOrganizationOidcMock,
+  isOrganizationOidcTransactionState: isOrganizationOidcTransactionStateMock,
 }))
 
 vi.mock('../../services/auth/index.js', () => ({
@@ -87,6 +96,7 @@ const userResponse = {
 describe('auth routes', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    isOrganizationOidcTransactionStateMock.mockResolvedValue(false)
     if (originalAppEnv === undefined) {
       Reflect.deleteProperty(process.env, 'APP_ENV')
     } else {
@@ -390,6 +400,82 @@ describe('auth routes', () => {
       },
       expect.any(Object)
     )
+  })
+
+  it('GET /api/auth/oidc/google/callback はOrganization transactionを新callbackへdispatchする', async () => {
+    process.env.OIDC_ENABLED = 'true'
+    process.env.OIDC_GOOGLE_CLIENT_ID = 'client-id'
+    process.env.OIDC_GOOGLE_CLIENT_SECRET = 'client-secret'
+    process.env.OIDC_GOOGLE_REDIRECT_URI = 'https://api.example.test/api/auth/oidc/google/callback'
+    process.env.OIDC_STATE_COOKIE_SECRET = 'state-cookie-secret'
+    process.env.FRONTEND_ORIGIN = 'https://app.example.test'
+    resetRuntimeConfigForTests()
+    isOrganizationOidcTransactionStateMock.mockResolvedValue(true)
+    completeOrganizationOidcMock.mockResolvedValue({
+      ok: true,
+      value: {
+        return_to: '/orgs/organization-a',
+        sessionToken: 'organization-session-token',
+      },
+    })
+
+    const app = createAuthTestApp()
+    const response = await app.request(
+      '/api/auth/oidc/google/callback?code=authorization-code&state=organization-state'
+    )
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toBe(
+      'https://app.example.test/auth/complete?result=success&return_to=%2Forgs%2Forganization-a'
+    )
+    expect(response.headers.get('set-cookie')).toContain(
+      'okarin_session=organization-session-token'
+    )
+    expect(completeOrganizationOidcMock).toHaveBeenCalledWith(
+      'authorization-code',
+      'organization-state',
+      expect.objectContaining({ sessionToken: undefined })
+    )
+    expect(completeGoogleOidcLoginMock).not.toHaveBeenCalled()
+    expect(completeGoogleOidcLinkMock).not.toHaveBeenCalled()
+  })
+
+  it('replayed Organization stateをlegacy callbackへfallbackしない', async () => {
+    process.env.OIDC_ENABLED = 'true'
+    process.env.OIDC_GOOGLE_CLIENT_ID = 'client-id'
+    process.env.OIDC_GOOGLE_CLIENT_SECRET = 'client-secret'
+    process.env.OIDC_GOOGLE_REDIRECT_URI = 'https://api.example.test/api/auth/oidc/google/callback'
+    process.env.OIDC_STATE_COOKIE_SECRET = 'state-cookie-secret'
+    process.env.FRONTEND_ORIGIN = 'https://app.example.test'
+    resetRuntimeConfigForTests()
+    isOrganizationOidcTransactionStateMock.mockResolvedValue(true)
+    completeOrganizationOidcMock.mockResolvedValue({
+      ok: false,
+      error: { type: 'OIDC_TRANSACTION_INVALID' },
+    })
+    const legacyStateCookie = serializeGoogleOidcStateCookie(
+      {
+        state: 'organization-state',
+        nonce: 'nonce-value',
+        codeVerifier: 'code-verifier',
+        expiresAt: '2099-06-17T00:10:00.000Z',
+        intent: 'login',
+      },
+      'state-cookie-secret'
+    )
+
+    const app = createAuthTestApp()
+    const response = await app.request(
+      '/api/auth/oidc/google/callback?code=authorization-code&state=organization-state',
+      { headers: { cookie: `okarin_oidc_google=${legacyStateCookie}` } }
+    )
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toBe(
+      'https://app.example.test/auth/complete?result=error&return_to=%2F&code=OIDC_TRANSACTION_INVALID'
+    )
+    expect(completeGoogleOidcLoginMock).not.toHaveBeenCalled()
+    expect(completeGoogleOidcLinkMock).not.toHaveBeenCalled()
   })
 
   it('GET /api/auth/me は cookie の session token で user を返す', async () => {

--- a/apps/kaede/src/routes/auth/error.ts
+++ b/apps/kaede/src/routes/auth/error.ts
@@ -1,6 +1,6 @@
 import { toAuthErrorResponse as toCommonAuthErrorResponse } from '../../schemas/common.js'
 import type { AuthErrorCode } from '../../schemas/common.js'
 
-export const toAuthErrorResponse = (error: { type: AuthErrorCode }) => {
+export const toAuthErrorResponse = <TCode extends AuthErrorCode>(error: { type: TCode }) => {
   return toCommonAuthErrorResponse(error.type)
 }

--- a/apps/kaede/src/routes/auth/me.ts
+++ b/apps/kaede/src/routes/auth/me.ts
@@ -1,7 +1,10 @@
 import { createRoute } from '@hono/zod-openapi'
 import type { OpenAPIHono } from '@hono/zod-openapi'
-import { authUserResponseSchema } from '../../schemas/auth.js'
-import { errorResponseSchema } from '../../schemas/common.js'
+import { authMeResponseSchema } from '../../schemas/auth.js'
+import {
+  globalSessionErrorResponseSchema,
+  userAccountErrorResponseSchema,
+} from '../../schemas/common.js'
 import { getMe } from '../../usecases/auth/index.js'
 import { getSessionTokenFromCookie } from './cookie.js'
 import { toAuthErrorResponse } from './error.js'
@@ -17,7 +20,7 @@ export const registerMeRoute = (app: OpenAPIHono) => {
         description: 'current user',
         content: {
           'application/json': {
-            schema: authUserResponseSchema,
+            schema: authMeResponseSchema,
           },
         },
       },
@@ -25,7 +28,7 @@ export const registerMeRoute = (app: OpenAPIHono) => {
         description: 'login required',
         content: {
           'application/json': {
-            schema: errorResponseSchema,
+            schema: globalSessionErrorResponseSchema,
           },
         },
       },
@@ -33,7 +36,7 @@ export const registerMeRoute = (app: OpenAPIHono) => {
         description: 'user disabled',
         content: {
           'application/json': {
-            schema: errorResponseSchema,
+            schema: userAccountErrorResponseSchema,
           },
         },
       },
@@ -44,6 +47,11 @@ export const registerMeRoute = (app: OpenAPIHono) => {
     const result = await getMe(getSessionTokenFromCookie(c))
 
     if (!result.ok) {
+      if (result.error.type === 'AUTH_USER_DISABLED') {
+        const error = toAuthErrorResponse(result.error)
+        return c.json(error.body, error.status)
+      }
+
       const error = toAuthErrorResponse(result.error)
       return c.json(error.body, error.status)
     }

--- a/apps/kaede/src/routes/auth/oidc-google-callback.ts
+++ b/apps/kaede/src/routes/auth/oidc-google-callback.ts
@@ -1,8 +1,12 @@
 import { createRoute, z } from '@hono/zod-openapi'
 import type { OpenAPIHono } from '@hono/zod-openapi'
-import { getOidcRuntimeConfig } from '../../config/runtime.js'
+import { getAppRuntimeConfig, getOidcRuntimeConfig } from '../../config/runtime.js'
 import { GoogleOidcClient } from '../../services/auth/index.js'
 import { completeGoogleOidcLink, completeGoogleOidcLogin } from '../../usecases/auth/index.js'
+import {
+  completeOrganizationOidc,
+  isOrganizationOidcTransactionState,
+} from '../../usecases/organization-oidc-auth/index.js'
 import { getSessionTokenFromCookie, setSessionCookie } from './cookie.js'
 import { clearGoogleOidcStateCookie, getGoogleOidcStateCookie } from './oidc-cookie.js'
 
@@ -18,6 +22,20 @@ const withError = (url: string, errorCode: string) => {
   return url.startsWith('/')
     ? `${redirectUrl.pathname}${redirectUrl.search}`
     : redirectUrl.toString()
+}
+
+const organizationCompletionUrl = (
+  result: 'success' | 'error',
+  returnTo: string,
+  errorCode?: string
+) => {
+  const frontendOrigin = getAppRuntimeConfig().frontendOrigin
+  const url = new URL('/auth/complete', frontendOrigin ?? 'http://localhost')
+  url.searchParams.set('result', result)
+  url.searchParams.set('return_to', returnTo)
+  if (errorCode) url.searchParams.set('code', errorCode)
+
+  return frontendOrigin ? url.toString() : `${url.pathname}${url.search}`
 }
 
 export const registerGoogleOidcCallbackRoute = (app: OpenAPIHono) => {
@@ -40,11 +58,44 @@ export const registerGoogleOidcCallbackRoute = (app: OpenAPIHono) => {
     const config = getOidcRuntimeConfig()
     const query = c.req.valid('query')
     const failureRedirectUrl = config.loginFailureRedirectUrl
+    if (!config.enabled) {
+      clearGoogleOidcStateCookie(c)
+      return c.redirect(withError(failureRedirectUrl, query.error ?? 'oidc_disabled'), 302)
+    }
+
+    const organizationTransaction = query.state
+      ? await isOrganizationOidcTransactionState(query.state)
+      : false
+    const client = new GoogleOidcClient({
+      clientId: config.googleClientId,
+      clientSecret: config.googleClientSecret,
+      redirectUri: config.googleRedirectUri,
+    })
+    if (organizationTransaction) {
+      const result = await completeOrganizationOidc(
+        query.error ? undefined : query.code,
+        query.state,
+        {
+          client,
+          configuredClientId: config.googleClientId,
+          transactionSecret: config.stateCookieSecret,
+          sessionToken: getSessionTokenFromCookie(c),
+        }
+      )
+      if (!result.ok) {
+        return c.redirect(
+          organizationCompletionUrl('error', result.return_to ?? '/', result.error.type),
+          302
+        )
+      }
+      if (result.value.sessionToken) setSessionCookie(c, result.value.sessionToken)
+
+      return c.redirect(organizationCompletionUrl('success', result.value.return_to), 302)
+    }
 
     clearGoogleOidcStateCookie(c)
-
-    if (!config.enabled || query.error) {
-      return c.redirect(withError(failureRedirectUrl, query.error ?? 'oidc_disabled'), 302)
+    if (query.error) {
+      return c.redirect(withError(failureRedirectUrl, query.error), 302)
     }
 
     const stateCookie = getGoogleOidcStateCookie(c, config.stateCookieSecret)
@@ -53,11 +104,6 @@ export const registerGoogleOidcCallbackRoute = (app: OpenAPIHono) => {
       return c.redirect(withError(failureRedirectUrl, 'invalid_state'), 302)
     }
 
-    const client = new GoogleOidcClient({
-      clientId: config.googleClientId,
-      clientSecret: config.googleClientSecret,
-      redirectUri: config.googleRedirectUri,
-    })
     const params = {
       code: query.code,
       state: query.state,

--- a/apps/kaede/src/routes/auth/oidc-google-callback.ts
+++ b/apps/kaede/src/routes/auth/oidc-google-callback.ts
@@ -3,6 +3,7 @@ import type { OpenAPIHono } from '@hono/zod-openapi'
 import { getAppRuntimeConfig, getOidcRuntimeConfig } from '../../config/runtime.js'
 import { GoogleOidcClient } from '../../services/auth/index.js'
 import { completeGoogleOidcLink, completeGoogleOidcLogin } from '../../usecases/auth/index.js'
+import { acceptOrganizationInviteWithOidc } from '../../usecases/organization-invites/index.js'
 import {
   completeOrganizationOidc,
   isOrganizationOidcTransactionState,
@@ -80,6 +81,7 @@ export const registerGoogleOidcCallbackRoute = (app: OpenAPIHono) => {
           configuredClientId: config.googleClientId,
           transactionSecret: config.stateCookieSecret,
           sessionToken: getSessionTokenFromCookie(c),
+          completeInvite: acceptOrganizationInviteWithOidc,
         }
       )
       if (!result.ok) {

--- a/apps/kaede/src/routes/index.ts
+++ b/apps/kaede/src/routes/index.ts
@@ -11,6 +11,7 @@ import { pedestriansRoutes } from './pedestrians/index.js'
 import { platformRoutes } from './platform/index.js'
 import { recordingsRoutes } from './recordings/index.js'
 import { trajectoriesRoutes } from './trajectories/index.js'
+import { usersRoutes } from './users/index.js'
 
 export const registerApiRoutes = (app: OpenAPIHono) => {
   const api = new OpenAPIHono()
@@ -27,6 +28,7 @@ export const registerApiRoutes = (app: OpenAPIHono) => {
   api.route('/platform', platformRoutes)
   api.route('/recordings', recordingsRoutes)
   api.route('/trajectories', trajectoriesRoutes)
+  api.route('/users', usersRoutes)
 
   app.route('/api', api)
 }

--- a/apps/kaede/src/routes/organization-auth-methods/index.ts
+++ b/apps/kaede/src/routes/organization-auth-methods/index.ts
@@ -1,0 +1,6 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { registerOrganizationAuthMethodsRoute } from './methods.js'
+
+export const organizationAuthMethodsRoutes = new OpenAPIHono()
+
+registerOrganizationAuthMethodsRoute(organizationAuthMethodsRoutes)

--- a/apps/kaede/src/routes/organization-auth-methods/methods.test.ts
+++ b/apps/kaede/src/routes/organization-auth-methods/methods.test.ts
@@ -1,0 +1,63 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { registerOrganizationAuthMethodsRoute } from './methods.js'
+
+const { getPublicOrganizationAuthMethodsMock } = vi.hoisted(() => ({
+  getPublicOrganizationAuthMethodsMock: vi.fn(),
+}))
+
+vi.mock('../../usecases/organization-auth-methods/index.js', () => ({
+  getPublicOrganizationAuthMethods: getPublicOrganizationAuthMethodsMock,
+}))
+
+const createApp = () => {
+  const app = new OpenAPIHono()
+  const routes = new OpenAPIHono()
+  registerOrganizationAuthMethodsRoute(routes)
+  app.route('/api/organizations', routes)
+  return app
+}
+
+describe('GET /api/organizations/:organizationSlug/auth/methods', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('secretやOrganization metadataを含めずLocal可否と有効OIDC providerだけを返す', async () => {
+    getPublicOrganizationAuthMethodsMock.mockResolvedValue({
+      local_auth_enabled: true,
+      allowed_auth_methods: ['local', 'oidc'],
+      oidc_providers: [
+        { id: '11111111-1111-4111-8111-111111111111', display_name: 'Google Workspace' },
+      ],
+    })
+
+    const response = await createApp().request('/api/organizations/example-org/auth/methods')
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    await expect(response.json()).resolves.toEqual({
+      local_auth_enabled: true,
+      allowed_auth_methods: ['local', 'oidc'],
+      oidc_providers: [
+        { id: '11111111-1111-4111-8111-111111111111', display_name: 'Google Workspace' },
+      ],
+    })
+    expect(getPublicOrganizationAuthMethodsMock).toHaveBeenCalledWith('example-org')
+  })
+
+  it('不存在・停止Organizationにも同じ空responseを返してslug enumerationを抑える', async () => {
+    getPublicOrganizationAuthMethodsMock.mockResolvedValue({
+      local_auth_enabled: false,
+      allowed_auth_methods: [],
+      oidc_providers: [],
+    })
+
+    const response = await createApp().request('/api/organizations/unknown-org/auth/methods')
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      local_auth_enabled: false,
+      allowed_auth_methods: [],
+      oidc_providers: [],
+    })
+  })
+})

--- a/apps/kaede/src/routes/organization-auth-methods/methods.ts
+++ b/apps/kaede/src/routes/organization-auth-methods/methods.ts
@@ -1,0 +1,29 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import {
+  organizationAuthMethodsParamsSchema,
+  organizationAuthMethodsResponseSchema,
+} from '../../schemas/organization-auth-methods.js'
+import { getPublicOrganizationAuthMethods } from '../../usecases/organization-auth-methods/index.js'
+
+export const registerOrganizationAuthMethodsRoute = (app: OpenAPIHono) => {
+  const route = createRoute({
+    method: 'get',
+    path: '/{organizationSlug}/auth/methods',
+    tags: ['Organization Auth'],
+    description: '認証前または再認証時に利用可能な最小限のOrganization認証方式を返す',
+    request: { params: organizationAuthMethodsParamsSchema },
+    responses: {
+      200: {
+        description: 'public organization authentication methods',
+        content: { 'application/json': { schema: organizationAuthMethodsResponseSchema } },
+      },
+    },
+  })
+
+  app.openapi(route, async (c) => {
+    const response = await getPublicOrganizationAuthMethods(c.req.valid('param').organizationSlug)
+    c.header('Cache-Control', 'no-store')
+    return c.json(response, 200)
+  })
+}

--- a/apps/kaede/src/routes/organization-invites/error.ts
+++ b/apps/kaede/src/routes/organization-invites/error.ts
@@ -1,0 +1,47 @@
+import type { OrganizationInviteError } from '../../usecases/organization-invites/index.js'
+
+export const toOrganizationInviteErrorResponse = (error: OrganizationInviteError) => {
+  switch (error.type) {
+    case 'AUTH_DASHBOARD_FORBIDDEN':
+    case 'AUTH_ORGANIZATION_FORBIDDEN':
+    case 'AUTH_METHOD_NOT_ALLOWED':
+    case 'INVITE_MEMBERSHIP_SUSPENDED':
+    case 'AUTH_USER_DISABLED':
+      return {
+        status: 403 as const,
+        body: { error_code: error.type, error_message: 'operation is not allowed' },
+      }
+    case 'AUTH_SESSION_EXPIRED':
+    case 'AUTH_SESSION_REVOKED':
+      return {
+        status: 401 as const,
+        body: { error_code: error.type, error_message: 'session is not valid' },
+      }
+    case 'INVITE_NOT_FOUND':
+    case 'INVITE_INVALID':
+      return {
+        status: 404 as const,
+        body: { error_code: error.type, error_message: 'invite is not available' },
+      }
+    case 'INVITE_EXPIRED':
+      return {
+        status: 422 as const,
+        body: { error_code: error.type, error_message: 'invite expired' },
+      }
+    case 'INVITE_ALREADY_REDEEMED':
+    case 'INVITE_ALREADY_REVOKED':
+    case 'INVITE_ALREADY_MEMBER':
+    case 'LOCAL_LOGIN_EMAIL_CONFLICT':
+    case 'MEMBERSHIP_PROFILE_UNAVAILABLE':
+      return {
+        status: 409 as const,
+        body: { error_code: error.type, error_message: 'invite conflicts with current state' },
+      }
+    case 'INVITE_NEW_USER_PROFILE_REQUIRED':
+    case 'INVITE_EXISTING_USER_PROFILE_NOT_ALLOWED':
+      return {
+        status: 400 as const,
+        body: { error_code: error.type, error_message: 'invalid invite registration payload' },
+      }
+  }
+}

--- a/apps/kaede/src/routes/organization-invites/index.ts
+++ b/apps/kaede/src/routes/organization-invites/index.ts
@@ -1,0 +1,5 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { registerPublicOrganizationInviteRoutes } from './public.js'
+
+export const organizationInvitesRoutes = new OpenAPIHono()
+registerPublicOrganizationInviteRoutes(organizationInvitesRoutes)

--- a/apps/kaede/src/routes/organization-invites/public.test.ts
+++ b/apps/kaede/src/routes/organization-invites/public.test.ts
@@ -32,10 +32,20 @@ describe('public organization invite routes', () => {
     usecases.verifyOrganizationInvite.mockResolvedValue({
       ok: true,
       value: {
-        organization: { name: 'Example' },
+        organization: {
+          id: '11111111-1111-4111-8111-111111111111',
+          name: 'Example',
+          slug: 'example',
+        },
         role: 'member',
         expires_at: '2026-08-18T10:00:00.000Z',
         authentication_methods: { local: true, oidc: true },
+        oidc_providers: [
+          {
+            id: '22222222-2222-4222-8222-222222222222',
+            display_name: 'Google',
+          },
+        ],
       },
     })
     const response = await app().request('/api/invites/verify', {

--- a/apps/kaede/src/routes/organization-invites/public.test.ts
+++ b/apps/kaede/src/routes/organization-invites/public.test.ts
@@ -1,0 +1,120 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { resetRuntimeConfigForTests } from '../../config/runtime.js'
+
+const usecases = vi.hoisted(() => ({
+  acceptOrganizationInviteWithLocalCredential: vi.fn(),
+  verifyOrganizationInvite: vi.fn(),
+}))
+vi.mock('../../usecases/organization-invites/index.js', () => usecases)
+
+import { organizationInvitesRoutes } from './index.js'
+
+const app = () => {
+  const instance = new OpenAPIHono()
+  instance.route('/api/invites', organizationInvitesRoutes)
+  return instance
+}
+
+describe('public organization invite routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.APP_ENV = 'local'
+    resetRuntimeConfigForTests()
+  })
+
+  afterEach(() => {
+    Reflect.deleteProperty(process.env, 'APP_ENV')
+    resetRuntimeConfigForTests()
+  })
+
+  it('verifyはInvite情報をno-storeで返す', async () => {
+    usecases.verifyOrganizationInvite.mockResolvedValue({
+      ok: true,
+      value: {
+        organization: { name: 'Example' },
+        role: 'member',
+        expires_at: '2026-08-18T10:00:00.000Z',
+        authentication_methods: { local: true, oidc: true },
+      },
+    })
+    const response = await app().request('/api/invites/verify', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ token: 'plain-token' }),
+    })
+    expect(response.status).toBe(200)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    await expect(response.json()).resolves.toMatchObject({ role: 'member' })
+  })
+
+  it('新規Local受領ではSession cookieを発行しtokenをresponse bodyへ含めない', async () => {
+    usecases.acceptOrganizationInviteWithLocalCredential.mockResolvedValue({
+      ok: true,
+      value: {
+        sessionToken: 'new-session-token',
+        session: { expires_at: '2026-08-18T10:00:00.000Z' },
+        membership: {
+          id: '22222222-2222-4222-8222-222222222222',
+          organization_id: '11111111-1111-4111-8111-111111111111',
+          role: 'member',
+          status: 'active',
+        },
+        grant: {
+          auth_method: 'local',
+          authenticated_at: '2026-08-11T10:00:00.000Z',
+          expires_at: '2026-08-11T11:00:00.000Z',
+        },
+      },
+    })
+    const response = await app().request('/api/invites/auth/local', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        token: 'plain-token',
+        login_email: 'member@example.test',
+        password: 'password',
+        contact_email: 'contact@example.test',
+        profile: { display_name: 'Member', locale: 'ja-JP', timezone: 'Asia/Tokyo' },
+      }),
+    })
+    expect(response.status).toBe(200)
+    expect(response.headers.get('set-cookie')).toContain('okarin_session=new-session-token')
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    expect(JSON.stringify(await response.json())).not.toContain('new-session-token')
+  })
+
+  it.each([
+    ['INVITE_INVALID', 404],
+    ['INVITE_ALREADY_REDEEMED', 409],
+    ['INVITE_EXPIRED', 422],
+  ])('verifyの%sをHTTP %iで返す', async (type, status) => {
+    usecases.verifyOrganizationInvite.mockResolvedValue({ ok: false, error: { type } })
+    const response = await app().request('/api/invites/verify', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ token: 'plain-token' }),
+    })
+    expect(response.status).toBe(status)
+  })
+
+  it.each([
+    ['locale', { display_name: 'Member', locale: 'not_a_locale', timezone: 'Asia/Tokyo' }],
+    ['timezone', { display_name: 'Member', locale: 'ja-JP', timezone: 'Mars/Olympus' }],
+  ])('無効な%sをUseCaseへ渡さない', async (_field, profile) => {
+    const response = await app().request('/api/invites/auth/local', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        token: 'plain-token',
+        login_email: ' member@example.test ',
+        password: 'password',
+        contact_email: ' contact@example.test ',
+        profile,
+      }),
+    })
+
+    expect(response.status).toBe(400)
+    expect(usecases.acceptOrganizationInviteWithLocalCredential).not.toHaveBeenCalled()
+  })
+})

--- a/apps/kaede/src/routes/organization-invites/public.ts
+++ b/apps/kaede/src/routes/organization-invites/public.ts
@@ -1,0 +1,127 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { errorResponseSchema } from '../../schemas/common.js'
+import {
+  acceptLocalOrganizationInviteRequestSchema,
+  acceptLocalOrganizationInviteResponseSchema,
+  verifyOrganizationInviteRequestSchema,
+  verifyOrganizationInviteResponseSchema,
+} from '../../schemas/organization-invites.js'
+import {
+  acceptOrganizationInviteWithLocalCredential,
+  verifyOrganizationInvite,
+} from '../../usecases/organization-invites/index.js'
+import { getSessionTokenFromCookie, setSessionCookie } from '../auth/cookie.js'
+import { toOrganizationInviteErrorResponse } from './error.js'
+
+const errors = {
+  400: {
+    description: 'invalid registration payload',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  401: {
+    description: 'invalid session',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  403: {
+    description: 'authentication method or membership is not allowed',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  404: {
+    description: 'invite not found',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  409: {
+    description: 'invite conflicts with current state',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  422: {
+    description: 'invite expired',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+} as const
+
+export const registerPublicOrganizationInviteRoutes = (app: OpenAPIHono) => {
+  const verifyRoute = createRoute({
+    method: 'post',
+    path: '/verify',
+    tags: ['Organization Invites'],
+    request: {
+      body: { content: { 'application/json': { schema: verifyOrganizationInviteRequestSchema } } },
+    },
+    responses: {
+      200: {
+        description: 'invite is available',
+        content: { 'application/json': { schema: verifyOrganizationInviteResponseSchema } },
+      },
+      404: errors[404],
+      409: errors[409],
+      422: errors[422],
+    },
+  })
+  app.openapi(verifyRoute, async (c) => {
+    const result = await verifyOrganizationInvite(c.req.valid('json').token)
+    if (!result.ok) {
+      switch (result.error.type) {
+        case 'INVITE_INVALID':
+          return c.json(
+            { error_code: result.error.type, error_message: 'invite is not available' },
+            404
+          )
+        case 'INVITE_ALREADY_REDEEMED':
+          return c.json(
+            { error_code: result.error.type, error_message: 'invite was already redeemed' },
+            409
+          )
+        case 'INVITE_EXPIRED':
+          return c.json({ error_code: result.error.type, error_message: 'invite expired' }, 422)
+      }
+    }
+    c.header('Cache-Control', 'no-store')
+    return c.json(result.value, 200)
+  })
+
+  const localRoute = createRoute({
+    method: 'post',
+    path: '/auth/local',
+    tags: ['Organization Invites'],
+    request: {
+      body: {
+        content: { 'application/json': { schema: acceptLocalOrganizationInviteRequestSchema } },
+      },
+    },
+    responses: {
+      200: {
+        description: 'invite accepted',
+        content: { 'application/json': { schema: acceptLocalOrganizationInviteResponseSchema } },
+      },
+      400: errors[400],
+      401: errors[401],
+      403: errors[403],
+      404: errors[404],
+      409: errors[409],
+      422: errors[422],
+    },
+  })
+  app.openapi(localRoute, async (c) => {
+    const result = await acceptOrganizationInviteWithLocalCredential(
+      getSessionTokenFromCookie(c),
+      c.req.valid('json'),
+      { requestId: c.req.header('x-request-id'), userAgent: c.req.header('user-agent') }
+    )
+    if (!result.ok) {
+      const error = toOrganizationInviteErrorResponse(result.error)
+      return c.json(error.body, error.status)
+    }
+    if (result.value.sessionToken) setSessionCookie(c, result.value.sessionToken)
+    c.header('Cache-Control', 'no-store')
+    return c.json(
+      {
+        session: result.value.session,
+        membership: result.value.membership,
+        grant: result.value.grant,
+      },
+      200
+    )
+  })
+}

--- a/apps/kaede/src/routes/organization-local-auth/index.ts
+++ b/apps/kaede/src/routes/organization-local-auth/index.ts
@@ -1,0 +1,6 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { registerLocalOrganizationLoginRoute } from './local-login.js'
+
+export const organizationLocalAuthRoutes = new OpenAPIHono()
+
+registerLocalOrganizationLoginRoute(organizationLocalAuthRoutes)

--- a/apps/kaede/src/routes/organization-local-auth/local-login.test.ts
+++ b/apps/kaede/src/routes/organization-local-auth/local-login.test.ts
@@ -1,0 +1,192 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { resetRuntimeConfigForTests } from '../../config/runtime.js'
+
+const { localLoginMock } = vi.hoisted(() => ({ localLoginMock: vi.fn() }))
+
+vi.mock('../../usecases/organization-local-auth/index.js', () => ({
+  loginToOrganizationWithLocalCredential: localLoginMock,
+}))
+
+import { organizationLocalAuthRoutes } from './index.js'
+
+const createTestApp = () => {
+  const app = new OpenAPIHono()
+  app.route('/api/organizations', organizationLocalAuthRoutes)
+  return app
+}
+
+describe('organization local auth route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.APP_ENV = 'local'
+    resetRuntimeConfigForTests()
+  })
+
+  afterEach(() => {
+    Reflect.deleteProperty(process.env, 'APP_ENV')
+    resetRuntimeConfigForTests()
+  })
+
+  it('新しいSessionのcookieとMembership Grantを返す', async () => {
+    localLoginMock.mockResolvedValue({
+      ok: true,
+      value: {
+        sessionToken: 'new-session-token',
+        session: {
+          id: '11111111-1111-4111-8111-111111111111',
+          expires_at: '2026-08-18T10:00:00.000Z',
+        },
+        membership: {
+          id: '22222222-2222-4222-8222-222222222222',
+          organization_id: '33333333-3333-4333-8333-333333333333',
+          role: 'member',
+          status: 'active',
+        },
+        grant: {
+          auth_method: 'local',
+          authenticated_at: '2026-08-11T10:00:00.000Z',
+          expires_at: '2026-08-11T18:00:00.000Z',
+        },
+        return_to: '/orgs/organization-a',
+      },
+    })
+
+    const response = await createTestApp().request(
+      '/api/organizations/organization-a/auth/local/login',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'user-agent': 'local-auth-test',
+          'x-request-id': 'request-id',
+        },
+        body: JSON.stringify({
+          login_email: 'local@example.test',
+          password: 'password',
+          return_to: '/orgs/organization-a',
+        }),
+      }
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('set-cookie')).toContain('okarin_session=new-session-token')
+    await expect(response.json()).resolves.toEqual({
+      session: { expires_at: '2026-08-18T10:00:00.000Z' },
+      membership: {
+        id: '22222222-2222-4222-8222-222222222222',
+        organization_id: '33333333-3333-4333-8333-333333333333',
+        role: 'member',
+        status: 'active',
+      },
+      grant: {
+        auth_method: 'local',
+        authenticated_at: '2026-08-11T10:00:00.000Z',
+        expires_at: '2026-08-11T18:00:00.000Z',
+      },
+      return_to: '/orgs/organization-a',
+    })
+    expect(localLoginMock).toHaveBeenCalledWith(
+      'organization-a',
+      undefined,
+      {
+        login_email: 'local@example.test',
+        password: 'password',
+        return_to: '/orgs/organization-a',
+      },
+      { requestId: 'request-id', userAgent: 'local-auth-test' }
+    )
+  })
+
+  it('reauthenticateでは既存Session cookieを渡し、新しいcookieを発行しない', async () => {
+    localLoginMock.mockResolvedValue({
+      ok: true,
+      value: {
+        session: {
+          id: '11111111-1111-4111-8111-111111111111',
+          expires_at: '2026-08-18T10:00:00.000Z',
+        },
+        membership: {
+          id: '22222222-2222-4222-8222-222222222222',
+          organization_id: '33333333-3333-4333-8333-333333333333',
+          role: 'member',
+          status: 'active',
+        },
+        grant: {
+          auth_method: 'local',
+          authenticated_at: '2026-08-11T10:00:00.000Z',
+          expires_at: '2026-08-11T18:00:00.000Z',
+        },
+        return_to: '/orgs/organization-a',
+      },
+    })
+
+    const response = await createTestApp().request(
+      '/api/organizations/organization-a/auth/local/login',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          cookie: 'okarin_session=existing-session-token',
+        },
+        body: JSON.stringify({
+          login_email: 'local@example.test',
+          password: 'password',
+          return_to: '/orgs/organization-a',
+        }),
+      }
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('set-cookie')).toBeNull()
+    expect(localLoginMock).toHaveBeenCalledWith(
+      'organization-a',
+      'existing-session-token',
+      expect.any(Object),
+      expect.any(Object)
+    )
+  })
+
+  it.each([
+    ['AUTH_INVALID_CREDENTIALS', 401],
+    ['AUTH_METHOD_NOT_ALLOWED', 403],
+    ['AUTH_IDENTITY_USER_MISMATCH', 403],
+    ['AUTH_CREDENTIAL_LOCKED', 429],
+  ])('%sをHTTP %iで返す', async (type, expectedStatus) => {
+    localLoginMock.mockResolvedValue({ ok: false, error: { type } })
+
+    const response = await createTestApp().request(
+      '/api/organizations/organization-a/auth/local/login',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          login_email: 'local@example.test',
+          password: 'password',
+          return_to: '/orgs/organization-a',
+        }),
+      }
+    )
+
+    expect(response.status).toBe(expectedStatus)
+    await expect(response.json()).resolves.toMatchObject({ error_code: type })
+  })
+
+  it('外部URL形式のreturn_toを拒否する', async () => {
+    const response = await createTestApp().request(
+      '/api/organizations/organization-a/auth/local/login',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          login_email: 'local@example.test',
+          password: 'password',
+          return_to: '//attacker.example.test',
+        }),
+      }
+    )
+
+    expect(response.status).toBe(400)
+    expect(localLoginMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/kaede/src/routes/organization-local-auth/local-login.ts
+++ b/apps/kaede/src/routes/organization-local-auth/local-login.ts
@@ -1,0 +1,129 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { errorResponseSchema } from '../../schemas/common.js'
+import {
+  localOrganizationLoginRequestSchema,
+  localOrganizationLoginResponseSchema,
+  organizationLocalAuthParamsSchema,
+} from '../../schemas/organization-local-auth.js'
+import { loginToOrganizationWithLocalCredential } from '../../usecases/organization-local-auth/index.js'
+import { getSessionTokenFromCookie, setSessionCookie } from '../auth/cookie.js'
+
+const localAuthError = (type: string) => {
+  switch (type) {
+    case 'AUTH_METHOD_NOT_ALLOWED':
+      return {
+        status: 403 as const,
+        body: {
+          error_code: type,
+          error_message: 'local authentication is not allowed for this organization',
+        },
+      }
+    case 'AUTH_IDENTITY_USER_MISMATCH':
+      return {
+        status: 403 as const,
+        body: {
+          error_code: type,
+          error_message: 'the credential belongs to a different user',
+        },
+      }
+    case 'AUTH_MEMBERSHIP_NOT_ACTIVE':
+      return {
+        status: 403 as const,
+        body: { error_code: type, error_message: 'organization membership is not active' },
+      }
+    case 'AUTH_USER_DISABLED':
+      return {
+        status: 403 as const,
+        body: { error_code: type, error_message: 'user is disabled' },
+      }
+    case 'AUTH_CREDENTIAL_LOCKED':
+      return {
+        status: 429 as const,
+        body: { error_code: type, error_message: 'local credential is temporarily locked' },
+      }
+    case 'AUTH_SESSION_EXPIRED':
+      return {
+        status: 401 as const,
+        body: { error_code: type, error_message: 'session expired' },
+      }
+    case 'AUTH_SESSION_REVOKED':
+      return {
+        status: 401 as const,
+        body: { error_code: type, error_message: 'session revoked' },
+      }
+    default:
+      return {
+        status: 401 as const,
+        body: {
+          error_code: 'AUTH_INVALID_CREDENTIALS',
+          error_message: 'invalid email or password',
+        },
+      }
+  }
+}
+
+export const registerLocalOrganizationLoginRoute = (app: OpenAPIHono) => {
+  const route = createRoute({
+    method: 'post',
+    path: '/{organizationSlug}/auth/local/login',
+    tags: ['Organization Auth'],
+    description: 'Membership単位のLocal CredentialでOrganizationへ認証する',
+    request: {
+      params: organizationLocalAuthParamsSchema,
+      body: {
+        content: { 'application/json': { schema: localOrganizationLoginRequestSchema } },
+      },
+    },
+    responses: {
+      200: {
+        description: 'local authentication succeeded',
+        content: { 'application/json': { schema: localOrganizationLoginResponseSchema } },
+      },
+      401: {
+        description: 'invalid credentials or session',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      403: {
+        description: 'local authentication is not allowed',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      429: {
+        description: 'credential is locked',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+    },
+  })
+
+  app.openapi(route, async (c) => {
+    const { organizationSlug } = c.req.valid('param')
+    const result = await loginToOrganizationWithLocalCredential(
+      organizationSlug,
+      getSessionTokenFromCookie(c),
+      c.req.valid('json'),
+      {
+        requestId: c.req.header('x-request-id'),
+        userAgent: c.req.header('user-agent'),
+      }
+    )
+
+    if (!result.ok) {
+      const error = localAuthError(result.error.type)
+      return c.json(error.body, error.status)
+    }
+
+    if (result.value.sessionToken) {
+      setSessionCookie(c, result.value.sessionToken)
+    }
+
+    return c.json(
+      {
+        session: { expires_at: result.value.session.expires_at },
+        membership: result.value.membership,
+        grant: result.value.grant,
+        return_to: result.value.return_to,
+      },
+      200
+    )
+  })
+}

--- a/apps/kaede/src/routes/organization-local-credentials/index.ts
+++ b/apps/kaede/src/routes/organization-local-credentials/index.ts
@@ -1,0 +1,6 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { registerOrganizationLocalCredentialRoutes } from './management.js'
+
+export const organizationLocalCredentialRoutes = new OpenAPIHono()
+
+registerOrganizationLocalCredentialRoutes(organizationLocalCredentialRoutes)

--- a/apps/kaede/src/routes/organization-local-credentials/management.ts
+++ b/apps/kaede/src/routes/organization-local-credentials/management.ts
@@ -1,0 +1,179 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { getRequestSessionId, requireRequestActor } from '../../middleware/request-actor-context.js'
+import type { RequestActorContext } from '../../middleware/request-actor-context.js'
+import { errorResponseSchema } from '../../schemas/common.js'
+import {
+  disableOrganizationLocalCredentialRequestSchema,
+  organizationLocalCredentialParamsSchema,
+  organizationLocalCredentialSchema,
+  putOrganizationLocalCredentialRequestSchema,
+} from '../../schemas/organization-local-credentials.js'
+import {
+  disableMyOrganizationLocalCredential,
+  getMyOrganizationLocalCredential,
+  putMyOrganizationLocalCredential,
+} from '../../usecases/organization-local-credentials/index.js'
+import type { OrganizationLocalCredentialManagementError } from '../../usecases/organization-local-credentials/index.js'
+
+const toErrorResponse = (error: OrganizationLocalCredentialManagementError) => {
+  switch (error.type) {
+    case 'AUTH_UNAUTHENTICATED':
+      return {
+        status: 401 as const,
+        body: { error_code: error.type, error_message: 'login required' },
+      }
+    case 'AUTH_INVALID_CREDENTIALS':
+      return {
+        status: 401 as const,
+        body: { error_code: error.type, error_message: 'current password is invalid' },
+      }
+    case 'AUTH_ORGANIZATION_FORBIDDEN':
+      return {
+        status: 403 as const,
+        body: { error_code: error.type, error_message: 'active membership is required' },
+      }
+    case 'AUTH_METHOD_NOT_ALLOWED':
+      return {
+        status: 403 as const,
+        body: { error_code: error.type, error_message: 'local authentication is disabled' },
+      }
+    case 'AUTH_MEMBERSHIP_REAUTHENTICATION_REQUIRED':
+      return {
+        status: 403 as const,
+        body: {
+          error_code: error.type,
+          error_message: 'recent membership authentication required',
+        },
+      }
+    case 'LOCAL_CREDENTIAL_NOT_FOUND':
+      return {
+        status: 404 as const,
+        body: { error_code: error.type, error_message: 'local credential not found' },
+      }
+    case 'LOCAL_CREDENTIAL_LAST_AUTH_METHOD':
+      return {
+        status: 409 as const,
+        body: { error_code: error.type, error_message: 'another usable login method is required' },
+      }
+    case 'LOCAL_LOGIN_EMAIL_CONFLICT':
+      return {
+        status: 409 as const,
+        body: { error_code: error.type, error_message: 'login email is already in use' },
+      }
+  }
+}
+
+const responses = {
+  200: {
+    description: 'local credential metadata（secret/hashは返さない）',
+    content: { 'application/json': { schema: organizationLocalCredentialSchema } },
+  },
+  400: {
+    description: 'request validation failed',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  401: {
+    description: 'login required or current password invalid',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  403: {
+    description: 'active membership or recent reauthentication required',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  404: {
+    description: 'credential not found',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  409: {
+    description: 'Organization内のlogin email conflict',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+} as const
+
+export const registerOrganizationLocalCredentialRoutes = (app: OpenAPIHono) => {
+  const getRoute = createRoute({
+    method: 'get',
+    path: '/{organizationId}/members/me/local-credential',
+    tags: ['Organization Local Credentials'],
+    description: '本人のMembership単位Local Credential metadataを取得する',
+    request: { params: organizationLocalCredentialParamsSchema },
+    responses,
+  })
+
+  app.openapi(getRoute, async (c) => {
+    const result = await getMyOrganizationLocalCredential(
+      requireRequestActor(c as RequestActorContext),
+      c.req.valid('param').organizationId
+    )
+    if (!result.ok) {
+      const error = toErrorResponse(result.error)
+      return c.json(error.body, error.status)
+    }
+    return c.json(result.value, 200)
+  })
+
+  const putRoute = createRoute({
+    method: 'put',
+    path: '/{organizationId}/members/me/local-credential',
+    tags: ['Organization Local Credentials'],
+    description:
+      '本人がLocal Credentialを初回設定または変更する。current passwordまたは最近のMembership認証を要求する',
+    request: {
+      params: organizationLocalCredentialParamsSchema,
+      body: {
+        required: true,
+        content: { 'application/json': { schema: putOrganizationLocalCredentialRequestSchema } },
+      },
+    },
+    responses,
+  })
+
+  app.openapi(putRoute, async (c) => {
+    const result = await putMyOrganizationLocalCredential(
+      requireRequestActor(c as RequestActorContext),
+      getRequestSessionId(c as RequestActorContext),
+      c.req.valid('param').organizationId,
+      c.req.valid('json'),
+      { requestId: c.req.header('x-request-id'), userAgent: c.req.header('user-agent') }
+    )
+    if (!result.ok) {
+      const error = toErrorResponse(result.error)
+      return c.json(error.body, error.status)
+    }
+    return c.json(result.value, 200)
+  })
+
+  const deleteRoute = createRoute({
+    method: 'delete',
+    path: '/{organizationId}/members/me/local-credential',
+    tags: ['Organization Local Credentials'],
+    description:
+      '本人のLocal Credentialを無効化する。current passwordまたは最近のMembership認証を要求する',
+    request: {
+      params: organizationLocalCredentialParamsSchema,
+      body: {
+        required: true,
+        content: {
+          'application/json': { schema: disableOrganizationLocalCredentialRequestSchema },
+        },
+      },
+    },
+    responses,
+  })
+
+  app.openapi(deleteRoute, async (c) => {
+    const result = await disableMyOrganizationLocalCredential(
+      requireRequestActor(c as RequestActorContext),
+      getRequestSessionId(c as RequestActorContext),
+      c.req.valid('param').organizationId,
+      c.req.valid('json'),
+      { requestId: c.req.header('x-request-id'), userAgent: c.req.header('user-agent') }
+    )
+    if (!result.ok) {
+      const error = toErrorResponse(result.error)
+      return c.json(error.body, error.status)
+    }
+    return c.json(result.value, 200)
+  })
+}

--- a/apps/kaede/src/routes/organization-oidc-auth/index.ts
+++ b/apps/kaede/src/routes/organization-oidc-auth/index.ts
@@ -1,0 +1,6 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { registerOrganizationOidcStartRoute } from './start.js'
+
+export const organizationOidcAuthRoutes = new OpenAPIHono()
+
+registerOrganizationOidcStartRoute(organizationOidcAuthRoutes)

--- a/apps/kaede/src/routes/organization-oidc-auth/start.ts
+++ b/apps/kaede/src/routes/organization-oidc-auth/start.ts
@@ -1,0 +1,84 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { getOidcRuntimeConfig } from '../../config/runtime.js'
+import { errorResponseSchema } from '../../schemas/common.js'
+import {
+  organizationOidcStartParamsSchema,
+  organizationOidcStartRequestSchema,
+  organizationOidcStartResponseSchema,
+} from '../../schemas/organization-oidc-auth.js'
+import { GoogleOidcClient } from '../../services/auth/index.js'
+import { startOrganizationOidc } from '../../usecases/organization-oidc-auth/index.js'
+import { getSessionTokenFromCookie } from '../auth/cookie.js'
+
+const errorStatus = (type: string) => {
+  if (type === 'INVITE_INVALID' || type === 'OIDC_PROVIDER_NOT_FOUND') return 404 as const
+  if (type === 'AUTH_SESSION_REQUIRED' || type.includes('SESSION_')) return 401 as const
+  return 403 as const
+}
+
+export const registerOrganizationOidcStartRoute = (app: OpenAPIHono) => {
+  const route = createRoute({
+    method: 'post',
+    path: '/{organizationSlug}/auth/oidc/{providerId}/start',
+    tags: ['Organization Auth'],
+    request: {
+      params: organizationOidcStartParamsSchema,
+      body: { content: { 'application/json': { schema: organizationOidcStartRequestSchema } } },
+    },
+    responses: {
+      200: {
+        description: 'authorization transaction created',
+        content: { 'application/json': { schema: organizationOidcStartResponseSchema } },
+      },
+      401: {
+        description: 'session required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      403: {
+        description: 'OIDC not allowed',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      404: {
+        description: 'provider or invite not found',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+    },
+  })
+
+  app.openapi(route, async (c) => {
+    const config = getOidcRuntimeConfig()
+    if (!config.enabled) {
+      return c.json(
+        { error_code: 'AUTH_METHOD_NOT_ALLOWED', error_message: 'OIDC is disabled' },
+        403
+      )
+    }
+    const { organizationSlug, providerId } = c.req.valid('param')
+    const client = new GoogleOidcClient({
+      clientId: config.googleClientId,
+      clientSecret: config.googleClientSecret,
+      redirectUri: config.googleRedirectUri,
+    })
+    const result = await startOrganizationOidc(
+      organizationSlug,
+      providerId,
+      getSessionTokenFromCookie(c),
+      c.req.valid('json'),
+      {
+        client,
+        configuredClientId: config.googleClientId,
+        transactionSecret: config.stateCookieSecret,
+      }
+    )
+    if (!result.ok) {
+      const status = errorStatus(result.error.type)
+      return c.json(
+        { error_code: result.error.type, error_message: 'OIDC authorization could not start' },
+        status
+      )
+    }
+
+    return c.json(result.value, 200)
+  })
+}

--- a/apps/kaede/src/routes/organization-session-auth/index.ts
+++ b/apps/kaede/src/routes/organization-session-auth/index.ts
@@ -1,0 +1,6 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { registerOrganizationSessionLogoutRoute } from './logout.js'
+
+export const organizationSessionAuthRoutes = new OpenAPIHono()
+
+registerOrganizationSessionLogoutRoute(organizationSessionAuthRoutes)

--- a/apps/kaede/src/routes/organization-session-auth/logout.test.ts
+++ b/apps/kaede/src/routes/organization-session-auth/logout.test.ts
@@ -1,0 +1,82 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { logoutMock } = vi.hoisted(() => ({ logoutMock: vi.fn() }))
+
+vi.mock('../../usecases/organization-session-auth/index.js', () => ({
+  logoutFromOrganization: logoutMock,
+}))
+
+import { organizationSessionAuthRoutes } from './index.js'
+
+const organizationId = '11111111-1111-4111-8111-111111111111'
+const membershipId = '22222222-2222-4222-8222-222222222222'
+
+const createTestApp = () => {
+  const app = new OpenAPIHono()
+  app.route('/api/organizations', organizationSessionAuthRoutes)
+  return app
+}
+
+describe('organization session logout route', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('対象Grantだけをrevokeし、Session cookieを削除しない', async () => {
+    logoutMock.mockResolvedValue({
+      ok: true,
+      value: { organization_id: organizationId, membership_id: membershipId, revoked: true },
+    })
+
+    const response = await createTestApp().request(
+      `/api/organizations/${organizationId}/auth/logout`,
+      {
+        method: 'POST',
+        headers: {
+          cookie: 'okarin_session=session-token',
+          'user-agent': 'logout-test',
+          'x-request-id': 'request-id',
+        },
+      }
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('set-cookie')).toBeNull()
+    await expect(response.json()).resolves.toEqual({
+      organization_id: organizationId,
+      membership_id: membershipId,
+      revoked: true,
+    })
+    expect(logoutMock).toHaveBeenCalledWith(organizationId, 'session-token', {
+      requestId: 'request-id',
+      userAgent: 'logout-test',
+    })
+  })
+
+  it('Sessionなしは401を返す', async () => {
+    logoutMock.mockResolvedValue({ ok: false, error: { type: 'AUTH_UNAUTHENTICATED' } })
+
+    const response = await createTestApp().request(
+      `/api/organizations/${organizationId}/auth/logout`,
+      { method: 'POST' }
+    )
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toMatchObject({
+      error_code: 'AUTH_UNAUTHENTICATED',
+    })
+  })
+
+  it('対象Organizationに所属していない場合は403を返す', async () => {
+    logoutMock.mockResolvedValue({
+      ok: false,
+      error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' },
+    })
+
+    const response = await createTestApp().request(
+      `/api/organizations/${organizationId}/auth/logout`,
+      { method: 'POST', headers: { cookie: 'okarin_session=session-token' } }
+    )
+
+    expect(response.status).toBe(403)
+  })
+})

--- a/apps/kaede/src/routes/organization-session-auth/logout.ts
+++ b/apps/kaede/src/routes/organization-session-auth/logout.ts
@@ -1,0 +1,63 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { errorResponseSchema } from '../../schemas/common.js'
+import {
+  organizationSessionLogoutParamsSchema,
+  organizationSessionLogoutResponseSchema,
+} from '../../schemas/organization-session-auth.js'
+import { logoutFromOrganization } from '../../usecases/organization-session-auth/index.js'
+import { getSessionTokenFromCookie } from '../auth/cookie.js'
+
+const logoutError = (type: string) => {
+  if (type === 'AUTH_ORGANIZATION_FORBIDDEN') {
+    return {
+      status: 403 as const,
+      body: { error_code: type, error_message: 'organization access forbidden' },
+    }
+  }
+  return {
+    status: 401 as const,
+    body: { error_code: type, error_message: 'valid session required' },
+  }
+}
+
+export const registerOrganizationSessionLogoutRoute = (app: OpenAPIHono) => {
+  const route = createRoute({
+    method: 'post',
+    path: '/{organizationId}/auth/logout',
+    tags: ['Organization Auth'],
+    description:
+      '現在Sessionの対象Organization Membership Grantだけをrevokeし、Sessionと他Organization Grantは維持する',
+    request: { params: organizationSessionLogoutParamsSchema },
+    responses: {
+      200: {
+        description: 'organization logout succeeded',
+        content: { 'application/json': { schema: organizationSessionLogoutResponseSchema } },
+      },
+      401: {
+        description: 'valid session required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      403: {
+        description: 'organization membership required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+    },
+  })
+
+  app.openapi(route, async (c) => {
+    const result = await logoutFromOrganization(
+      c.req.valid('param').organizationId,
+      getSessionTokenFromCookie(c),
+      {
+        requestId: c.req.header('x-request-id'),
+        userAgent: c.req.header('user-agent'),
+      }
+    )
+    if (!result.ok) {
+      const error = logoutError(result.error.type)
+      return c.json(error.body, error.status)
+    }
+    return c.json(result.value, 200)
+  })
+}

--- a/apps/kaede/src/routes/organizations/auth-settings.test.ts
+++ b/apps/kaede/src/routes/organizations/auth-settings.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import { createRouteTestApp } from '../create-route-test-app.js'
+
+const mocks = vi.hoisted(() => ({
+  getOrganizationAuthSettings: vi.fn(),
+  patchOrganizationAuthSettings: vi.fn(),
+}))
+
+vi.mock('../../usecases/organization-auth-settings/index.js', () => mocks)
+
+import { registerOrganizationAuthSettingsRoutes } from './auth-settings.js'
+
+const organizationId = '11111111-1111-4111-8111-111111111111'
+const response = {
+  organization_id: organizationId,
+  local_auth_enabled: true,
+  oidc_auth_enabled: false,
+  policy_version: 1,
+  membership_grant_ttl_seconds: 28_800,
+  reauthentication_interval_seconds: 14_400,
+  created_at: '2026-08-11T00:00:00.000Z',
+  updated_at: '2026-08-11T00:00:00.000Z',
+}
+const actor: RequestActor = {
+  type: 'user',
+  user_id: '22222222-2222-4222-8222-222222222222',
+  email: 'owner@example.com',
+  global_role: 'none',
+  account_state: 'active',
+  memberships: [{ organization_id: organizationId, organization_name: 'Example', role: 'owner' }],
+}
+
+const app = createRouteTestApp('/organizations', registerOrganizationAuthSettingsRoutes, { actor })
+
+describe('organization auth settings routes', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('GETでowner向け認証設定を返す', async () => {
+    mocks.getOrganizationAuthSettings.mockResolvedValue({ ok: true, value: response })
+
+    const result = await app.request(`/api/organizations/${organizationId}/auth-settings`)
+
+    expect(result.status).toBe(200)
+    await expect(result.json()).resolves.toEqual(response)
+    expect(mocks.getOrganizationAuthSettings).toHaveBeenCalledWith(actor, organizationId)
+  })
+
+  it('PATCHで部分更新requestをusecaseへ渡す', async () => {
+    mocks.patchOrganizationAuthSettings.mockResolvedValue({
+      ok: true,
+      value: { ...response, policy_version: 2, membership_grant_ttl_seconds: 36_000 },
+    })
+
+    const result = await app.request(`/api/organizations/${organizationId}/auth-settings`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ membership_grant_ttl_seconds: 36_000 }),
+    })
+
+    expect(result.status).toBe(200)
+    expect(mocks.patchOrganizationAuthSettings).toHaveBeenCalledWith(actor, organizationId, {
+      membership_grant_ttl_seconds: 36_000,
+    })
+  })
+
+  it('OIDC Provider不足をtyped 422 errorで返す', async () => {
+    mocks.patchOrganizationAuthSettings.mockResolvedValue({
+      ok: false,
+      error: { type: 'OIDC_PROVIDER_REQUIRED' },
+    })
+
+    const result = await app.request(`/api/organizations/${organizationId}/auth-settings`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ oidc_auth_enabled: true }),
+    })
+
+    expect(result.status).toBe(422)
+    await expect(result.json()).resolves.toEqual({
+      error_code: 'OIDC_PROVIDER_REQUIRED',
+      error_message: 'an enabled OIDC provider is required before enabling OIDC',
+    })
+  })
+
+  it('active ownerでなければtyped 403 errorを返す', async () => {
+    mocks.getOrganizationAuthSettings.mockResolvedValue({
+      ok: false,
+      error: { type: 'AUTH_DASHBOARD_FORBIDDEN' },
+    })
+
+    const result = await app.request(`/api/organizations/${organizationId}/auth-settings`)
+
+    expect(result.status).toBe(403)
+    await expect(result.json()).resolves.toEqual({
+      error_code: 'AUTH_DASHBOARD_FORBIDDEN',
+      error_message: 'active owner permission is required',
+    })
+  })
+
+  it('空PATCHを400で拒否してusecaseを呼ばない', async () => {
+    const result = await app.request(`/api/organizations/${organizationId}/auth-settings`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+
+    expect(result.status).toBe(400)
+    expect(mocks.patchOrganizationAuthSettings).not.toHaveBeenCalled()
+  })
+})

--- a/apps/kaede/src/routes/organizations/auth-settings.ts
+++ b/apps/kaede/src/routes/organizations/auth-settings.ts
@@ -1,0 +1,142 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { requireRequestActor } from '../../middleware/request-actor-context.js'
+import type { RequestActorContext } from '../../middleware/request-actor-context.js'
+import { authErrorResponseSchema, errorResponseSchema } from '../../schemas/common.js'
+import {
+  organizationAuthSettingsErrorResponseSchema,
+  organizationAuthSettingsSchema,
+  updateOrganizationAuthSettingsRequestSchema,
+} from '../../schemas/organization-auth-settings.js'
+import { organizationIdParamsSchema } from '../../schemas/organizations.js'
+import {
+  getOrganizationAuthSettings,
+  patchOrganizationAuthSettings,
+} from '../../usecases/organization-auth-settings/index.js'
+
+const commonErrorResponses = {
+  401: {
+    description: 'login required',
+    content: { 'application/json': { schema: authErrorResponseSchema } },
+  },
+  403: {
+    description: 'active owner required',
+    content: { 'application/json': { schema: authErrorResponseSchema } },
+  },
+  404: {
+    description: 'auth settings not found',
+    content: { 'application/json': { schema: organizationAuthSettingsErrorResponseSchema } },
+  },
+} as const
+
+export const registerOrganizationAuthSettingsRoutes = (app: OpenAPIHono) => {
+  const getRoute = createRoute({
+    method: 'get',
+    path: '/{organizationId}/auth-settings',
+    tags: ['Organization Auth'],
+    description: 'active ownerがOrganizationの認証Policyを取得する',
+    request: { params: organizationIdParamsSchema },
+    responses: {
+      200: {
+        description: 'organization auth settings',
+        content: { 'application/json': { schema: organizationAuthSettingsSchema } },
+      },
+      401: commonErrorResponses[401],
+      403: commonErrorResponses[403],
+      404: commonErrorResponses[404],
+    },
+  })
+
+  app.openapi(getRoute, async (c) => {
+    const result = await getOrganizationAuthSettings(
+      requireRequestActor(c as RequestActorContext),
+      c.req.valid('param').organizationId
+    )
+    if (!result.ok) {
+      if (result.error.type === 'AUTH_DASHBOARD_FORBIDDEN') {
+        return c.json(
+          { error_code: result.error.type, error_message: 'active owner permission is required' },
+          403
+        )
+      }
+      return c.json(
+        {
+          error_code: 'ORGANIZATION_AUTH_SETTINGS_NOT_FOUND' as const,
+          error_message: 'organization auth settings not found',
+        },
+        404
+      )
+    }
+    return c.json(result.value, 200)
+  })
+
+  const patchRoute = createRoute({
+    method: 'patch',
+    path: '/{organizationId}/auth-settings',
+    tags: ['Organization Auth'],
+    description: 'active ownerが認証Policyを部分更新する。実質変更時だけpolicy_versionを増加させる',
+    request: {
+      params: organizationIdParamsSchema,
+      body: {
+        required: true,
+        content: { 'application/json': { schema: updateOrganizationAuthSettingsRequestSchema } },
+      },
+    },
+    responses: {
+      200: {
+        description: 'updated organization auth settings',
+        content: { 'application/json': { schema: organizationAuthSettingsSchema } },
+      },
+      400: {
+        description: 'request validation failed',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      401: commonErrorResponses[401],
+      403: commonErrorResponses[403],
+      404: commonErrorResponses[404],
+      422: {
+        description: 'policy invariant violation',
+        content: { 'application/json': { schema: organizationAuthSettingsErrorResponseSchema } },
+      },
+    },
+  })
+
+  app.openapi(patchRoute, async (c) => {
+    const result = await patchOrganizationAuthSettings(
+      requireRequestActor(c as RequestActorContext),
+      c.req.valid('param').organizationId,
+      c.req.valid('json')
+    )
+    if (!result.ok) {
+      if (result.error.type === 'AUTH_DASHBOARD_FORBIDDEN') {
+        return c.json(
+          { error_code: result.error.type, error_message: 'active owner permission is required' },
+          403
+        )
+      }
+      if (result.error.type === 'ORGANIZATION_AUTH_SETTINGS_NOT_FOUND') {
+        return c.json(
+          { error_code: result.error.type, error_message: 'organization auth settings not found' },
+          404
+        )
+      }
+      if (result.error.type === 'OIDC_PROVIDER_REQUIRED') {
+        return c.json(
+          {
+            error_code: result.error.type,
+            error_message: 'an enabled OIDC provider is required before enabling OIDC',
+          },
+          422
+        )
+      }
+      return c.json(
+        {
+          error_code: result.error.type,
+          error_message: 'organization auth settings are invalid',
+        },
+        422
+      )
+    }
+    return c.json(result.value, 200)
+  })
+}

--- a/apps/kaede/src/routes/organizations/create-organization-user.test.ts
+++ b/apps/kaede/src/routes/organizations/create-organization-user.test.ts
@@ -155,8 +155,8 @@ describe('POST /api/organizations/:organizationId/users', () => {
           pedestrian_id: '33333333-3333-4333-8333-333333333333',
           organization_id: '11111111-1111-4111-8111-111111111111',
           display_name: 'Pedestrian A',
-          height: 170.5,
-          stride_length: 72,
+          height: 1.705,
+          stride_length: 0.72,
           attributes: {
             team: 'A',
           },
@@ -182,8 +182,8 @@ describe('POST /api/organizations/:organizationId/users', () => {
           create_pedestrian: true,
           pedestrian: {
             display_name: 'Pedestrian A',
-            height: 170.5,
-            stride_length: 72,
+            height: 1.705,
+            stride_length: 0.72,
             attributes: {
               team: 'A',
             },
@@ -210,8 +210,8 @@ describe('POST /api/organizations/:organizationId/users', () => {
         create_pedestrian: true,
         pedestrian: {
           display_name: 'Pedestrian A',
-          height: 170.5,
-          stride_length: 72,
+          height: 1.705,
+          stride_length: 0.72,
           attributes: {
             team: 'A',
           },

--- a/apps/kaede/src/routes/organizations/index.ts
+++ b/apps/kaede/src/routes/organizations/index.ts
@@ -16,6 +16,7 @@ import { registerListOrganizationRecordingsRoute } from './list-organization-rec
 import { registerListOrganizationTrajectoriesRoute } from './list-organization-trajectories.js'
 import { registerListOrganizationUsersRoute } from './list-organization-users.js'
 import { registerListOrganizationsRoute } from './list-organizations.js'
+import { registerOrganizationMemberProfileRoutes } from './member-profiles.js'
 
 export const organizationsRoutes = new OpenAPIHono()
 
@@ -36,3 +37,4 @@ registerCreateOrganizationUserActivationLinkRoute(organizationsRoutes)
 registerCreateOrganizationMembershipRoute(organizationsRoutes)
 registerCreateStayHeatmapRoute(organizationsRoutes)
 registerAnalysisRunRoutes(organizationsRoutes)
+registerOrganizationMemberProfileRoutes(organizationsRoutes)

--- a/apps/kaede/src/routes/organizations/index.ts
+++ b/apps/kaede/src/routes/organizations/index.ts
@@ -17,6 +17,7 @@ import { registerListOrganizationTrajectoriesRoute } from './list-organization-t
 import { registerListOrganizationUsersRoute } from './list-organization-users.js'
 import { registerListOrganizationsRoute } from './list-organizations.js'
 import { registerOrganizationMemberProfileRoutes } from './member-profiles.js'
+import { registerOrganizationOidcProviderRoutes } from './oidc-providers.js'
 
 export const organizationsRoutes = new OpenAPIHono()
 
@@ -38,3 +39,4 @@ registerCreateOrganizationMembershipRoute(organizationsRoutes)
 registerCreateStayHeatmapRoute(organizationsRoutes)
 registerAnalysisRunRoutes(organizationsRoutes)
 registerOrganizationMemberProfileRoutes(organizationsRoutes)
+registerOrganizationOidcProviderRoutes(organizationsRoutes)

--- a/apps/kaede/src/routes/organizations/index.ts
+++ b/apps/kaede/src/routes/organizations/index.ts
@@ -9,6 +9,7 @@ import { registerCreateOrganizationRoute } from './create-organization.js'
 import { registerCreateStayHeatmapRoute } from './create-stay-heatmap.js'
 import { registerGetOrganizationUserRoute } from './get-organization-user.js'
 import { registerGetOrganizationRoute } from './get-organization.js'
+import { registerOrganizationInviteRoutes } from './invites.js'
 import { registerListOrganizationBuildingFloorsRoute } from './list-organization-building-floors.js'
 import { registerListOrganizationBuildingsRoute } from './list-organization-buildings.js'
 import { registerListOrganizationFloorsRoute } from './list-organization-floors.js'
@@ -40,3 +41,4 @@ registerCreateStayHeatmapRoute(organizationsRoutes)
 registerAnalysisRunRoutes(organizationsRoutes)
 registerOrganizationMemberProfileRoutes(organizationsRoutes)
 registerOrganizationOidcProviderRoutes(organizationsRoutes)
+registerOrganizationInviteRoutes(organizationsRoutes)

--- a/apps/kaede/src/routes/organizations/index.ts
+++ b/apps/kaede/src/routes/organizations/index.ts
@@ -1,5 +1,6 @@
 import { OpenAPIHono } from '@hono/zod-openapi'
 import { registerAnalysisRunRoutes } from './analysis-runs.js'
+import { registerOrganizationAuthSettingsRoutes } from './auth-settings.js'
 import { registerCreateOrganizationBuildingFloorRoute } from './create-organization-building-floor.js'
 import { registerCreateOrganizationBuildingRoute } from './create-organization-building.js'
 import { registerCreateOrganizationMembershipRoute } from './create-organization-membership.js'
@@ -39,6 +40,7 @@ registerCreateOrganizationUserActivationLinkRoute(organizationsRoutes)
 registerCreateOrganizationMembershipRoute(organizationsRoutes)
 registerCreateStayHeatmapRoute(organizationsRoutes)
 registerAnalysisRunRoutes(organizationsRoutes)
+registerOrganizationAuthSettingsRoutes(organizationsRoutes)
 registerOrganizationMemberProfileRoutes(organizationsRoutes)
 registerOrganizationOidcProviderRoutes(organizationsRoutes)
 registerOrganizationInviteRoutes(organizationsRoutes)

--- a/apps/kaede/src/routes/organizations/index.ts
+++ b/apps/kaede/src/routes/organizations/index.ts
@@ -20,6 +20,7 @@ import { registerListOrganizationUsersRoute } from './list-organization-users.js
 import { registerListOrganizationsRoute } from './list-organizations.js'
 import { registerOrganizationMemberProfileRoutes } from './member-profiles.js'
 import { registerMembershipAdministrationRoutes } from './membership-administration.js'
+import { registerOrganizationOidcLinkRoutes } from './oidc-links.js'
 import { registerOrganizationOidcProviderRoutes } from './oidc-providers.js'
 
 export const organizationsRoutes = new OpenAPIHono()
@@ -44,5 +45,6 @@ registerAnalysisRunRoutes(organizationsRoutes)
 registerOrganizationAuthSettingsRoutes(organizationsRoutes)
 registerOrganizationMemberProfileRoutes(organizationsRoutes)
 registerMembershipAdministrationRoutes(organizationsRoutes)
+registerOrganizationOidcLinkRoutes(organizationsRoutes)
 registerOrganizationOidcProviderRoutes(organizationsRoutes)
 registerOrganizationInviteRoutes(organizationsRoutes)

--- a/apps/kaede/src/routes/organizations/index.ts
+++ b/apps/kaede/src/routes/organizations/index.ts
@@ -19,6 +19,7 @@ import { registerListOrganizationTrajectoriesRoute } from './list-organization-t
 import { registerListOrganizationUsersRoute } from './list-organization-users.js'
 import { registerListOrganizationsRoute } from './list-organizations.js'
 import { registerOrganizationMemberProfileRoutes } from './member-profiles.js'
+import { registerMembershipAdministrationRoutes } from './membership-administration.js'
 import { registerOrganizationOidcProviderRoutes } from './oidc-providers.js'
 
 export const organizationsRoutes = new OpenAPIHono()
@@ -42,5 +43,6 @@ registerCreateStayHeatmapRoute(organizationsRoutes)
 registerAnalysisRunRoutes(organizationsRoutes)
 registerOrganizationAuthSettingsRoutes(organizationsRoutes)
 registerOrganizationMemberProfileRoutes(organizationsRoutes)
+registerMembershipAdministrationRoutes(organizationsRoutes)
 registerOrganizationOidcProviderRoutes(organizationsRoutes)
 registerOrganizationInviteRoutes(organizationsRoutes)

--- a/apps/kaede/src/routes/organizations/invites.ts
+++ b/apps/kaede/src/routes/organizations/invites.ts
@@ -1,0 +1,155 @@
+import { createRoute, z } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { requireRequestActor } from '../../middleware/request-actor-context.js'
+import type { RequestActorContext } from '../../middleware/request-actor-context.js'
+import { errorResponseSchema } from '../../schemas/common.js'
+import {
+  createOrganizationInviteRequestSchema,
+  organizationInviteParamsSchema,
+  organizationInvitesParamsSchema,
+  organizationInvitesResponseSchema,
+  organizationInviteTokenResponseSchema,
+} from '../../schemas/organization-invites.js'
+import {
+  getOrganizationInvites,
+  issueOrganizationInvite,
+  reissueInvite,
+  revokeInvite,
+} from '../../usecases/organization-invites/index.js'
+import { toOrganizationInviteErrorResponse } from '../organization-invites/error.js'
+
+const errorResponses = {
+  400: {
+    description: 'invalid request',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  401: {
+    description: 'login required',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  403: {
+    description: 'permission denied',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  404: {
+    description: 'invite not found',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  409: {
+    description: 'invite conflicts with current state',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+} as const
+
+/* OpenAPIHono keeps each handler's status union at the call site; this shared mapper intentionally erases it. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const respondError = (c: any, error: Parameters<typeof toOrganizationInviteErrorResponse>[0]) => {
+  const response = toOrganizationInviteErrorResponse(error)
+  return c.json(response.body, response.status)
+}
+
+export const registerOrganizationInviteRoutes = (app: OpenAPIHono) => {
+  const listRoute = createRoute({
+    method: 'get',
+    path: '/{organizationId}/invites',
+    tags: ['Organization Invites'],
+    request: { params: organizationInvitesParamsSchema },
+    responses: {
+      200: {
+        description: 'invites',
+        content: { 'application/json': { schema: organizationInvitesResponseSchema } },
+      },
+      401: errorResponses[401],
+      403: errorResponses[403],
+    },
+  })
+  app.openapi(listRoute, async (c) => {
+    const result = await getOrganizationInvites(
+      requireRequestActor(c as RequestActorContext),
+      c.req.valid('param').organizationId
+    )
+    return result.ok ? c.json(result.value, 200) : respondError(c, result.error)
+  })
+
+  const issueRoute = createRoute({
+    method: 'post',
+    path: '/{organizationId}/invites',
+    tags: ['Organization Invites'],
+    request: {
+      params: organizationInvitesParamsSchema,
+      body: { content: { 'application/json': { schema: createOrganizationInviteRequestSchema } } },
+    },
+    responses: {
+      201: {
+        description: 'plain token is returned once',
+        content: { 'application/json': { schema: organizationInviteTokenResponseSchema } },
+      },
+      401: errorResponses[401],
+      403: errorResponses[403],
+    },
+  })
+  app.openapi(issueRoute, async (c) => {
+    const result = await issueOrganizationInvite(
+      requireRequestActor(c as RequestActorContext),
+      c.req.valid('param').organizationId,
+      c.req.valid('json')
+    )
+    if (!result.ok) return respondError(c, result.error)
+    c.header('Cache-Control', 'no-store')
+    return c.json(result.value, 201)
+  })
+
+  const revokeRoute = createRoute({
+    method: 'post',
+    path: '/{organizationId}/invites/{inviteId}/revoke',
+    tags: ['Organization Invites'],
+    request: { params: organizationInviteParamsSchema },
+    responses: {
+      200: {
+        description: 'revoked',
+        content: { 'application/json': { schema: z.object({ revoked: z.literal(true) }) } },
+      },
+      401: errorResponses[401],
+      403: errorResponses[403],
+      404: errorResponses[404],
+      409: errorResponses[409],
+    },
+  })
+  app.openapi(revokeRoute, async (c) => {
+    const p = c.req.valid('param')
+    const result = await revokeInvite(
+      requireRequestActor(c as RequestActorContext),
+      p.organizationId,
+      p.inviteId
+    )
+    return result.ok ? c.json(result.value, 200) : respondError(c, result.error)
+  })
+
+  const reissueRoute = createRoute({
+    method: 'post',
+    path: '/{organizationId}/invites/{inviteId}/reissue',
+    tags: ['Organization Invites'],
+    request: { params: organizationInviteParamsSchema },
+    responses: {
+      201: {
+        description: 'old invite revoked and new plain token returned once',
+        content: { 'application/json': { schema: organizationInviteTokenResponseSchema } },
+      },
+      401: errorResponses[401],
+      403: errorResponses[403],
+      404: errorResponses[404],
+      409: errorResponses[409],
+    },
+  })
+  app.openapi(reissueRoute, async (c) => {
+    const p = c.req.valid('param')
+    const result = await reissueInvite(
+      requireRequestActor(c as RequestActorContext),
+      p.organizationId,
+      p.inviteId
+    )
+    if (!result.ok) return respondError(c, result.error)
+    c.header('Cache-Control', 'no-store')
+    return c.json(result.value, 201)
+  })
+}

--- a/apps/kaede/src/routes/organizations/member-profiles.test.ts
+++ b/apps/kaede/src/routes/organizations/member-profiles.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import { createRouteTestApp } from '../create-route-test-app.js'
+import { registerOrganizationMemberProfileRoutes } from './member-profiles.js'
+
+const mocks = vi.hoisted(() => ({
+  getMyOrganizationMemberProfile: vi.fn(),
+  updateMyOrganizationMemberProfile: vi.fn(),
+  updateOrganizationMemberProfile: vi.fn(),
+}))
+
+vi.mock('../../usecases/profiles/index.js', () => mocks)
+
+const organizationId = '11111111-1111-4111-8111-111111111111'
+const membershipId = '22222222-2222-4222-8222-222222222222'
+const actor: RequestActor = {
+  type: 'user',
+  user_id: '33333333-3333-4333-8333-333333333333',
+  email: 'manager@example.com',
+  global_role: 'none',
+  account_state: 'active',
+  memberships: [{ organization_id: organizationId, organization_name: 'Example', role: 'manager' }],
+}
+
+const profile = {
+  organization_id: organizationId,
+  membership_id: membershipId,
+  global: { display_name: 'Alice' },
+  override: { display_name: null, height_meters: 1.705, stride_length_meters: 0.72 },
+  effective: { display_name: 'Alice', display_name_source: 'global' },
+  updated_at: '2026-08-11T00:00:00.000Z',
+}
+
+describe('organization member profile routes', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('本人の共通・override・実効Profileを返す', async () => {
+    mocks.getMyOrganizationMemberProfile.mockResolvedValue({ ok: true, value: profile })
+    const app = createRouteTestApp('/organizations', registerOrganizationMemberProfileRoutes, {
+      actor,
+    })
+
+    const response = await app.request(`/api/organizations/${organizationId}/members/me/profile`)
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual(profile)
+    expect(mocks.getMyOrganizationMemberProfile).toHaveBeenCalledWith(actor, organizationId)
+  })
+
+  it('managerによる第三者更新をmembership IDで処理する', async () => {
+    mocks.updateOrganizationMemberProfile.mockResolvedValue({
+      ok: true,
+      value: {
+        ...profile,
+        override: { ...profile.override, display_name: 'Managed' },
+        effective: { display_name: 'Managed', display_name_source: 'organization_override' },
+        update_context: { kind: 'forced', actor_role: 'manager' },
+      },
+    })
+    const app = createRouteTestApp('/organizations', registerOrganizationMemberProfileRoutes, {
+      actor,
+    })
+
+    const response = await app.request(
+      `/api/organizations/${organizationId}/members/${membershipId}/profile`,
+      {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ display_name: 'Managed' }),
+      }
+    )
+
+    expect(response.status).toBe(200)
+    expect(mocks.updateOrganizationMemberProfile).toHaveBeenCalledWith(
+      actor,
+      organizationId,
+      membershipId,
+      { display_name: 'Managed' }
+    )
+  })
+
+  it('height_metersが3mを超えるrequestを400で拒否する', async () => {
+    const app = createRouteTestApp('/organizations', registerOrganizationMemberProfileRoutes, {
+      actor,
+    })
+
+    const response = await app.request(`/api/organizations/${organizationId}/members/me/profile`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ height_meters: 170.5 }),
+    })
+
+    expect(response.status).toBe(400)
+    expect(mocks.updateMyOrganizationMemberProfile).not.toHaveBeenCalled()
+  })
+})

--- a/apps/kaede/src/routes/organizations/member-profiles.ts
+++ b/apps/kaede/src/routes/organizations/member-profiles.ts
@@ -1,0 +1,151 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { requireRequestActor } from '../../middleware/request-actor-context.js'
+import type { RequestActorContext } from '../../middleware/request-actor-context.js'
+import { errorResponseSchema } from '../../schemas/common.js'
+import {
+  organizationMemberProfileParamsSchema,
+  organizationMemberProfileSchema,
+  organizationMemberProfileUpdateResponseSchema,
+  organizationProfileParamsSchema,
+  updateOrganizationMemberProfileRequestSchema,
+} from '../../schemas/profiles.js'
+import {
+  getMyOrganizationMemberProfile,
+  updateMyOrganizationMemberProfile,
+  updateOrganizationMemberProfile,
+} from '../../usecases/profiles/index.js'
+import { toProfileErrorResponse } from '../profiles/error.js'
+
+const errorResponses = {
+  401: {
+    description: 'login required',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  403: {
+    description: 'permission denied or membership inactive',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  404: {
+    description: 'membership not found',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+  409: {
+    description: 'membership migration is incomplete',
+    content: { 'application/json': { schema: errorResponseSchema } },
+  },
+} as const
+
+export const registerOrganizationMemberProfileRoutes = (app: OpenAPIHono) => {
+  const getMyRoute = createRoute({
+    method: 'get',
+    path: '/{organizationId}/members/me/profile',
+    tags: ['Organization Member Profiles'],
+    description: 'Organization共通値、override値、実効Profileを取得する',
+    request: { params: organizationProfileParamsSchema },
+    responses: {
+      200: {
+        description: 'organization member profile',
+        content: { 'application/json': { schema: organizationMemberProfileSchema } },
+      },
+      401: errorResponses[401],
+      403: errorResponses[403],
+      404: errorResponses[404],
+      409: errorResponses[409],
+    },
+  })
+
+  app.openapi(getMyRoute, async (c) => {
+    const { organizationId } = c.req.valid('param')
+    const result = await getMyOrganizationMemberProfile(
+      requireRequestActor(c as RequestActorContext),
+      organizationId
+    )
+    if (!result.ok) {
+      const error = toProfileErrorResponse(result.error)
+      return c.json(error.body, error.status)
+    }
+    return c.json(result.value, 200)
+  })
+
+  const patchMyRoute = createRoute({
+    method: 'patch',
+    path: '/{organizationId}/members/me/profile',
+    tags: ['Organization Member Profiles'],
+    description: '本人がOrganization内Profileを部分更新する。身長・歩幅の単位はメートル',
+    request: {
+      params: organizationProfileParamsSchema,
+      body: {
+        required: true,
+        content: { 'application/json': { schema: updateOrganizationMemberProfileRequestSchema } },
+      },
+    },
+    responses: {
+      200: {
+        description: 'updated organization member profile',
+        content: {
+          'application/json': { schema: organizationMemberProfileUpdateResponseSchema },
+        },
+      },
+      401: errorResponses[401],
+      403: errorResponses[403],
+      404: errorResponses[404],
+      409: errorResponses[409],
+    },
+  })
+
+  app.openapi(patchMyRoute, async (c) => {
+    const { organizationId } = c.req.valid('param')
+    const result = await updateMyOrganizationMemberProfile(
+      requireRequestActor(c as RequestActorContext),
+      organizationId,
+      c.req.valid('json')
+    )
+    if (!result.ok) {
+      const error = toProfileErrorResponse(result.error)
+      return c.json(error.body, error.status)
+    }
+    return c.json(result.value, 200)
+  })
+
+  const patchMemberRoute = createRoute({
+    method: 'patch',
+    path: '/{organizationId}/members/{membershipId}/profile',
+    tags: ['Organization Member Profiles'],
+    description: 'manager/ownerが管理対象MembershipのProfileを部分更新する',
+    request: {
+      params: organizationMemberProfileParamsSchema,
+      body: {
+        required: true,
+        content: { 'application/json': { schema: updateOrganizationMemberProfileRequestSchema } },
+      },
+    },
+    responses: {
+      200: {
+        description: 'forcibly updated organization member profile',
+        content: {
+          'application/json': { schema: organizationMemberProfileUpdateResponseSchema },
+        },
+      },
+      401: errorResponses[401],
+      403: errorResponses[403],
+      404: errorResponses[404],
+      409: errorResponses[409],
+    },
+  })
+
+  app.openapi(patchMemberRoute, async (c) => {
+    const { organizationId, membershipId } = c.req.valid('param')
+    const result = await updateOrganizationMemberProfile(
+      requireRequestActor(c as RequestActorContext),
+      organizationId,
+      membershipId,
+      c.req.valid('json')
+    )
+    if (!result.ok) {
+      const error = toProfileErrorResponse(result.error)
+      return c.json(error.body, error.status)
+    }
+    return c.json(result.value, 200)
+  })
+}

--- a/apps/kaede/src/routes/organizations/membership-administration.ts
+++ b/apps/kaede/src/routes/organizations/membership-administration.ts
@@ -1,0 +1,73 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { requireRequestActor } from '../../middleware/request-actor-context.js'
+import type { RequestActorContext } from '../../middleware/request-actor-context.js'
+import { errorResponseSchema } from '../../schemas/common.js'
+import {
+  managedMembershipSchema,
+  membershipAdministrationParamsSchema,
+  updateMembershipRequestSchema,
+} from '../../schemas/membership-administration.js'
+import { updateOrganizationMembership } from '../../usecases/membership-administration/index.js'
+
+const errorResponse = (type: string) => {
+  if (type === 'MEMBERSHIP_NOT_FOUND') {
+    return {
+      status: 404 as const,
+      body: { error_code: type, error_message: 'membership not found' },
+    }
+  }
+  if (type === 'MEMBERSHIP_LAST_OWNER' || type === 'MEMBERSHIP_LEFT') {
+    return {
+      status: 409 as const,
+      body: { error_code: type, error_message: 'membership conflict' },
+    }
+  }
+  return { status: 403 as const, body: { error_code: type, error_message: 'operation forbidden' } }
+}
+
+export const registerMembershipAdministrationRoutes = (app: OpenAPIHono) => {
+  const route = createRoute({
+    method: 'patch',
+    path: '/{organizationId}/members/{membershipId}',
+    tags: ['Organizations'],
+    description: 'Membershipのrole/statusを変更する。left Membershipは再利用しない',
+    request: {
+      params: membershipAdministrationParamsSchema,
+      body: { content: { 'application/json': { schema: updateMembershipRequestSchema } } },
+    },
+    responses: {
+      200: {
+        description: 'membership updated',
+        content: { 'application/json': { schema: managedMembershipSchema } },
+      },
+      403: {
+        description: 'operation forbidden',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      404: {
+        description: 'membership not found',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      409: {
+        description: 'membership lifecycle conflict',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+    },
+  })
+
+  app.openapi(route, async (c) => {
+    const params = c.req.valid('param')
+    const result = await updateOrganizationMembership(
+      requireRequestActor(c as RequestActorContext),
+      params.organizationId,
+      params.membershipId,
+      c.req.valid('json')
+    )
+    if (!result.ok) {
+      const error = errorResponse(result.error.type)
+      return c.json(error.body, error.status)
+    }
+    return c.json(result.value, 200)
+  })
+}

--- a/apps/kaede/src/routes/organizations/oidc-links.ts
+++ b/apps/kaede/src/routes/organizations/oidc-links.ts
@@ -1,0 +1,121 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { requireRequestActor } from '../../middleware/request-actor-context.js'
+import type { RequestActorContext } from '../../middleware/request-actor-context.js'
+import { authOkResponseSchema } from '../../schemas/auth.js'
+import { authErrorResponseSchema } from '../../schemas/common.js'
+import {
+  organizationOidcLinkErrorResponseSchema,
+  organizationOidcLinkParamsSchema,
+  organizationOidcLinksResponseSchema,
+} from '../../schemas/organization-oidc-links.js'
+import { organizationIdParamsSchema } from '../../schemas/organizations.js'
+import {
+  getMyOrganizationOidcLinks,
+  unlinkMyOrganizationOidcIdentity,
+} from '../../usecases/organization-oidc-links/index.js'
+
+const authErrors = {
+  401: {
+    description: 'login required',
+    content: { 'application/json': { schema: authErrorResponseSchema } },
+  },
+  403: {
+    description: 'active membership and grant required',
+    content: { 'application/json': { schema: authErrorResponseSchema } },
+  },
+} as const
+
+export const registerOrganizationOidcLinkRoutes = (app: OpenAPIHono) => {
+  const listRoute = createRoute({
+    method: 'get',
+    path: '/{organizationId}/members/me/oidc-links',
+    tags: ['Organization OIDC Links'],
+    description: '本人Membershipのactive OIDC LinkとProvider表示情報を取得する',
+    request: { params: organizationIdParamsSchema },
+    responses: {
+      200: {
+        description: 'active OIDC links',
+        content: { 'application/json': { schema: organizationOidcLinksResponseSchema } },
+      },
+      401: authErrors[401],
+      403: authErrors[403],
+    },
+  })
+
+  app.openapi(listRoute, async (c) => {
+    const result = await getMyOrganizationOidcLinks(
+      requireRequestActor(c as RequestActorContext),
+      c.req.valid('param').organizationId
+    )
+    if (!result.ok) {
+      return c.json(
+        {
+          error_code: 'AUTH_ORGANIZATION_FORBIDDEN' as const,
+          error_message: 'organization membership access is required',
+        },
+        403
+      )
+    }
+    return c.json(result.value, 200)
+  })
+
+  const unlinkRoute = createRoute({
+    method: 'delete',
+    path: '/{organizationId}/members/me/oidc-links/{linkId}',
+    tags: ['Organization OIDC Links'],
+    description:
+      '本人がOIDC Linkを明示的にunlinkする。canonical Identityは維持し、対象Link由来のGrantだけをrevokeする',
+    request: { params: organizationOidcLinkParamsSchema },
+    responses: {
+      200: {
+        description: 'OIDC link unlinked',
+        content: { 'application/json': { schema: authOkResponseSchema } },
+      },
+      401: authErrors[401],
+      403: authErrors[403],
+      404: {
+        description: 'active OIDC link not found',
+        content: { 'application/json': { schema: organizationOidcLinkErrorResponseSchema } },
+      },
+      409: {
+        description: 'unlink would remove the last usable authentication method',
+        content: { 'application/json': { schema: organizationOidcLinkErrorResponseSchema } },
+      },
+    },
+  })
+
+  app.openapi(unlinkRoute, async (c) => {
+    const { organizationId, linkId } = c.req.valid('param')
+    const result = await unlinkMyOrganizationOidcIdentity(
+      requireRequestActor(c as RequestActorContext),
+      organizationId,
+      linkId
+    )
+    if (!result.ok) {
+      if (result.error.type === 'AUTH_ORGANIZATION_FORBIDDEN') {
+        return c.json(
+          {
+            error_code: result.error.type,
+            error_message: 'organization membership access is required',
+          },
+          403
+        )
+      }
+      if (result.error.type === 'OIDC_MEMBERSHIP_LINK_NOT_FOUND') {
+        return c.json(
+          { error_code: result.error.type, error_message: 'active OIDC link not found' },
+          404
+        )
+      }
+      return c.json(
+        {
+          error_code: result.error.type,
+          error_message: 'the last usable authentication method cannot be removed',
+        },
+        409
+      )
+    }
+    return c.json(result.value, 200)
+  })
+}

--- a/apps/kaede/src/routes/organizations/oidc-providers.ts
+++ b/apps/kaede/src/routes/organizations/oidc-providers.ts
@@ -1,0 +1,230 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { getOidcRuntimeConfig } from '../../config/runtime.js'
+import { authOkResponseSchema } from '../../schemas/auth.js'
+import { errorResponseSchema } from '../../schemas/common.js'
+import {
+  createOrganizationOidcProviderRequestSchema,
+  organizationOidcProviderParamsSchema,
+  organizationOidcProviderSchema,
+  organizationOidcProvidersResponseSchema,
+  updateOrganizationOidcProviderRequestSchema,
+} from '../../schemas/organization-oidc-auth.js'
+import { organizationIdParamsSchema } from '../../schemas/organizations.js'
+import { requireActiveSessionUser } from '../../usecases/auth/index.js'
+import {
+  createOrganizationOidcProvider,
+  disableOrganizationOidcProvider,
+  getOrganizationOidcProviders,
+  patchOrganizationOidcProvider,
+} from '../../usecases/organization-oidc-auth/index.js'
+import { getSessionTokenFromCookie } from '../auth/cookie.js'
+
+const authErrorBody = {
+  error_code: 'AUTH_UNAUTHENTICATED',
+  error_message: 'login required',
+} as const
+
+export const registerOrganizationOidcProviderRoutes = (app: OpenAPIHono) => {
+  const listRoute = createRoute({
+    method: 'get',
+    path: '/{organizationId}/oidc-providers',
+    tags: ['Organization Auth'],
+    request: { params: organizationIdParamsSchema },
+    responses: {
+      200: {
+        description: 'OIDC providers',
+        content: { 'application/json': { schema: organizationOidcProvidersResponseSchema } },
+      },
+      401: {
+        description: 'login required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      403: {
+        description: 'owner required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+    },
+  })
+  app.openapi(listRoute, async (c) => {
+    const actor = await requireActiveSessionUser(getSessionTokenFromCookie(c))
+    if (!actor.ok) return c.json(authErrorBody, 401)
+    const result = await getOrganizationOidcProviders(
+      c.req.valid('param').organizationId,
+      actor.value.id
+    )
+    if (!result.ok)
+      return c.json(
+        { error_code: result.error.type, error_message: 'owner permission is required' },
+        403
+      )
+    return c.json(result.value, 200)
+  })
+
+  const createRouteDefinition = createRoute({
+    method: 'post',
+    path: '/{organizationId}/oidc-providers',
+    tags: ['Organization Auth'],
+    request: {
+      params: organizationIdParamsSchema,
+      body: {
+        content: { 'application/json': { schema: createOrganizationOidcProviderRequestSchema } },
+      },
+    },
+    responses: {
+      201: {
+        description: 'OIDC provider created',
+        content: { 'application/json': { schema: organizationOidcProviderSchema } },
+      },
+      401: {
+        description: 'login required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      403: {
+        description: 'owner required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      422: {
+        description: 'invalid provider config',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+    },
+  })
+  app.openapi(createRouteDefinition, async (c) => {
+    const actor = await requireActiveSessionUser(getSessionTokenFromCookie(c))
+    if (!actor.ok) return c.json(authErrorBody, 401)
+    const config = getOidcRuntimeConfig()
+    const result = await createOrganizationOidcProvider(
+      c.req.valid('param').organizationId,
+      actor.value.id,
+      c.req.valid('json'),
+      config.googleClientId
+    )
+    if (!result.ok) {
+      if (result.error.type === 'OIDC_PROVIDER_CONFIG_INVALID') {
+        return c.json(
+          { error_code: result.error.type, error_message: 'OIDC provider config is invalid' },
+          422
+        )
+      }
+      return c.json(
+        { error_code: result.error.type, error_message: 'owner permission is required' },
+        403
+      )
+    }
+    return c.json(result.value, 201)
+  })
+
+  const patchRoute = createRoute({
+    method: 'patch',
+    path: '/{organizationId}/oidc-providers/{providerId}',
+    tags: ['Organization Auth'],
+    request: {
+      params: organizationOidcProviderParamsSchema,
+      body: {
+        content: { 'application/json': { schema: updateOrganizationOidcProviderRequestSchema } },
+      },
+    },
+    responses: {
+      200: {
+        description: 'OIDC provider updated',
+        content: { 'application/json': { schema: organizationOidcProviderSchema } },
+      },
+      401: {
+        description: 'login required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      403: {
+        description: 'owner required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      404: {
+        description: 'provider not found',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      422: {
+        description: 'invalid provider config',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+    },
+  })
+  app.openapi(patchRoute, async (c) => {
+    const actor = await requireActiveSessionUser(getSessionTokenFromCookie(c))
+    if (!actor.ok) return c.json(authErrorBody, 401)
+    const params = c.req.valid('param')
+    const result = await patchOrganizationOidcProvider(
+      params.organizationId,
+      params.providerId,
+      actor.value.id,
+      c.req.valid('json'),
+      getOidcRuntimeConfig().googleClientId
+    )
+    if (!result.ok) {
+      if (result.error.type === 'OIDC_PROVIDER_NOT_FOUND') {
+        return c.json(
+          { error_code: result.error.type, error_message: 'OIDC provider not found' },
+          404
+        )
+      }
+      if (result.error.type === 'OIDC_PROVIDER_CONFIG_INVALID') {
+        return c.json(
+          { error_code: result.error.type, error_message: 'OIDC provider config is invalid' },
+          422
+        )
+      }
+      return c.json(
+        { error_code: result.error.type, error_message: 'owner permission is required' },
+        403
+      )
+    }
+    return c.json(result.value, 200)
+  })
+
+  const deleteRoute = createRoute({
+    method: 'delete',
+    path: '/{organizationId}/oidc-providers/{providerId}',
+    tags: ['Organization Auth'],
+    request: { params: organizationOidcProviderParamsSchema },
+    responses: {
+      200: {
+        description: 'OIDC provider disabled',
+        content: { 'application/json': { schema: authOkResponseSchema } },
+      },
+      401: {
+        description: 'login required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      403: {
+        description: 'owner required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      404: {
+        description: 'provider not found',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+    },
+  })
+  app.openapi(deleteRoute, async (c) => {
+    const actor = await requireActiveSessionUser(getSessionTokenFromCookie(c))
+    if (!actor.ok) return c.json(authErrorBody, 401)
+    const params = c.req.valid('param')
+    const result = await disableOrganizationOidcProvider(
+      params.organizationId,
+      params.providerId,
+      actor.value.id
+    )
+    if (!result.ok) {
+      if (result.error.type === 'OIDC_PROVIDER_NOT_FOUND') {
+        return c.json(
+          { error_code: result.error.type, error_message: 'OIDC provider not found' },
+          404
+        )
+      }
+      return c.json(
+        { error_code: result.error.type, error_message: 'owner permission is required' },
+        403
+      )
+    }
+    return c.json({ ok: true as const }, 200)
+  })
+}

--- a/apps/kaede/src/routes/pedestrians/create-pedestrian.test.ts
+++ b/apps/kaede/src/routes/pedestrians/create-pedestrian.test.ts
@@ -233,6 +233,24 @@ describe('POST /api/pedestrians', () => {
     expect(createPedestrianMock).not.toHaveBeenCalled()
   })
 
+  it('meterではない height はバリデーションエラーを返し usecase を呼ばない', async () => {
+    const app = createRouteTestApp('/pedestrians', registerCreatePedestrianRoute)
+    const response = await app.request('/api/pedestrians', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        organization_id: '99999999-9999-4999-8999-999999999999',
+        display_name: 'test participant',
+        height: 170,
+      }),
+    })
+
+    expect(response.status).toBe(400)
+    expect(createPedestrianMock).not.toHaveBeenCalled()
+  })
+
   it('organization_id がない場合はバリデーションエラーを返し usecase を呼ばない', async () => {
     const app = createRouteTestApp('/pedestrians', registerCreatePedestrianRoute)
     const response = await app.request('/api/pedestrians', {

--- a/apps/kaede/src/routes/profiles/error.ts
+++ b/apps/kaede/src/routes/profiles/error.ts
@@ -1,0 +1,33 @@
+import type { ProfileError } from '../../usecases/profiles/index.js'
+import { toAuthorizationErrorResponse } from '../authorization-error.js'
+
+export const toProfileErrorResponse = (error: ProfileError) => {
+  switch (error.type) {
+    case 'AUTH_DASHBOARD_FORBIDDEN':
+    case 'AUTH_ORGANIZATION_FORBIDDEN':
+      return toAuthorizationErrorResponse(error)
+    case 'USER_NOT_FOUND':
+      return {
+        body: { error_code: error.type, error_message: 'user not found' },
+        status: 404 as const,
+      }
+    case 'MEMBERSHIP_NOT_FOUND':
+      return {
+        body: { error_code: error.type, error_message: 'membership not found' },
+        status: 404 as const,
+      }
+    case 'MEMBERSHIP_NOT_ACTIVE':
+      return {
+        body: { error_code: error.type, error_message: 'membership is not active' },
+        status: 403 as const,
+      }
+    case 'MEMBERSHIP_PROFILE_UNAVAILABLE':
+      return {
+        body: {
+          error_code: error.type,
+          error_message: 'membership profile is not available during migration',
+        },
+        status: 409 as const,
+      }
+  }
+}

--- a/apps/kaede/src/routes/users/index.ts
+++ b/apps/kaede/src/routes/users/index.ts
@@ -1,0 +1,7 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import type { RequestActorHonoEnv } from '../../middleware/request-actor-context.js'
+import { registerUserProfileRoutes } from './profile.js'
+
+export const usersRoutes = new OpenAPIHono<RequestActorHonoEnv>()
+
+registerUserProfileRoutes(usersRoutes)

--- a/apps/kaede/src/routes/users/profile.test.ts
+++ b/apps/kaede/src/routes/users/profile.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import { createRouteTestApp } from '../create-route-test-app.js'
+import { registerUserProfileRoutes } from './profile.js'
+
+const mocks = vi.hoisted(() => ({
+  getMyUserProfile: vi.fn(),
+  updateMyUserProfile: vi.fn(),
+}))
+
+vi.mock('../../usecases/profiles/index.js', () => mocks)
+
+const actor: RequestActor = {
+  type: 'user',
+  user_id: '11111111-1111-4111-8111-111111111111',
+  email: 'user@example.com',
+  global_role: 'none',
+  account_state: 'active',
+  memberships: [],
+}
+
+const responseProfile = {
+  user_id: '11111111-1111-4111-8111-111111111111',
+  display_name: 'Alice',
+  locale: 'ja-JP',
+  timezone: 'Asia/Tokyo',
+  updated_at: '2026-08-11T00:00:00.000Z',
+}
+
+describe('/api/users/me/profile', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('共通Profileを取得する', async () => {
+    mocks.getMyUserProfile.mockResolvedValue({ ok: true, value: responseProfile })
+    const app = createRouteTestApp('/users', registerUserProfileRoutes, { actor })
+
+    const response = await app.request('/api/users/me/profile')
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual(responseProfile)
+    expect(mocks.getMyUserProfile).toHaveBeenCalledWith(actor)
+  })
+
+  it('指定fieldだけをPATCHへ渡す', async () => {
+    mocks.updateMyUserProfile.mockResolvedValue({
+      ok: true,
+      value: { ...responseProfile, locale: 'en-US' },
+    })
+    const app = createRouteTestApp('/users', registerUserProfileRoutes, { actor })
+
+    const response = await app.request('/api/users/me/profile', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ locale: 'en-US' }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(mocks.updateMyUserProfile).toHaveBeenCalledWith(actor, { locale: 'en-US' })
+  })
+
+  it('空PATCHを400で拒否する', async () => {
+    const app = createRouteTestApp('/users', registerUserProfileRoutes, { actor })
+
+    const response = await app.request('/api/users/me/profile', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+
+    expect(response.status).toBe(400)
+    expect(mocks.updateMyUserProfile).not.toHaveBeenCalled()
+  })
+})

--- a/apps/kaede/src/routes/users/profile.ts
+++ b/apps/kaede/src/routes/users/profile.ts
@@ -1,0 +1,84 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { requireRequestActor } from '../../middleware/request-actor-context.js'
+import type { RequestActorHonoEnv } from '../../middleware/request-actor-context.js'
+import { errorResponseSchema } from '../../schemas/common.js'
+import { updateUserProfileRequestSchema, userProfileSchema } from '../../schemas/profiles.js'
+import { getMyUserProfile, updateMyUserProfile } from '../../usecases/profiles/index.js'
+import { toProfileErrorResponse } from '../profiles/error.js'
+
+export const registerUserProfileRoutes = (app: OpenAPIHono<RequestActorHonoEnv>) => {
+  const getRoute = createRoute({
+    method: 'get',
+    path: '/me/profile',
+    tags: ['Users'],
+    description: 'ログインUserのOrganization共通Profileを取得する',
+    responses: {
+      200: {
+        description: 'user profile',
+        content: { 'application/json': { schema: userProfileSchema } },
+      },
+      401: {
+        description: 'login required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      403: {
+        description: 'permission denied',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      404: {
+        description: 'user not found',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+    },
+  })
+
+  app.openapi(getRoute, async (c) => {
+    const result = await getMyUserProfile(requireRequestActor(c))
+    if (!result.ok) {
+      const error = toProfileErrorResponse(result.error)
+      return c.json(error.body, error.status as 403 | 404)
+    }
+    return c.json(result.value, 200)
+  })
+
+  const patchRoute = createRoute({
+    method: 'patch',
+    path: '/me/profile',
+    tags: ['Users'],
+    description: 'ログインUserのOrganization共通Profileを部分更新する',
+    request: {
+      body: {
+        required: true,
+        content: { 'application/json': { schema: updateUserProfileRequestSchema } },
+      },
+    },
+    responses: {
+      200: {
+        description: 'updated user profile',
+        content: { 'application/json': { schema: userProfileSchema } },
+      },
+      401: {
+        description: 'login required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      403: {
+        description: 'permission denied',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      404: {
+        description: 'user not found',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+    },
+  })
+
+  app.openapi(patchRoute, async (c) => {
+    const result = await updateMyUserProfile(requireRequestActor(c), c.req.valid('json'))
+    if (!result.ok) {
+      const error = toProfileErrorResponse(result.error)
+      return c.json(error.body, error.status as 403 | 404)
+    }
+    return c.json(result.value, 200)
+  })
+}

--- a/apps/kaede/src/schemas/auth.test.ts
+++ b/apps/kaede/src/schemas/auth.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { authMeResponseSchema } from './auth.js'
+
+describe('authMeResponseSchema', () => {
+  it('Membership直下にallowed_auth_methodsを持つ再認証待ちレスポンスを受理する', () => {
+    expect(
+      authMeResponseSchema.safeParse({
+        session_auth_method: 'oidc',
+        user: {
+          user_id: 'f5fe0359-75c5-4676-b0f3-8986319e18b2',
+          email: 'user@example.com',
+          display_name: 'User',
+          global_role: 'none',
+          status: 'active',
+          account_state: 'active',
+          password_changed_at: null,
+          memberships: [
+            {
+              membership_id: '6dc417b9-932d-47e4-a8eb-1e0f651bca28',
+              organization_id: '80f796d9-8fd3-49da-a4e5-efb34123263f',
+              organization_name: 'Organization',
+              organization_slug: 'organization',
+              role: 'owner',
+              status: 'active',
+              allowed_auth_methods: ['local', 'oidc'],
+              grant_state: {
+                status: 'reauthentication_required',
+                reason: 'grant_missing',
+                auth_method: null,
+                authenticated_at: null,
+                reauthentication_required_at: null,
+                expires_at: null,
+                effective_expires_at: null,
+              },
+            },
+          ],
+        },
+      }).success
+    ).toBe(true)
+  })
+})

--- a/apps/kaede/src/schemas/auth.ts
+++ b/apps/kaede/src/schemas/auth.ts
@@ -12,6 +12,31 @@ export const authMembershipSchema = z
     organization_id: uuidSchema,
     organization_name: z.string().min(1).max(255),
     role: membershipRoleSchema,
+    grant_state: z
+      .discriminatedUnion('status', [
+        z.object({
+          status: z.literal('granted'),
+          auth_method: z.enum(['local', 'oidc']),
+          authenticated_at: isoDatetimeSchema,
+          expires_at: isoDatetimeSchema,
+        }),
+        z.object({
+          status: z.literal('reauthentication_required'),
+          reason: z.enum([
+            'grant_missing',
+            'grant_revoked',
+            'grant_expired',
+            'reauthentication_interval_elapsed',
+            'policy_changed',
+            'auth_method_not_allowed',
+          ]),
+          allowed_auth_methods: z.array(z.enum(['local', 'oidc'])),
+        }),
+        z.object({
+          status: z.literal('forbidden'),
+        }),
+      ])
+      .optional(),
   })
   .openapi('AuthMembership')
 

--- a/apps/kaede/src/schemas/auth.ts
+++ b/apps/kaede/src/schemas/auth.ts
@@ -40,15 +40,19 @@ export const authMembershipSchema = z
   })
   .openapi('AuthMembership')
 
+const authUserBaseShape = {
+  user_id: uuidSchema,
+  email: z.string().email().max(255),
+  display_name: z.string().min(1).max(255),
+  global_role: z.enum(['none', 'admin']),
+  status: userStatusSchema,
+  account_state: accountStateSchema,
+  password_changed_at: isoDatetimeSchema.nullable(),
+}
+
 export const authUserSchema = z
   .object({
-    user_id: uuidSchema,
-    email: z.string().email().max(255),
-    display_name: z.string().min(1).max(255),
-    global_role: z.enum(['none', 'admin']),
-    status: userStatusSchema,
-    account_state: accountStateSchema,
-    password_changed_at: isoDatetimeSchema.nullable(),
+    ...authUserBaseShape,
     memberships: z.array(authMembershipSchema),
   })
   .openapi('AuthUser')
@@ -123,11 +127,17 @@ export const authMeMembershipSchema = z
   })
   .openapi('AuthMeMembership')
 
-export const authMeResponseSchema = authUserResponseSchema
-  .extend({
-    user: authUserSchema.extend({
-      memberships: z.array(authMeMembershipSchema),
-    }),
+export const authMeUserSchema = z
+  .object({
+    ...authUserBaseShape,
+    memberships: z.array(authMeMembershipSchema),
+  })
+  .openapi('AuthMeUser')
+
+export const authMeResponseSchema = z
+  .object({
+    session_auth_method: authUserResponseSchema.shape.session_auth_method,
+    user: authMeUserSchema,
   })
   .openapi('AuthMeResponse')
 

--- a/apps/kaede/src/schemas/auth.ts
+++ b/apps/kaede/src/schemas/auth.ts
@@ -67,6 +67,70 @@ export const authUserResponseSchema = z
   })
   .openapi('AuthUserResponse')
 
+export const authMeGrantStateSchema = z
+  .discriminatedUnion('status', [
+    z.object({
+      status: z.literal('granted'),
+      reason: z.null(),
+      auth_method: z.enum(['local', 'oidc']),
+      authenticated_at: isoDatetimeSchema,
+      reauthentication_required_at: isoDatetimeSchema,
+      expires_at: isoDatetimeSchema,
+      effective_expires_at: isoDatetimeSchema,
+    }),
+    z.object({
+      status: z.literal('reauthentication_required'),
+      reason: z.enum([
+        'grant_missing',
+        'grant_revoked',
+        'grant_expired',
+        'reauthentication_interval_elapsed',
+        'policy_changed',
+        'auth_method_not_allowed',
+      ]),
+      auth_method: z.enum(['local', 'oidc']).nullable(),
+      authenticated_at: isoDatetimeSchema.nullable(),
+      reauthentication_required_at: isoDatetimeSchema.nullable(),
+      expires_at: isoDatetimeSchema.nullable(),
+      effective_expires_at: isoDatetimeSchema.nullable(),
+    }),
+    z.object({
+      status: z.literal('forbidden'),
+      reason: z.enum([
+        'membership_suspended',
+        'organization_unavailable',
+        'auth_settings_unavailable',
+      ]),
+      auth_method: z.null(),
+      authenticated_at: z.null(),
+      reauthentication_required_at: z.null(),
+      expires_at: z.null(),
+      effective_expires_at: z.null(),
+    }),
+  ])
+  .openapi('AuthMeGrantState')
+
+export const authMeMembershipSchema = z
+  .object({
+    membership_id: uuidSchema,
+    organization_id: uuidSchema,
+    organization_name: z.string().min(1).max(255),
+    organization_slug: z.string().min(1).max(63),
+    role: membershipRoleSchema,
+    status: z.enum(['active', 'suspended']),
+    allowed_auth_methods: z.array(z.enum(['local', 'oidc'])),
+    grant_state: authMeGrantStateSchema,
+  })
+  .openapi('AuthMeMembership')
+
+export const authMeResponseSchema = authUserResponseSchema
+  .extend({
+    user: authUserSchema.extend({
+      memberships: z.array(authMeMembershipSchema),
+    }),
+  })
+  .openapi('AuthMeResponse')
+
 export const changePasswordRequestSchema = z
   .object({
     current_password: z.string().min(1).max(100),
@@ -112,5 +176,6 @@ export type ActivationCompleteRequest = z.infer<typeof activationCompleteRequest
 export type ActivationVerifyRequest = z.infer<typeof activationVerifyRequestSchema>
 export type ActivationVerifyResponse = z.infer<typeof activationVerifyResponseSchema>
 export type AuthUserResponse = z.infer<typeof authUserResponseSchema>
+export type AuthMeResponse = z.infer<typeof authMeResponseSchema>
 export type ChangePasswordRequest = z.infer<typeof changePasswordRequestSchema>
 export type LoginRequest = z.infer<typeof loginRequestSchema>

--- a/apps/kaede/src/schemas/common.ts
+++ b/apps/kaede/src/schemas/common.ts
@@ -111,6 +111,7 @@ export const authErrorCodes = [
   'AUTH_PASSWORD_LOGIN_DISABLED',
   'AUTH_DASHBOARD_FORBIDDEN',
   'AUTH_ORGANIZATION_FORBIDDEN',
+  'AUTH_MEMBERSHIP_REAUTHENTICATION_REQUIRED',
 ] as const
 
 export const authErrorCodeSchema = z.enum(authErrorCodes).openapi({
@@ -128,6 +129,7 @@ export const authErrorMessages: Record<AuthErrorCode, string> = {
   AUTH_ACTIVATION_TOKEN_INVALID: 'activation token is invalid',
   AUTH_INVALID_CREDENTIALS: 'invalid email or password',
   AUTH_ORGANIZATION_FORBIDDEN: 'organization access forbidden',
+  AUTH_MEMBERSHIP_REAUTHENTICATION_REQUIRED: 'organization membership reauthentication required',
   AUTH_PASSWORD_CHANGE_REQUIRED: 'password change required',
   AUTH_PASSWORD_LOGIN_DISABLED: 'password login is disabled',
   AUTH_SESSION_EXPIRED: 'session expired',
@@ -142,6 +144,7 @@ export const authErrorStatuses: Record<AuthErrorCode, 401 | 403> = {
   AUTH_ACTIVATION_TOKEN_INVALID: 401,
   AUTH_INVALID_CREDENTIALS: 401,
   AUTH_ORGANIZATION_FORBIDDEN: 403,
+  AUTH_MEMBERSHIP_REAUTHENTICATION_REQUIRED: 403,
   AUTH_PASSWORD_CHANGE_REQUIRED: 403,
   AUTH_PASSWORD_LOGIN_DISABLED: 403,
   AUTH_SESSION_EXPIRED: 401,

--- a/apps/kaede/src/schemas/common.ts
+++ b/apps/kaede/src/schemas/common.ts
@@ -124,7 +124,52 @@ export const authErrorResponseSchema = errorResponseSchema
   })
   .openapi('AuthErrorResponse')
 
-export const authErrorMessages: Record<AuthErrorCode, string> = {
+const authErrorVariant = <TCode extends AuthErrorCode>(errorCode: TCode) =>
+  z.object({
+    error_code: z.literal(errorCode),
+    error_message: z.string().min(1),
+    details: z.record(z.string(), z.unknown()).optional(),
+  })
+
+export const globalSessionErrorResponseSchema = z
+  .discriminatedUnion('error_code', [
+    authErrorVariant('AUTH_UNAUTHENTICATED'),
+    authErrorVariant('AUTH_SESSION_EXPIRED'),
+    authErrorVariant('AUTH_SESSION_REVOKED'),
+  ])
+  .openapi('GlobalSessionErrorResponse')
+
+export const userAccountErrorResponseSchema = authErrorVariant('AUTH_USER_DISABLED').openapi(
+  'UserAccountErrorResponse'
+)
+
+export const organizationAuthorizationErrorResponseSchema = z
+  .discriminatedUnion('error_code', [
+    authErrorVariant('AUTH_USER_DISABLED'),
+    authErrorVariant('AUTH_PASSWORD_CHANGE_REQUIRED'),
+    authErrorVariant('AUTH_DASHBOARD_FORBIDDEN'),
+    authErrorVariant('AUTH_ORGANIZATION_FORBIDDEN'),
+    z.object({
+      error_code: z.literal('AUTH_MEMBERSHIP_REAUTHENTICATION_REQUIRED'),
+      error_message: z.string().min(1),
+      details: z.object({
+        organization_id: uuidSchema,
+        membership_id: uuidSchema,
+        reason: z.enum([
+          'grant_missing',
+          'grant_revoked',
+          'grant_expired',
+          'reauthentication_interval_elapsed',
+          'policy_changed',
+          'auth_method_not_allowed',
+        ]),
+        allowed_auth_methods: z.array(z.enum(['local', 'oidc'])),
+      }),
+    }),
+  ])
+  .openapi('OrganizationAuthorizationErrorResponse')
+
+export const authErrorMessages = {
   AUTH_DASHBOARD_FORBIDDEN: 'dashboard access forbidden',
   AUTH_ACTIVATION_TOKEN_INVALID: 'activation token is invalid',
   AUTH_INVALID_CREDENTIALS: 'invalid email or password',
@@ -137,9 +182,9 @@ export const authErrorMessages: Record<AuthErrorCode, string> = {
   AUTH_UNAUTHENTICATED: 'login required',
   AUTH_USER_DISABLED: 'user is disabled',
   AUTH_USER_LOCKED: 'account is locked due to too many failed attempts',
-}
+} as const satisfies Record<AuthErrorCode, string>
 
-export const authErrorStatuses: Record<AuthErrorCode, 401 | 403> = {
+export const authErrorStatuses = {
   AUTH_DASHBOARD_FORBIDDEN: 403,
   AUTH_ACTIVATION_TOKEN_INVALID: 401,
   AUTH_INVALID_CREDENTIALS: 401,
@@ -152,9 +197,9 @@ export const authErrorStatuses: Record<AuthErrorCode, 401 | 403> = {
   AUTH_UNAUTHENTICATED: 401,
   AUTH_USER_DISABLED: 403,
   AUTH_USER_LOCKED: 403,
-}
+} as const satisfies Record<AuthErrorCode, 401 | 403>
 
-export const toAuthErrorResponse = (errorCode: AuthErrorCode) => {
+export const toAuthErrorResponse = <TCode extends AuthErrorCode>(errorCode: TCode) => {
   return {
     body: {
       error_code: errorCode,

--- a/apps/kaede/src/schemas/membership-administration.ts
+++ b/apps/kaede/src/schemas/membership-administration.ts
@@ -1,0 +1,30 @@
+import { z } from '@hono/zod-openapi'
+import { membershipRoleSchema, uuidSchema } from './common.js'
+
+export const membershipAdministrationParamsSchema = z
+  .object({ organizationId: uuidSchema, membershipId: uuidSchema })
+  .openapi('MembershipAdministrationParams')
+
+export const updateMembershipRequestSchema = z
+  .object({
+    role: membershipRoleSchema.optional(),
+    status: z.enum(['active', 'suspended', 'left']).optional(),
+  })
+  .strict()
+  .refine((value) => Object.keys(value).length > 0, 'at least one field is required')
+  .openapi('UpdateMembershipRequest')
+
+export const managedMembershipSchema = z
+  .object({
+    id: uuidSchema,
+    organization_id: uuidSchema,
+    user_id: uuidSchema,
+    role: membershipRoleSchema,
+    status: z.enum(['active', 'suspended', 'left']),
+    joined_at: z.string().datetime(),
+    left_at: z.string().datetime().nullable(),
+    updated_at: z.string().datetime(),
+  })
+  .openapi('ManagedMembership')
+
+export type UpdateMembershipRequest = z.infer<typeof updateMembershipRequestSchema>

--- a/apps/kaede/src/schemas/organization-auth-methods.ts
+++ b/apps/kaede/src/schemas/organization-auth-methods.ts
@@ -1,0 +1,22 @@
+import { z } from '@hono/zod-openapi'
+import { uuidSchema } from './common.js'
+import { organizationSlugSchema } from './organizations.js'
+
+export const organizationAuthMethodsParamsSchema = z.object({
+  organizationSlug: organizationSlugSchema,
+})
+
+export const organizationAuthMethodsResponseSchema = z
+  .object({
+    local_auth_enabled: z.boolean(),
+    allowed_auth_methods: z.array(z.enum(['local', 'oidc'])),
+    oidc_providers: z.array(
+      z.object({
+        id: uuidSchema,
+        display_name: z.string().min(1).max(255),
+      })
+    ),
+  })
+  .openapi('OrganizationAuthMethodsResponse')
+
+export type OrganizationAuthMethodsResponse = z.infer<typeof organizationAuthMethodsResponseSchema>

--- a/apps/kaede/src/schemas/organization-auth-settings.ts
+++ b/apps/kaede/src/schemas/organization-auth-settings.ts
@@ -1,0 +1,44 @@
+import { z } from '@hono/zod-openapi'
+import { errorResponseSchema, isoDatetimeSchema, uuidSchema } from './common.js'
+
+const positiveSecondsSchema = z.number().int().positive().max(2_147_483_647)
+
+export const organizationAuthSettingsSchema = z
+  .object({
+    organization_id: uuidSchema,
+    local_auth_enabled: z.boolean(),
+    oidc_auth_enabled: z.boolean(),
+    policy_version: z.number().int().positive(),
+    membership_grant_ttl_seconds: positiveSecondsSchema,
+    reauthentication_interval_seconds: positiveSecondsSchema,
+    created_at: isoDatetimeSchema,
+    updated_at: isoDatetimeSchema,
+  })
+  .openapi('OrganizationAuthSettings')
+
+export const updateOrganizationAuthSettingsRequestSchema = z
+  .object({
+    local_auth_enabled: z.boolean().optional(),
+    oidc_auth_enabled: z.boolean().optional(),
+    membership_grant_ttl_seconds: positiveSecondsSchema.optional(),
+    reauthentication_interval_seconds: positiveSecondsSchema.optional(),
+  })
+  .strict()
+  .refine((value) => Object.keys(value).length > 0, 'at least one field is required')
+  .openapi('UpdateOrganizationAuthSettingsRequest')
+
+export const organizationAuthSettingsErrorCodeSchema = z.enum([
+  'ORGANIZATION_AUTH_SETTINGS_NOT_FOUND',
+  'ORGANIZATION_AUTH_SETTINGS_INVALID',
+  'OIDC_PROVIDER_REQUIRED',
+])
+
+export const organizationAuthSettingsErrorResponseSchema = errorResponseSchema
+  .extend({
+    error_code: organizationAuthSettingsErrorCodeSchema,
+  })
+  .openapi('OrganizationAuthSettingsErrorResponse')
+
+export type UpdateOrganizationAuthSettingsRequest = z.infer<
+  typeof updateOrganizationAuthSettingsRequestSchema
+>

--- a/apps/kaede/src/schemas/organization-invites.test.ts
+++ b/apps/kaede/src/schemas/organization-invites.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { createOrganizationInviteRequestSchema } from './organization-invites.js'
+
+describe('organization invite schemas', () => {
+  it('owner roleのInviteを受け付けない', () => {
+    expect(createOrganizationInviteRequestSchema.safeParse({ role: 'owner' }).success).toBe(false)
+  })
+
+  it.each(['member', 'manager'])('%s roleのInviteを受け付ける', (role) => {
+    expect(createOrganizationInviteRequestSchema.safeParse({ role }).success).toBe(true)
+  })
+})

--- a/apps/kaede/src/schemas/organization-invites.ts
+++ b/apps/kaede/src/schemas/organization-invites.ts
@@ -1,0 +1,87 @@
+import { z } from '@hono/zod-openapi'
+import { isoDatetimeSchema, uuidSchema } from './common.js'
+import { displayNameSchema, localeSchema, timezoneSchema } from './profiles.js'
+
+export const inviteRoleSchema = z.enum(['member', 'manager'])
+export const inviteStatusSchema = z.enum(['active', 'redeemed', 'revoked', 'expired'])
+
+export const organizationInviteParamsSchema = z.object({
+  organizationId: uuidSchema,
+  inviteId: uuidSchema,
+})
+
+export const organizationInvitesParamsSchema = z.object({ organizationId: uuidSchema })
+
+export const createOrganizationInviteRequestSchema = z.object({ role: inviteRoleSchema })
+
+export const organizationInviteTokenResponseSchema = z
+  .object({
+    token: z.string().min(1),
+    expires_at: isoDatetimeSchema,
+  })
+  .openapi('OrganizationInviteTokenResponse')
+
+export const organizationInviteSchema = z.object({
+  id: uuidSchema,
+  role: inviteRoleSchema,
+  status: inviteStatusSchema,
+  expires_at: isoDatetimeSchema,
+  created_at: isoDatetimeSchema,
+})
+
+export const organizationInvitesResponseSchema = z
+  .object({ invites: z.array(organizationInviteSchema) })
+  .openapi('OrganizationInvitesResponse')
+
+export const verifyOrganizationInviteRequestSchema = z.object({
+  token: z.string().min(1).max(512),
+})
+
+export const verifyOrganizationInviteResponseSchema = z
+  .object({
+    organization: z.object({ name: z.string().min(1) }),
+    role: inviteRoleSchema,
+    expires_at: isoDatetimeSchema,
+    authentication_methods: z.object({
+      local: z.boolean(),
+      oidc: z.boolean(),
+    }),
+  })
+  .openapi('VerifyOrganizationInviteResponse')
+
+const newUserProfileSchema = z.object({
+  display_name: displayNameSchema,
+  locale: localeSchema,
+  timezone: timezoneSchema,
+})
+
+export const acceptLocalOrganizationInviteRequestSchema = z.object({
+  token: z.string().min(1).max(512),
+  login_email: z.string().trim().email().max(255),
+  password: z.string().min(8).max(100),
+  contact_email: z.string().trim().email().max(255).optional(),
+  profile: newUserProfileSchema.optional(),
+})
+
+export const acceptLocalOrganizationInviteResponseSchema = z
+  .object({
+    session: z.object({ expires_at: isoDatetimeSchema }),
+    membership: z.object({
+      id: uuidSchema,
+      organization_id: uuidSchema,
+      role: inviteRoleSchema,
+      status: z.literal('active'),
+    }),
+    grant: z.object({
+      auth_method: z.literal('local'),
+      authenticated_at: isoDatetimeSchema,
+      expires_at: isoDatetimeSchema,
+    }),
+  })
+  .openapi('AcceptLocalOrganizationInviteResponse')
+
+export type InviteRole = z.infer<typeof inviteRoleSchema>
+export type CreateOrganizationInviteRequest = z.infer<typeof createOrganizationInviteRequestSchema>
+export type AcceptLocalOrganizationInviteRequest = z.infer<
+  typeof acceptLocalOrganizationInviteRequestSchema
+>

--- a/apps/kaede/src/schemas/organization-invites.ts
+++ b/apps/kaede/src/schemas/organization-invites.ts
@@ -1,5 +1,6 @@
 import { z } from '@hono/zod-openapi'
 import { isoDatetimeSchema, uuidSchema } from './common.js'
+import { organizationSlugSchema } from './organizations.js'
 import { displayNameSchema, localeSchema, timezoneSchema } from './profiles.js'
 
 export const inviteRoleSchema = z.enum(['member', 'manager'])
@@ -39,13 +40,23 @@ export const verifyOrganizationInviteRequestSchema = z.object({
 
 export const verifyOrganizationInviteResponseSchema = z
   .object({
-    organization: z.object({ name: z.string().min(1) }),
+    organization: z.object({
+      id: uuidSchema,
+      name: z.string().min(1),
+      slug: organizationSlugSchema,
+    }),
     role: inviteRoleSchema,
     expires_at: isoDatetimeSchema,
     authentication_methods: z.object({
       local: z.boolean(),
       oidc: z.boolean(),
     }),
+    oidc_providers: z.array(
+      z.object({
+        id: uuidSchema,
+        display_name: z.string().min(1).max(255),
+      })
+    ),
   })
   .openapi('VerifyOrganizationInviteResponse')
 

--- a/apps/kaede/src/schemas/organization-local-auth.ts
+++ b/apps/kaede/src/schemas/organization-local-auth.ts
@@ -1,0 +1,42 @@
+import { z } from '@hono/zod-openapi'
+import { isoDatetimeSchema, membershipRoleSchema, uuidSchema } from './common.js'
+import { organizationSlugSchema } from './organizations.js'
+
+export const organizationLocalAuthParamsSchema = z
+  .object({ organizationSlug: organizationSlugSchema })
+  .openapi('OrganizationLocalAuthParams')
+
+export const localOrganizationLoginRequestSchema = z
+  .object({
+    login_email: z.string().email().max(255),
+    password: z.string().min(1).max(100),
+    return_to: z
+      .string()
+      .min(1)
+      .max(2048)
+      .refine(
+        (value) => value.startsWith('/') && !value.startsWith('//') && !value.includes('\\'),
+        'return_to must be a safe application-relative path'
+      ),
+  })
+  .openapi('LocalOrganizationLoginRequest')
+
+export const localOrganizationLoginResponseSchema = z
+  .object({
+    session: z.object({ expires_at: isoDatetimeSchema }),
+    membership: z.object({
+      id: uuidSchema,
+      organization_id: uuidSchema,
+      role: membershipRoleSchema,
+      status: z.literal('active'),
+    }),
+    grant: z.object({
+      auth_method: z.literal('local'),
+      authenticated_at: isoDatetimeSchema,
+      expires_at: isoDatetimeSchema,
+    }),
+    return_to: localOrganizationLoginRequestSchema.shape.return_to,
+  })
+  .openapi('LocalOrganizationLoginResponse')
+
+export type LocalOrganizationLoginRequest = z.infer<typeof localOrganizationLoginRequestSchema>

--- a/apps/kaede/src/schemas/organization-local-credentials.ts
+++ b/apps/kaede/src/schemas/organization-local-credentials.ts
@@ -1,0 +1,50 @@
+import { z } from '@hono/zod-openapi'
+import { isoDatetimeSchema, uuidSchema } from './common.js'
+
+export const organizationLocalCredentialParamsSchema = z
+  .object({ organizationId: uuidSchema })
+  .openapi('OrganizationLocalCredentialParams')
+
+const passwordSchema = z
+  .string()
+  .min(1)
+  .max(100)
+  .refine((value) => value.trim().length > 0, 'password must not be blank')
+
+export const organizationLocalCredentialSchema = z
+  .discriminatedUnion('configured', [
+    z.object({
+      organization_id: uuidSchema,
+      membership_id: uuidSchema,
+      configured: z.literal(false),
+    }),
+    z.object({
+      organization_id: uuidSchema,
+      membership_id: uuidSchema,
+      configured: z.literal(true),
+      login_email: z.string().email().max(255),
+      enabled: z.boolean(),
+      password_changed_at: isoDatetimeSchema,
+      updated_at: isoDatetimeSchema,
+    }),
+  ])
+  .openapi('OrganizationLocalCredential')
+
+export const putOrganizationLocalCredentialRequestSchema = z
+  .object({
+    login_email: z.string().email().max(255),
+    new_password: passwordSchema,
+    current_password: passwordSchema.optional(),
+  })
+  .openapi('PutOrganizationLocalCredentialRequest')
+
+export const disableOrganizationLocalCredentialRequestSchema = z
+  .object({ current_password: passwordSchema.optional() })
+  .openapi('DisableOrganizationLocalCredentialRequest')
+
+export type PutOrganizationLocalCredentialRequest = z.infer<
+  typeof putOrganizationLocalCredentialRequestSchema
+>
+export type DisableOrganizationLocalCredentialRequest = z.infer<
+  typeof disableOrganizationLocalCredentialRequestSchema
+>

--- a/apps/kaede/src/schemas/organization-oidc-auth.ts
+++ b/apps/kaede/src/schemas/organization-oidc-auth.ts
@@ -1,0 +1,99 @@
+import { z } from '@hono/zod-openapi'
+import { isoDatetimeSchema, uuidSchema } from './common.js'
+import { organizationIdParamsSchema, organizationSlugSchema } from './organizations.js'
+
+const safeReturnToSchema = z
+  .string()
+  .min(1)
+  .max(2048)
+  .refine(
+    (value) => value.startsWith('/') && !value.startsWith('//') && !value.includes('\\'),
+    'return_to must be a safe application-relative path'
+  )
+
+export const oidcIntentSchema = z.enum([
+  'login',
+  'reauthenticate',
+  'accept_invite',
+  'link_identity',
+])
+
+export const organizationOidcStartParamsSchema = z.object({
+  organizationSlug: organizationSlugSchema,
+  providerId: uuidSchema,
+})
+
+export const organizationOidcStartRequestSchema = z
+  .object({
+    intent: oidcIntentSchema,
+    return_to: safeReturnToSchema,
+    invite_token: z.string().min(1).optional(),
+  })
+  .superRefine((value, context) => {
+    if (value.intent === 'accept_invite' && !value.invite_token) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'invite_token is required for accept_invite',
+        path: ['invite_token'],
+      })
+    }
+    if (value.intent !== 'accept_invite' && value.invite_token) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'invite_token is only allowed for accept_invite',
+        path: ['invite_token'],
+      })
+    }
+  })
+
+export const organizationOidcStartResponseSchema = z.object({
+  authorization_url: z.string().url(),
+})
+
+const hostedDomainSchema = z
+  .string()
+  .min(1)
+  .max(253)
+  .regex(/^[a-zA-Z0-9](?:[a-zA-Z0-9.-]*[a-zA-Z0-9])?$/)
+
+export const createOrganizationOidcProviderRequestSchema = z.object({
+  display_name: z.string().trim().min(1).max(255),
+  issuer: z.enum(['accounts.google.com', 'https://accounts.google.com']),
+  client_id: z.string().trim().min(1).max(2048),
+  allowed_hosted_domains: z.array(hostedDomainSchema).max(100).nullable().optional(),
+  enabled: z.boolean().default(true),
+})
+
+export const updateOrganizationOidcProviderRequestSchema =
+  createOrganizationOidcProviderRequestSchema
+    .partial()
+    .refine((value) => Object.keys(value).length > 0, 'at least one field is required')
+
+export const organizationOidcProviderSchema = z.object({
+  id: uuidSchema,
+  organization_id: uuidSchema,
+  display_name: z.string(),
+  issuer: z.string(),
+  client_id: z.string(),
+  allowed_hosted_domains: z.array(z.string()).nullable(),
+  enabled: z.boolean(),
+  created_at: isoDatetimeSchema,
+  updated_at: isoDatetimeSchema,
+})
+
+export const organizationOidcProvidersResponseSchema = z.object({
+  providers: z.array(organizationOidcProviderSchema),
+})
+
+export const organizationOidcProviderParamsSchema = organizationIdParamsSchema.extend({
+  providerId: uuidSchema,
+})
+
+export type CreateOrganizationOidcProviderRequest = z.infer<
+  typeof createOrganizationOidcProviderRequestSchema
+>
+export type OrganizationOidcStartRequest = z.infer<typeof organizationOidcStartRequestSchema>
+export type OidcIntent = z.infer<typeof oidcIntentSchema>
+export type UpdateOrganizationOidcProviderRequest = z.infer<
+  typeof updateOrganizationOidcProviderRequestSchema
+>

--- a/apps/kaede/src/schemas/organization-oidc-links.ts
+++ b/apps/kaede/src/schemas/organization-oidc-links.ts
@@ -1,0 +1,32 @@
+import { z } from '@hono/zod-openapi'
+import { errorResponseSchema, isoDatetimeSchema, uuidSchema } from './common.js'
+import { organizationIdParamsSchema } from './organizations.js'
+
+export const organizationOidcLinkSchema = z
+  .object({
+    id: uuidSchema,
+    provider: z.object({
+      id: uuidSchema,
+      display_name: z.string().min(1),
+      enabled: z.boolean(),
+    }),
+    linked_at: isoDatetimeSchema,
+  })
+  .openapi('OrganizationOidcLink')
+
+export const organizationOidcLinksResponseSchema = z
+  .object({ links: z.array(organizationOidcLinkSchema) })
+  .openapi('OrganizationOidcLinksResponse')
+
+export const organizationOidcLinkParamsSchema = organizationIdParamsSchema.extend({
+  linkId: uuidSchema,
+})
+
+export const organizationOidcLinkErrorCodeSchema = z.enum([
+  'OIDC_MEMBERSHIP_LINK_NOT_FOUND',
+  'OIDC_LINK_LAST_USABLE_AUTH_METHOD',
+])
+
+export const organizationOidcLinkErrorResponseSchema = errorResponseSchema
+  .extend({ error_code: organizationOidcLinkErrorCodeSchema })
+  .openapi('OrganizationOidcLinkErrorResponse')

--- a/apps/kaede/src/schemas/organization-session-auth.ts
+++ b/apps/kaede/src/schemas/organization-session-auth.ts
@@ -1,0 +1,14 @@
+import { z } from '@hono/zod-openapi'
+import { uuidSchema } from './common.js'
+
+export const organizationSessionLogoutParamsSchema = z
+  .object({ organizationId: uuidSchema })
+  .openapi('OrganizationSessionLogoutParams')
+
+export const organizationSessionLogoutResponseSchema = z
+  .object({
+    organization_id: uuidSchema,
+    membership_id: uuidSchema,
+    revoked: z.boolean(),
+  })
+  .openapi('OrganizationSessionLogoutResponse')

--- a/apps/kaede/src/schemas/organizations.ts
+++ b/apps/kaede/src/schemas/organizations.ts
@@ -104,6 +104,7 @@ export const rejectOrganizationCreationRequestRequestSchema = z
 
 export const organizationUserSchema = z
   .object({
+    membership_id: uuidSchema,
     user_id: authUserSchema.shape.user_id,
     email: authUserSchema.shape.email,
     display_name: authUserSchema.shape.display_name,

--- a/apps/kaede/src/schemas/pedestrians.ts
+++ b/apps/kaede/src/schemas/pedestrians.ts
@@ -23,10 +23,10 @@ export const pedestrianSchema = z
       description: 'pedestrian を画面上で識別する表示名',
     }),
     height: z.number().nullable().openapi({
-      description: '身長。未設定の場合は null',
+      description: '身長（メートル）。未設定の場合は null',
     }),
     stride_length: z.number().nullable().openapi({
-      description: '歩幅。未設定の場合は null',
+      description: '歩幅（メートル）。未設定の場合は null',
     }),
     attributes: jsonObjectSchema.openapi({
       description: 'pedestrian に紐づく任意属性',
@@ -53,11 +53,11 @@ export const createPedestrianWithoutOrganizationRequestSchema = z
     display_name: z.string().min(1).openapi({
       description: 'pedestrian を画面上で識別する表示名',
     }),
-    height: z.number().positive().nullable().optional().openapi({
-      description: '身長。未設定の場合は null',
+    height: z.number().positive().max(3).nullable().optional().openapi({
+      description: '身長（メートル）。未設定の場合は null',
     }),
-    stride_length: z.number().positive().nullable().optional().openapi({
-      description: '歩幅。未設定の場合は null',
+    stride_length: z.number().positive().max(3).nullable().optional().openapi({
+      description: '歩幅（メートル）。未設定の場合は null',
     }),
     attributes: jsonObjectSchema.optional().openapi({
       description: 'pedestrian に紐づく任意属性',

--- a/apps/kaede/src/schemas/profiles.ts
+++ b/apps/kaede/src/schemas/profiles.ts
@@ -1,9 +1,9 @@
 import { z } from '@hono/zod-openapi'
 import { isoDatetimeSchema, uuidSchema } from './common.js'
 
-const displayNameSchema = z.string().trim().min(1).max(255)
+export const displayNameSchema = z.string().trim().min(1).max(255)
 
-const localeSchema = z
+export const localeSchema = z
   .string()
   .trim()
   .min(1)
@@ -17,7 +17,7 @@ const localeSchema = z
     }
   }, 'locale must be a valid BCP 47 language tag')
 
-const timezoneSchema = z
+export const timezoneSchema = z
   .string()
   .trim()
   .min(1)

--- a/apps/kaede/src/schemas/profiles.ts
+++ b/apps/kaede/src/schemas/profiles.ts
@@ -1,0 +1,121 @@
+import { z } from '@hono/zod-openapi'
+import { isoDatetimeSchema, uuidSchema } from './common.js'
+
+const displayNameSchema = z.string().trim().min(1).max(255)
+
+const localeSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(64)
+  .refine((value) => {
+    try {
+      new Intl.Locale(value)
+      return true
+    } catch {
+      return false
+    }
+  }, 'locale must be a valid BCP 47 language tag')
+
+const timezoneSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(255)
+  .refine((value) => {
+    try {
+      new Intl.DateTimeFormat('en-US', { timeZone: value })
+      return true
+    } catch {
+      return false
+    }
+  }, 'timezone must be a valid IANA time zone')
+
+const heightMetersSchema = z.number().positive().max(3).nullable().openapi({
+  description: 'Organization内プロフィールで使用する身長（メートル）',
+  example: 1.705,
+})
+
+const strideLengthMetersSchema = z.number().positive().max(3).nullable().openapi({
+  description: 'Organization内プロフィールで使用する歩幅（メートル）',
+  example: 0.72,
+})
+
+export const userProfileSchema = z
+  .object({
+    user_id: uuidSchema,
+    display_name: displayNameSchema,
+    locale: localeSchema,
+    timezone: timezoneSchema,
+    updated_at: isoDatetimeSchema,
+  })
+  .openapi('UserProfile')
+
+export const updateUserProfileRequestSchema = z
+  .object({
+    display_name: displayNameSchema.optional(),
+    locale: localeSchema.optional(),
+    timezone: timezoneSchema.optional(),
+  })
+  .refine((payload) => Object.keys(payload).length > 0, 'at least one field is required')
+  .openapi('UpdateUserProfileRequest')
+
+export const organizationMemberProfileSchema = z
+  .object({
+    organization_id: uuidSchema,
+    membership_id: uuidSchema,
+    global: z.object({
+      display_name: displayNameSchema,
+    }),
+    override: z.object({
+      display_name: displayNameSchema.nullable(),
+      height_meters: heightMetersSchema,
+      stride_length_meters: strideLengthMetersSchema,
+    }),
+    effective: z.object({
+      display_name: displayNameSchema,
+      display_name_source: z.enum(['global', 'organization_override']),
+    }),
+    updated_at: isoDatetimeSchema.nullable(),
+  })
+  .openapi('OrganizationMemberProfile')
+
+export const organizationMemberProfileUpdateResponseSchema = organizationMemberProfileSchema
+  .extend({
+    update_context: z.discriminatedUnion('kind', [
+      z.object({ kind: z.literal('self') }),
+      z.object({
+        kind: z.literal('forced'),
+        actor_role: z.enum(['manager', 'owner', 'global_admin']),
+      }),
+    ]),
+  })
+  .openapi('OrganizationMemberProfileUpdateResponse')
+
+export const updateOrganizationMemberProfileRequestSchema = z
+  .object({
+    display_name: displayNameSchema.nullable().optional(),
+    height_meters: heightMetersSchema.optional(),
+    stride_length_meters: strideLengthMetersSchema.optional(),
+  })
+  .refine((payload) => Object.keys(payload).length > 0, 'at least one field is required')
+  .openapi('UpdateOrganizationMemberProfileRequest')
+
+export const organizationMemberProfileParamsSchema = z.object({
+  organizationId: uuidSchema,
+  membershipId: uuidSchema,
+})
+
+export const organizationProfileParamsSchema = z.object({
+  organizationId: uuidSchema,
+})
+
+export type UserProfileResponse = z.infer<typeof userProfileSchema>
+export type UpdateUserProfileRequest = z.infer<typeof updateUserProfileRequestSchema>
+export type OrganizationMemberProfileResponse = z.infer<typeof organizationMemberProfileSchema>
+export type OrganizationMemberProfileUpdateResponse = z.infer<
+  typeof organizationMemberProfileUpdateResponseSchema
+>
+export type UpdateOrganizationMemberProfileRequest = z.infer<
+  typeof updateOrganizationMemberProfileRequestSchema
+>

--- a/apps/kaede/src/server.test.ts
+++ b/apps/kaede/src/server.test.ts
@@ -125,10 +125,33 @@ describe('createApp auth wiring', { timeout: 60_000 }, () => {
             },
           },
         },
+        '/api/invites/verify': {
+          post: {
+            responses: {
+              '200': {
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/VerifyOrganizationInviteResponse' },
+                  },
+                },
+              },
+            },
+          },
+        },
       },
       components: {
         schemas: {
           GlobalSessionErrorResponse: expect.any(Object),
+          VerifyOrganizationInviteResponse: {
+            properties: {
+              organization: {
+                required: ['id', 'name', 'slug'],
+              },
+              oidc_providers: {
+                type: 'array',
+              },
+            },
+          },
           OrganizationAuthorizationErrorResponse: expect.objectContaining({
             oneOf: expect.arrayContaining([
               expect.objectContaining({

--- a/apps/kaede/src/server.test.ts
+++ b/apps/kaede/src/server.test.ts
@@ -152,6 +152,12 @@ describe('createApp auth wiring', { timeout: 60_000 }, () => {
               },
             },
           },
+          OrganizationUser: {
+            required: expect.arrayContaining(['membership_id']),
+            properties: {
+              membership_id: expect.objectContaining({ format: 'uuid' }),
+            },
+          },
           OrganizationAuthorizationErrorResponse: expect.objectContaining({
             oneOf: expect.arrayContaining([
               expect.objectContaining({

--- a/apps/kaede/src/server.test.ts
+++ b/apps/kaede/src/server.test.ts
@@ -84,6 +84,68 @@ describe('createApp auth wiring', { timeout: 60_000 }, () => {
     })
   })
 
+  it('OpenAPIでglobal session 401とmembership 403を別schemaとして公開する', async () => {
+    const app = await createTestApp()
+
+    const response = await app.request('/specification')
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      paths: {
+        '/api/auth/me': {
+          get: {
+            responses: {
+              '401': {
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/GlobalSessionErrorResponse' },
+                  },
+                },
+              },
+              '403': {
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/UserAccountErrorResponse' },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/api/organizations/{organizationSlug}/auth/methods': {
+          get: {
+            responses: {
+              '200': {
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/OrganizationAuthMethodsResponse' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          GlobalSessionErrorResponse: expect.any(Object),
+          OrganizationAuthorizationErrorResponse: expect.objectContaining({
+            oneOf: expect.arrayContaining([
+              expect.objectContaining({
+                properties: expect.objectContaining({
+                  error_code: {
+                    type: 'string',
+                    enum: ['AUTH_MEMBERSHIP_REAUTHENTICATION_REQUIRED'],
+                  },
+                }),
+              }),
+            ]),
+          }),
+        },
+      },
+    })
+  })
+
   it('FRONTEND_ORIGIN があれば credential 付き CORS preflight を許可する', async () => {
     process.env.FRONTEND_ORIGIN = 'https://mio.example.test'
     resetRuntimeConfigForTests()

--- a/apps/kaede/src/server.ts
+++ b/apps/kaede/src/server.ts
@@ -10,6 +10,7 @@ import { registerApiRoutes } from './routes/index.js'
 import { organizationInvitesRoutes } from './routes/organization-invites/index.js'
 import { organizationLocalAuthRoutes } from './routes/organization-local-auth/index.js'
 import { organizationOidcAuthRoutes } from './routes/organization-oidc-auth/index.js'
+import { organizationSessionAuthRoutes } from './routes/organization-session-auth/index.js'
 
 export const createApp = () => {
   const app = new OpenAPIHono()
@@ -39,6 +40,8 @@ export const createApp = () => {
   // Local loginはSessionなしでも利用でき、Sessionがある場合だけreauthenticateとして扱う。
   app.route('/api/organizations', organizationLocalAuthRoutes)
   app.route('/api/organizations', organizationOidcAuthRoutes)
+  // Grantが失効済みでも対象Organizationからlogoutできるよう、Membership Guardより前に手動でSessionを検証する。
+  app.route('/api/organizations', organizationSessionAuthRoutes)
   // 招待確認・Local招待受領はSessionなしでも利用する。
   app.route('/api/invites', organizationInvitesRoutes)
 

--- a/apps/kaede/src/server.ts
+++ b/apps/kaede/src/server.ts
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/node'
 import { cors } from 'hono/cors'
 import { HTTPException } from 'hono/http-exception'
 import { getRuntimeConfig } from './config/runtime.js'
+import { organizationAuthorizationMiddleware } from './middleware/organization-authorization.js'
 import { requestActorMiddleware } from './middleware/request-actor.js'
 import { registerApiRoutes } from './routes/index.js'
 import { organizationLocalAuthRoutes } from './routes/organization-local-auth/index.js'
@@ -58,6 +59,10 @@ export const createApp = () => {
       sharedToken: runtimeConfig.app.apiSharedToken,
     })
   )
+
+  const authorizeOrganization = organizationAuthorizationMiddleware()
+  app.use('/api/organizations/:organizationId', authorizeOrganization)
+  app.use('/api/organizations/:organizationId/*', authorizeOrganization)
 
   const healthRoute = createRoute({
     method: 'get',

--- a/apps/kaede/src/server.ts
+++ b/apps/kaede/src/server.ts
@@ -7,6 +7,7 @@ import { getRuntimeConfig } from './config/runtime.js'
 import { organizationAuthorizationMiddleware } from './middleware/organization-authorization.js'
 import { requestActorMiddleware } from './middleware/request-actor.js'
 import { registerApiRoutes } from './routes/index.js'
+import { organizationInvitesRoutes } from './routes/organization-invites/index.js'
 import { organizationLocalAuthRoutes } from './routes/organization-local-auth/index.js'
 import { organizationOidcAuthRoutes } from './routes/organization-oidc-auth/index.js'
 
@@ -38,6 +39,8 @@ export const createApp = () => {
   // Local loginはSessionなしでも利用でき、Sessionがある場合だけreauthenticateとして扱う。
   app.route('/api/organizations', organizationLocalAuthRoutes)
   app.route('/api/organizations', organizationOidcAuthRoutes)
+  // 招待確認・Local招待受領はSessionなしでも利用する。
+  app.route('/api/invites', organizationInvitesRoutes)
 
   app.onError((err, c) => {
     Sentry.captureException(err)

--- a/apps/kaede/src/server.ts
+++ b/apps/kaede/src/server.ts
@@ -10,6 +10,7 @@ import { registerApiRoutes } from './routes/index.js'
 import { organizationAuthMethodsRoutes } from './routes/organization-auth-methods/index.js'
 import { organizationInvitesRoutes } from './routes/organization-invites/index.js'
 import { organizationLocalAuthRoutes } from './routes/organization-local-auth/index.js'
+import { organizationLocalCredentialRoutes } from './routes/organization-local-credentials/index.js'
 import { organizationOidcAuthRoutes } from './routes/organization-oidc-auth/index.js'
 import { organizationSessionAuthRoutes } from './routes/organization-session-auth/index.js'
 import { organizationAuthorizationErrorResponseSchema } from './schemas/common.js'
@@ -76,6 +77,10 @@ export const createApp = () => {
       sharedToken: runtimeConfig.app.apiSharedToken,
     })
   )
+
+  // Credential変更はcurrent passwordでも認可できるため、通常のMembership Grant Guardより前で
+  // 本人Session・Membership・再認証条件を専用Use Caseが検証する。
+  app.route('/api/organizations', organizationLocalCredentialRoutes)
 
   const authorizeOrganization = organizationAuthorizationMiddleware()
   app.use('/api/organizations/:organizationId', authorizeOrganization)

--- a/apps/kaede/src/server.ts
+++ b/apps/kaede/src/server.ts
@@ -7,13 +7,20 @@ import { getRuntimeConfig } from './config/runtime.js'
 import { organizationAuthorizationMiddleware } from './middleware/organization-authorization.js'
 import { requestActorMiddleware } from './middleware/request-actor.js'
 import { registerApiRoutes } from './routes/index.js'
+import { organizationAuthMethodsRoutes } from './routes/organization-auth-methods/index.js'
 import { organizationInvitesRoutes } from './routes/organization-invites/index.js'
 import { organizationLocalAuthRoutes } from './routes/organization-local-auth/index.js'
 import { organizationOidcAuthRoutes } from './routes/organization-oidc-auth/index.js'
 import { organizationSessionAuthRoutes } from './routes/organization-session-auth/index.js'
+import { organizationAuthorizationErrorResponseSchema } from './schemas/common.js'
 
 export const createApp = () => {
   const app = new OpenAPIHono()
+  // Middleware responseは個別route handlerに紐づかないため、Mio向けcomponentを明示登録する。
+  app.openAPIRegistry.register(
+    'OrganizationAuthorizationErrorResponse',
+    organizationAuthorizationErrorResponseSchema
+  )
   const runtimeConfig = getRuntimeConfig()
   const deployRef = runtimeConfig.app.deployRef
   const revision = runtimeConfig.app.revision
@@ -42,6 +49,8 @@ export const createApp = () => {
   app.route('/api/organizations', organizationOidcAuthRoutes)
   // Grantが失効済みでも対象Organizationからlogoutできるよう、Membership Guardより前に手動でSessionを検証する。
   app.route('/api/organizations', organizationSessionAuthRoutes)
+  // 認証前にも必要なため、global Session / Membership grant middlewareより先に公開する。
+  app.route('/api/organizations', organizationAuthMethodsRoutes)
   // 招待確認・Local招待受領はSessionなしでも利用する。
   app.route('/api/invites', organizationInvitesRoutes)
 

--- a/apps/kaede/src/server.ts
+++ b/apps/kaede/src/server.ts
@@ -7,6 +7,7 @@ import { getRuntimeConfig } from './config/runtime.js'
 import { requestActorMiddleware } from './middleware/request-actor.js'
 import { registerApiRoutes } from './routes/index.js'
 import { organizationLocalAuthRoutes } from './routes/organization-local-auth/index.js'
+import { organizationOidcAuthRoutes } from './routes/organization-oidc-auth/index.js'
 
 export const createApp = () => {
   const app = new OpenAPIHono()
@@ -35,6 +36,7 @@ export const createApp = () => {
 
   // Local loginはSessionなしでも利用でき、Sessionがある場合だけreauthenticateとして扱う。
   app.route('/api/organizations', organizationLocalAuthRoutes)
+  app.route('/api/organizations', organizationOidcAuthRoutes)
 
   app.onError((err, c) => {
     Sentry.captureException(err)

--- a/apps/kaede/src/server.ts
+++ b/apps/kaede/src/server.ts
@@ -6,6 +6,7 @@ import { HTTPException } from 'hono/http-exception'
 import { getRuntimeConfig } from './config/runtime.js'
 import { requestActorMiddleware } from './middleware/request-actor.js'
 import { registerApiRoutes } from './routes/index.js'
+import { organizationLocalAuthRoutes } from './routes/organization-local-auth/index.js'
 
 export const createApp = () => {
   const app = new OpenAPIHono()
@@ -31,6 +32,9 @@ export const createApp = () => {
       })
     )
   }
+
+  // Local loginはSessionなしでも利用でき、Sessionがある場合だけreauthenticateとして扱う。
+  app.route('/api/organizations', organizationLocalAuthRoutes)
 
   app.onError((err, c) => {
     Sentry.captureException(err)

--- a/apps/kaede/src/services/auth/google-oidc-client.test.ts
+++ b/apps/kaede/src/services/auth/google-oidc-client.test.ts
@@ -100,6 +100,7 @@ describe('GoogleOidcClient', () => {
     )
 
     await expect(client.verifyIdToken({ idToken, nonce: 'nonce-value' })).resolves.toEqual({
+      issuer: 'https://accounts.google.com',
       sub: 'google-subject',
       email: 'user@example.com',
       emailVerified: true,
@@ -109,5 +110,41 @@ describe('GoogleOidcClient', () => {
     await expect(client.verifyIdToken({ idToken, nonce: 'wrong-nonce' })).rejects.toThrow(
       'Google ID token nonce mismatch'
     )
+  }, 15_000)
+
+  it('Google の issuer alias と複数 audience の authorized party を検証する', async () => {
+    const { publicKey, privateKey } = await generateKeyPair('RS256')
+    const publicJwk = await exportJWK(publicKey)
+    const createToken = (azp: string) =>
+      new SignJWT({
+        sub: 'google-subject',
+        email: 'user@example.com',
+        email_verified: true,
+        nonce: 'nonce-value',
+        azp,
+      })
+        .setProtectedHeader({ alg: 'RS256', kid: 'test-key' })
+        .setIssuedAt()
+        .setIssuer('accounts.google.com')
+        .setAudience(['client-id', 'another-audience'])
+        .setExpirationTime('5m')
+        .sign(privateKey)
+    const client = new GoogleOidcClient(
+      {
+        clientId: 'client-id',
+        clientSecret: 'client-secret',
+        redirectUri: 'https://api.example.test/callback',
+      },
+      {
+        jwks: { keys: [{ ...publicJwk, kid: 'test-key', alg: 'RS256', use: 'sig' }] },
+      }
+    )
+
+    await expect(
+      client.verifyIdToken({ idToken: await createToken('client-id'), nonce: 'nonce-value' })
+    ).resolves.toMatchObject({ issuer: 'accounts.google.com', sub: 'google-subject' })
+    await expect(
+      client.verifyIdToken({ idToken: await createToken('another-client'), nonce: 'nonce-value' })
+    ).rejects.toThrow('Google ID token authorized party mismatch')
   }, 15_000)
 })

--- a/apps/kaede/src/services/auth/google-oidc-client.ts
+++ b/apps/kaede/src/services/auth/google-oidc-client.ts
@@ -21,6 +21,7 @@ export interface GoogleOidcClientOptions {
 }
 
 export interface GoogleIdTokenClaims {
+  issuer: string
   sub: string
   email: string
   emailVerified: boolean
@@ -29,6 +30,7 @@ export interface GoogleIdTokenClaims {
 }
 
 interface GoogleIdTokenPayload extends JWTPayload {
+  azp?: unknown
   email?: unknown
   email_verified?: unknown
   name?: unknown
@@ -142,8 +144,13 @@ export class GoogleOidcClient {
     if (googlePayload.nonce !== nonce) {
       throw new Error('Google ID token nonce mismatch')
     }
+    const audiences = Array.isArray(googlePayload.aud) ? googlePayload.aud : [googlePayload.aud]
+    if (audiences.length > 1 && googlePayload.azp !== this.config.clientId) {
+      throw new Error('Google ID token authorized party mismatch')
+    }
 
     return {
+      issuer: requireStringClaim(googlePayload, 'iss'),
       sub: requireStringClaim(googlePayload, 'sub'),
       email: requireStringClaim(googlePayload, 'email'),
       emailVerified: googlePayload.email_verified === true,

--- a/apps/kaede/src/services/db/generated.ts
+++ b/apps/kaede/src/services/db/generated.ts
@@ -10,6 +10,8 @@ export type Generated<T> =
     ? ColumnType<S, I | undefined, U>
     : ColumnType<T, T | undefined, T>
 
+export type Int8 = ColumnType<string, bigint | number | string, bigint | number | string>
+
 export type Json = JsonValue
 
 export type JsonArray = JsonValue[]
@@ -22,19 +24,9 @@ export type JsonPrimitive = boolean | number | string | null
 
 export type JsonValue = JsonArray | JsonObject | JsonPrimitive
 
-export type Timestamp = ColumnType<Date, Date | string, Date | string>
+export type Numeric = ColumnType<string, number | string, number | string>
 
-export interface AuthIdentities {
-  created_at: Generated<Timestamp>
-  email: string
-  email_verified: Generated<boolean>
-  hosted_domain: string | null
-  id: Generated<string>
-  provider: string
-  provider_subject: string
-  updated_at: Generated<Timestamp>
-  user_id: string
-}
+export type Timestamp = ColumnType<Date, Date | string, Date | string>
 
 export interface AnalysisRuns {
   analysis_type: string
@@ -58,6 +50,50 @@ export interface AnalysisRunTrajectories {
   trajectory_id: string
 }
 
+export interface AuditEvents {
+  action: string
+  actor_membership_id: string | null
+  actor_user_id: string | null
+  after_values: Json | null
+  before_values: Json | null
+  changed_fields: string[]
+  id: Generated<string>
+  occurred_at: Generated<Timestamp>
+  organization_id: string | null
+  request_id: string | null
+  target_id: string
+  target_type: string
+}
+
+export interface AuthenticationEvents {
+  auth_method: string | null
+  credential_reference_id: string | null
+  event_type: string
+  failure_code: string | null
+  id: Generated<string>
+  ip_address_hash: string | null
+  membership_id: string | null
+  occurred_at: Generated<Timestamp>
+  organization_id: string | null
+  outcome: string
+  request_id: string | null
+  session_id: string | null
+  user_agent: string | null
+  user_id: string | null
+}
+
+export interface AuthIdentities {
+  created_at: Generated<Timestamp>
+  email: string
+  email_verified: Generated<boolean>
+  hosted_domain: string | null
+  id: Generated<string>
+  provider: string
+  provider_subject: string
+  updated_at: Generated<Timestamp>
+  user_id: string
+}
+
 export interface Buildings {
   created_at: Generated<Timestamp>
   id: Generated<string>
@@ -79,6 +115,44 @@ export interface Floors {
   name: string
   organization_id: string
   scale: number | null
+  updated_at: Generated<Timestamp>
+}
+
+export interface OidcIdentities {
+  created_at: Generated<Timestamp>
+  id: Generated<string>
+  issuer: string
+  last_claimed_email: string | null
+  last_claimed_email_verified: boolean | null
+  subject: string
+  updated_at: Generated<Timestamp>
+  user_id: string
+}
+
+export interface OidcLoginTransactions {
+  consumed_at: Timestamp | null
+  created_at: Generated<Timestamp>
+  expires_at: Timestamp
+  id: Generated<string>
+  intent: string
+  invite_id: string | null
+  nonce: string
+  organization_id: string
+  organization_oidc_provider_id: string
+  pkce_code_verifier_ciphertext: string
+  return_to: string
+  session_id: string | null
+  state_hash: string
+}
+
+export interface OrganizationAuthSettings {
+  created_at: Generated<Timestamp>
+  local_auth_enabled: boolean
+  membership_grant_ttl_seconds: number
+  oidc_auth_enabled: boolean
+  organization_id: string
+  policy_version: Generated<Int8>
+  reauthentication_interval_seconds: number
   updated_at: Generated<Timestamp>
 }
 
@@ -107,12 +181,15 @@ export interface OrganizationInviteRedemptions {
 
 export interface OrganizationInvites {
   created_at: Generated<Timestamp>
+  created_by_membership_id: string | null
   created_by_user_id: string
   email: string
   expires_at: Timestamp
   id: Generated<string>
   max_uses: Generated<number>
   organization_id: string
+  redeemed_at: Timestamp | null
+  redeemed_membership_id: string | null
   revoked_at: Timestamp | null
   role: Generated<string>
   token_hash: string
@@ -120,12 +197,66 @@ export interface OrganizationInvites {
   used_count: Generated<number>
 }
 
-export interface OrganizationMemberships {
+export interface OrganizationLocalCredentials {
   created_at: Generated<Timestamp>
+  enabled: Generated<boolean>
+  failed_login_attempts: Generated<number>
+  id: Generated<string>
+  locked_until: Timestamp | null
+  login_email: string
+  membership_id: string
+  normalized_login_email: string
   organization_id: string
-  role: string
+  password_changed_at: Generated<Timestamp>
+  password_hash: string
+  updated_at: Generated<Timestamp>
+}
+
+export interface OrganizationMemberOidcIdentities {
+  created_at: Generated<Timestamp>
+  id: Generated<string>
+  membership_id: string
+  oidc_identity_id: string
+  organization_id: string
+  organization_oidc_provider_id: string
+  revoked_at: Timestamp | null
   updated_at: Generated<Timestamp>
   user_id: string
+}
+
+export interface OrganizationMemberProfiles {
+  created_at: Generated<Timestamp>
+  display_name: string | null
+  height_meters: Numeric | null
+  membership_id: string
+  stride_length_meters: Numeric | null
+  updated_at: Generated<Timestamp>
+}
+
+export interface OrganizationMemberships {
+  created_at: Generated<Timestamp>
+  id: Generated<string | null>
+  joined_at: Generated<Timestamp | null>
+  left_at: Timestamp | null
+  organization_id: string
+  role: string
+  status: Generated<string | null>
+  updated_at: Generated<Timestamp>
+  user_id: string
+}
+
+export interface OrganizationOidcProviders {
+  allowed_hosted_domains: string[] | null
+  client_id: string
+  client_secret_ref: string | null
+  created_at: Generated<Timestamp>
+  enabled: Generated<boolean>
+  id: Generated<string>
+  issuer: string
+  name: string
+  organization_id: string
+  scopes: string[]
+  updated_at: Generated<Timestamp>
 }
 
 export interface Organizations {
@@ -133,6 +264,7 @@ export interface Organizations {
   id: Generated<string>
   name: string
   slug: Generated<string>
+  status: Generated<string | null>
   updated_at: Generated<Timestamp>
 }
 
@@ -142,6 +274,7 @@ export interface Pedestrians {
   display_name: string
   height: number | null
   id: Generated<string>
+  membership_id: string | null
   organization_id: string
   stride_length: number | null
   updated_at: Generated<Timestamp>
@@ -159,6 +292,21 @@ export interface Recordings {
   updated_at: Generated<Timestamp>
   upload_status: Generated<string>
   upload_targets: string[]
+}
+
+export interface SessionMembershipAuthentications {
+  auth_method: string
+  authenticated_at: Timestamp
+  created_at: Generated<Timestamp>
+  expires_at: Timestamp
+  local_credential_id: string | null
+  member_oidc_identity_id: string | null
+  membership_id: string
+  policy_version: Int8
+  revoked_at: Timestamp | null
+  session_id: string
+  updated_at: Generated<Timestamp>
+  user_id: string
 }
 
 export interface Sessions {
@@ -199,7 +347,18 @@ export interface UserActivationTokens {
   user_id: string
 }
 
+export interface UserProfiles {
+  created_at: Generated<Timestamp>
+  display_name: string
+  locale: Generated<string>
+  timezone: Generated<string>
+  updated_at: Generated<Timestamp>
+  user_id: string
+}
+
 export interface Users {
+  contact_email: string | null
+  contact_email_verified_at: Timestamp | null
   created_at: Generated<Timestamp>
   display_name: string
   email: string
@@ -207,6 +366,7 @@ export interface Users {
   global_role: Generated<string>
   id: Generated<string>
   locked_until: Timestamp | null
+  normalized_contact_email: string | null
   password_changed_at: Timestamp | null
   password_hash: string | null
   status: string
@@ -216,18 +376,29 @@ export interface Users {
 export interface DB {
   analysis_run_trajectories: AnalysisRunTrajectories
   analysis_runs: AnalysisRuns
+  audit_events: AuditEvents
   auth_identities: AuthIdentities
+  authentication_events: AuthenticationEvents
   buildings: Buildings
   floors: Floors
+  oidc_identities: OidcIdentities
+  oidc_login_transactions: OidcLoginTransactions
+  organization_auth_settings: OrganizationAuthSettings
   organization_creation_requests: OrganizationCreationRequests
   organization_invite_redemptions: OrganizationInviteRedemptions
   organization_invites: OrganizationInvites
+  organization_local_credentials: OrganizationLocalCredentials
+  organization_member_oidc_identities: OrganizationMemberOidcIdentities
+  organization_member_profiles: OrganizationMemberProfiles
   organization_memberships: OrganizationMemberships
+  organization_oidc_providers: OrganizationOidcProviders
   organizations: Organizations
   pedestrians: Pedestrians
   recordings: Recordings
+  session_membership_authentications: SessionMembershipAuthentications
   sessions: Sessions
   trajectories: Trajectories
   user_activation_tokens: UserActivationTokens
+  user_profiles: UserProfiles
   users: Users
 }

--- a/apps/kaede/src/services/db/generated.ts
+++ b/apps/kaede/src/services/db/generated.ts
@@ -235,12 +235,12 @@ export interface OrganizationMemberProfiles {
 
 export interface OrganizationMemberships {
   created_at: Generated<Timestamp>
-  id: Generated<string | null>
-  joined_at: Generated<Timestamp | null>
+  id: Generated<string>
+  joined_at: Generated<Timestamp>
   left_at: Timestamp | null
   organization_id: string
   role: string
-  status: Generated<string | null>
+  status: Generated<string>
   updated_at: Generated<Timestamp>
   user_id: string
 }

--- a/apps/kaede/src/services/db/generated.ts
+++ b/apps/kaede/src/services/db/generated.ts
@@ -50,6 +50,12 @@ export interface AnalysisRunTrajectories {
   trajectory_id: string
 }
 
+export interface ApplicationDataMigrations {
+  completed_at: Generated<Timestamp>
+  details: Generated<Json>
+  name: string
+}
+
 export interface AuditEvents {
   action: string
   actor_membership_id: string | null
@@ -376,6 +382,7 @@ export interface Users {
 export interface DB {
   analysis_run_trajectories: AnalysisRunTrajectories
   analysis_runs: AnalysisRuns
+  application_data_migrations: ApplicationDataMigrations
   audit_events: AuditEvents
   auth_identities: AuthIdentities
   authentication_events: AuthenticationEvents

--- a/apps/kaede/src/services/membership-administration/index.ts
+++ b/apps/kaede/src/services/membership-administration/index.ts
@@ -1,0 +1,10 @@
+export {
+  countActiveOwners,
+  findCurrentMembershipByUserForUpdate,
+  findMembershipByIdForUpdate,
+  insertMembershipAdministrationAuditEvent,
+  lockOrganizationForMembershipAdministration,
+  revokeAllMembershipGrants,
+  revokeMembershipAuthenticationSources,
+  updateManagedMembership,
+} from './repository.js'

--- a/apps/kaede/src/services/membership-administration/repository.ts
+++ b/apps/kaede/src/services/membership-administration/repository.ts
@@ -1,0 +1,101 @@
+import type { Insertable, Updateable } from 'kysely'
+import type { AuditEvents, OrganizationMemberships } from '../db/generated.js'
+import { db } from '../db/index.js'
+import type { DbExecutor } from '../executor.js'
+
+export const lockOrganizationForMembershipAdministration = async (
+  organizationId: string,
+  executor: DbExecutor = db
+) =>
+  executor
+    .selectFrom('organizations')
+    .select('id')
+    .where('id', '=', organizationId)
+    .forUpdate()
+    .executeTakeFirst()
+
+export const findCurrentMembershipByUserForUpdate = async (
+  organizationId: string,
+  userId: string,
+  executor: DbExecutor
+) =>
+  executor
+    .selectFrom('organization_memberships')
+    .selectAll()
+    .where('organization_id', '=', organizationId)
+    .where('user_id', '=', userId)
+    .where('status', 'in', ['active', 'suspended'])
+    .forUpdate()
+    .executeTakeFirst()
+
+export const findMembershipByIdForUpdate = async (
+  organizationId: string,
+  membershipId: string,
+  executor: DbExecutor
+) =>
+  executor
+    .selectFrom('organization_memberships')
+    .selectAll()
+    .where('organization_id', '=', organizationId)
+    .where('id', '=', membershipId)
+    .forUpdate()
+    .executeTakeFirst()
+
+export const countActiveOwners = async (organizationId: string, executor: DbExecutor) => {
+  const row = await executor
+    .selectFrom('organization_memberships')
+    .select(({ fn }) => fn.countAll<number>().as('count'))
+    .where('organization_id', '=', organizationId)
+    .where('role', '=', 'owner')
+    .where('status', '=', 'active')
+    .executeTakeFirstOrThrow()
+  return Number.parseInt(row.count.toString(), 10)
+}
+
+export const updateManagedMembership = async (
+  membershipId: string,
+  values: Updateable<OrganizationMemberships>,
+  executor: DbExecutor
+) =>
+  executor
+    .updateTable('organization_memberships')
+    .set(values)
+    .where('id', '=', membershipId)
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+export const revokeAllMembershipGrants = async (
+  membershipId: string,
+  revokedAt: Date,
+  executor: DbExecutor
+) =>
+  executor
+    .updateTable('session_membership_authentications')
+    .set({ revoked_at: revokedAt, updated_at: revokedAt })
+    .where('membership_id', '=', membershipId)
+    .where('revoked_at', 'is', null)
+    .execute()
+
+export const revokeMembershipAuthenticationSources = async (
+  membershipId: string,
+  revokedAt: Date,
+  executor: DbExecutor
+) => {
+  await executor
+    .updateTable('organization_local_credentials')
+    .set({ enabled: false, updated_at: revokedAt })
+    .where('membership_id', '=', membershipId)
+    .where('enabled', '=', true)
+    .execute()
+  await executor
+    .updateTable('organization_member_oidc_identities')
+    .set({ revoked_at: revokedAt })
+    .where('membership_id', '=', membershipId)
+    .where('revoked_at', 'is', null)
+    .execute()
+}
+
+export const insertMembershipAdministrationAuditEvent = async (
+  event: Insertable<AuditEvents>,
+  executor: DbExecutor
+) => executor.insertInto('audit_events').values(event).executeTakeFirst()

--- a/apps/kaede/src/services/migrations/multi-org-auth-backfill.ts
+++ b/apps/kaede/src/services/migrations/multi-org-auth-backfill.ts
@@ -1,0 +1,813 @@
+import { sql } from 'kysely'
+import type { RawBuilder } from 'kysely'
+import { db } from '../db/index.js'
+import type { DbExecutor } from '../executor.js'
+
+export const canonicalGoogleIssuer = 'https://accounts.google.com'
+
+export type PreflightScope = 'core' | 'auth' | 'measurements' | 'legacy'
+
+export interface PreflightIssue {
+  blocking: boolean
+  code: string
+  count: number
+  description: string
+  scope: PreflightScope
+  samples: string[]
+}
+
+export interface PreflightReport {
+  blocking: boolean
+  issues: PreflightIssue[]
+  measurements: MeasurementClassification
+}
+
+export interface MeasurementClassification {
+  already_m: number
+  converted_cm: number
+  invalid: number
+}
+
+export interface BackfillResult {
+  auth_settings_unchanged: number
+  contact_emails: number
+  invite_creators: number
+  local_credentials: number
+  measurement_values_already_m: number
+  measurement_values_converted_cm: number
+  memberships: number
+  member_profiles: number
+  oidc_identities: number
+  oidc_links: number
+  organizations: number
+  pedestrian_memberships: number
+  user_profiles: number
+}
+
+const emptyResult = (): BackfillResult => ({
+  auth_settings_unchanged: 0,
+  contact_emails: 0,
+  invite_creators: 0,
+  local_credentials: 0,
+  measurement_values_already_m: 0,
+  measurement_values_converted_cm: 0,
+  memberships: 0,
+  member_profiles: 0,
+  oidc_identities: 0,
+  oidc_links: 0,
+  organizations: 0,
+  pedestrian_memberships: 0,
+  user_profiles: 0,
+})
+
+const getIssue = async (
+  executor: DbExecutor,
+  issue: Omit<PreflightIssue, 'count' | 'samples'>,
+  query: RawBuilder<{ sample: string }>
+): Promise<PreflightIssue | undefined> => {
+  const result = await sql<{ sample: string; total_count: number }>`
+    SELECT sample, (count(*) OVER ())::integer AS total_count
+    FROM (${query}) AS issue
+    LIMIT 20
+  `.execute(executor)
+  if (result.rows.length === 0) return undefined
+
+  return {
+    ...issue,
+    count: result.rows[0]?.total_count ?? 0,
+    samples: result.rows.map((row) => row.sample),
+  }
+}
+
+export const getMultiOrgAuthPreflightReport = async (
+  executor: DbExecutor = db
+): Promise<PreflightReport> => {
+  const [candidates, measurementRows] = await Promise.all([
+    Promise.all([
+      getIssue(
+        executor,
+        {
+          blocking: true,
+          code: 'LOCAL_LOGIN_EMAIL_COLLISION',
+          description:
+            'The same normalized legacy login email belongs to multiple users in one organization.',
+          scope: 'auth',
+        },
+        sql<{ sample: string }>`
+        SELECT organization_id::text || ':' || lower(btrim(u.email)) AS sample
+        FROM organization_memberships AS m
+        JOIN users AS u ON u.id = m.user_id
+        WHERE u.password_hash IS NOT NULL
+          AND COALESCE(m.status, 'active') IN ('active', 'suspended')
+        GROUP BY organization_id, lower(btrim(u.email))
+        HAVING count(*) > 1
+      `
+      ),
+      getIssue(
+        executor,
+        {
+          blocking: true,
+          code: 'MISSING_ORGANIZATION_AUTH_POLICY',
+          description:
+            'Organization authentication policy is an operator decision and cannot be inferred from global runtime flags.',
+          scope: 'auth',
+        },
+        sql<{ sample: string }>`
+        SELECT o.id::text AS sample
+        FROM organizations AS o
+        LEFT JOIN organization_auth_settings AS settings
+          ON settings.organization_id = o.id
+        WHERE settings.organization_id IS NULL
+        ORDER BY o.id
+      `
+      ),
+      getIssue(
+        executor,
+        {
+          blocking: true,
+          code: 'OIDC_PROVIDER_MAPPING_MISSING_OR_AMBIGUOUS',
+          description:
+            'An OIDC-enabled organization with a legacy Google user must have exactly one enabled canonical Google provider.',
+          scope: 'auth',
+        },
+        sql<{ sample: string }>`
+        SELECT DISTINCT m.organization_id::text AS sample
+        FROM organization_memberships AS m
+        JOIN auth_identities AS legacy
+          ON legacy.user_id = m.user_id
+         AND legacy.provider = 'google'
+        JOIN organization_auth_settings AS settings
+          ON settings.organization_id = m.organization_id
+         AND settings.oidc_auth_enabled
+        LEFT JOIN organization_oidc_providers AS provider
+          ON provider.organization_id = m.organization_id
+         AND provider.enabled
+         AND provider.issuer = ${canonicalGoogleIssuer}
+        WHERE COALESCE(m.status, 'active') IN ('active', 'suspended')
+        GROUP BY m.organization_id, m.user_id
+        HAVING count(provider.id) <> 1
+      `
+      ),
+      getIssue(
+        executor,
+        {
+          blocking: true,
+          code: 'OIDC_IDENTITY_OWNER_CONFLICT',
+          description: 'A canonical issuer and subject pair resolves to more than one user.',
+          scope: 'auth',
+        },
+        sql<{ sample: string }>`
+        WITH identities AS (
+          SELECT ${canonicalGoogleIssuer}::text AS issuer, provider_subject AS subject, user_id
+          FROM auth_identities
+          WHERE provider = 'google'
+          UNION ALL
+          SELECT issuer, subject, user_id
+          FROM oidc_identities
+        )
+        SELECT issuer || ':' || subject AS sample
+        FROM identities
+        GROUP BY issuer, subject
+        HAVING count(DISTINCT user_id) > 1
+      `
+      ),
+      getIssue(
+        executor,
+        {
+          blocking: true,
+          code: 'PEDESTRIAN_MEMBERSHIP_NOT_FOUND',
+          description: 'A pedestrian user and organization do not resolve to a membership.',
+          scope: 'core',
+        },
+        sql<{ sample: string }>`
+        SELECT p.id::text AS sample
+        FROM pedestrians AS p
+        LEFT JOIN organization_memberships AS m
+          ON m.organization_id = p.organization_id
+         AND m.user_id = p.user_id
+         AND COALESCE(m.status, 'active') IN ('active', 'suspended')
+        WHERE p.user_id IS NOT NULL
+          AND m.user_id IS NULL
+        ORDER BY p.id
+      `
+      ),
+      getIssue(
+        executor,
+        {
+          blocking: true,
+          code: 'PEDESTRIAN_MEASUREMENT_OUT_OF_RANGE',
+          description:
+            'Legacy measurements must be greater than 0 and at most 300 before meter normalization.',
+          scope: 'measurements',
+        },
+        sql<{ sample: string }>`
+        SELECT p.id::text || ':height=' || p.height::text AS sample
+        FROM pedestrians AS p
+        WHERE p.height IS NOT NULL
+          AND (
+            NOT (p.height > 0 AND p.height <= 300)
+            OR round((CASE WHEN p.height <= 3 THEN p.height ELSE p.height / 100 END)::numeric, 3)
+              <= 0
+          )
+        UNION ALL
+        SELECT p.id::text || ':stride_length=' || p.stride_length::text AS sample
+        FROM pedestrians AS p
+        WHERE p.stride_length IS NOT NULL
+          AND (
+            NOT (p.stride_length > 0 AND p.stride_length <= 300)
+            OR round((CASE
+                WHEN p.stride_length <= 3 THEN p.stride_length
+                ELSE p.stride_length / 100
+              END)::numeric, 3) <= 0
+          )
+      `
+      ),
+      getIssue(
+        executor,
+        {
+          blocking: true,
+          code: 'INVITE_CREATOR_MEMBERSHIP_NOT_FOUND',
+          description:
+            'A legacy invite creator does not have a current membership in the organization.',
+          scope: 'core',
+        },
+        sql<{ sample: string }>`
+        SELECT invite.id::text AS sample
+        FROM organization_invites AS invite
+        LEFT JOIN organization_memberships AS m
+          ON m.organization_id = invite.organization_id
+         AND m.user_id = invite.created_by_user_id
+         AND COALESCE(m.status, 'active') IN ('active', 'suspended')
+        WHERE invite.created_by_membership_id IS NULL
+          AND m.user_id IS NULL
+        ORDER BY invite.id
+      `
+      ),
+      getIssue(
+        executor,
+        {
+          blocking: true,
+          code: 'LEGACY_MULTI_USE_INVITE',
+          description:
+            'Multi-use or already-used legacy invites require an operator migration decision.',
+          scope: 'legacy',
+        },
+        sql<{ sample: string }>`
+        SELECT id::text AS sample
+        FROM organization_invites
+        WHERE max_uses <> 1 OR used_count <> 0
+        ORDER BY id
+      `
+      ),
+      getIssue(
+        executor,
+        {
+          blocking: false,
+          code: 'PENDING_ACTIVATION_USER',
+          description: 'Pending activation users must be handled by the cutover plan.',
+          scope: 'legacy',
+        },
+        sql<{ sample: string }>`
+        SELECT id::text AS sample
+        FROM users
+        WHERE status = 'pending_activation'
+        ORDER BY id
+      `
+      ),
+    ]),
+    sql<MeasurementClassification>`
+      SELECT
+        (
+          count(*) FILTER (WHERE height > 0 AND height <= 3 AND round(height::numeric, 3) > 0)
+          + count(*) FILTER (
+              WHERE stride_length > 0
+                AND stride_length <= 3
+                AND round(stride_length::numeric, 3) > 0
+            )
+        )::integer AS already_m,
+        (
+          count(*) FILTER (
+              WHERE height > 3 AND height <= 300 AND round((height / 100)::numeric, 3) > 0
+            )
+          + count(*) FILTER (
+              WHERE stride_length > 3
+                AND stride_length <= 300
+                AND round((stride_length / 100)::numeric, 3) > 0
+            )
+        )::integer AS converted_cm,
+        (
+          count(*) FILTER (
+              WHERE height IS NOT NULL
+                AND (
+                  NOT (height > 0 AND height <= 300)
+                  OR round((CASE WHEN height <= 3 THEN height ELSE height / 100 END)::numeric, 3)
+                    <= 0
+                )
+            )
+          + count(*) FILTER (
+              WHERE stride_length IS NOT NULL
+                AND (
+                  NOT (stride_length > 0 AND stride_length <= 300)
+                  OR round((CASE
+                      WHEN stride_length <= 3 THEN stride_length
+                      ELSE stride_length / 100
+                    END)::numeric, 3) <= 0
+                )
+            )
+        )::integer AS invalid
+      FROM pedestrians
+    `.execute(executor),
+  ])
+
+  const issues = candidates.filter((issue): issue is PreflightIssue => issue !== undefined)
+  return {
+    blocking: issues.some((issue) => issue.blocking),
+    issues,
+    measurements: measurementRows.rows[0] ?? { already_m: 0, converted_cm: 0, invalid: 0 },
+  }
+}
+
+const runBatches = async (runBatch: () => Promise<number>): Promise<number> => {
+  let total = 0
+  for (;;) {
+    const updated = await runBatch()
+    total += updated
+    if (updated === 0) return total
+  }
+}
+
+export const backfillMultiOrgAuthCore = async (
+  batchSize: number,
+  executor: DbExecutor = db
+): Promise<BackfillResult> => {
+  const result = emptyResult()
+  const preflight = await getMultiOrgAuthPreflightReport(executor)
+  const blockers = preflight.issues.filter(
+    (issue) =>
+      issue.blocking &&
+      (issue.scope === 'core' || issue.scope === 'measurements' || issue.scope === 'legacy')
+  )
+  if (blockers.length > 0) {
+    throw new Error(`core backfill blocked: ${blockers.map((issue) => issue.code).join(', ')}`)
+  }
+
+  result.organizations = await runBatches(async () => {
+    const rows = await sql<{ id: string }>`
+      WITH target AS (
+        SELECT id FROM organizations WHERE status IS NULL ORDER BY id LIMIT ${batchSize}
+      )
+      UPDATE organizations AS o
+      SET status = 'active'
+      FROM target
+      WHERE o.id = target.id
+      RETURNING o.id
+    `.execute(executor)
+    return rows.rows.length
+  })
+
+  result.memberships = await runBatches(async () => {
+    const rows = await sql<{ id: string }>`
+      WITH target AS (
+        SELECT organization_id, user_id
+        FROM organization_memberships
+        WHERE id IS NULL OR status IS NULL OR joined_at IS NULL
+        ORDER BY organization_id, user_id
+        LIMIT ${batchSize}
+        FOR UPDATE SKIP LOCKED
+      )
+      UPDATE organization_memberships AS m
+      SET
+        id = COALESCE(m.id, gen_random_uuid()),
+        status = COALESCE(m.status, 'active'),
+        joined_at = COALESCE(m.joined_at, m.created_at)
+      FROM target
+      WHERE m.organization_id = target.organization_id
+        AND m.user_id = target.user_id
+      RETURNING m.id
+    `.execute(executor)
+    return rows.rows.length
+  })
+
+  result.contact_emails = await runBatches(async () => {
+    const rows = await sql<{ id: string }>`
+      WITH target AS (
+        SELECT id FROM users WHERE contact_email IS NULL ORDER BY id LIMIT ${batchSize}
+      )
+      UPDATE users AS u
+      SET
+        contact_email = u.email,
+        normalized_contact_email = lower(btrim(u.email))
+      FROM target
+      WHERE u.id = target.id
+      RETURNING u.id
+    `.execute(executor)
+    return rows.rows.length
+  })
+
+  result.user_profiles = await runBatches(async () => {
+    const rows = await sql<{ user_id: string }>`
+      INSERT INTO user_profiles (user_id, display_name)
+      SELECT u.id, u.display_name
+      FROM users AS u
+      LEFT JOIN user_profiles AS profile ON profile.user_id = u.id
+      WHERE profile.user_id IS NULL
+      ORDER BY u.id
+      LIMIT ${batchSize}
+      ON CONFLICT (user_id) DO NOTHING
+      RETURNING user_id
+    `.execute(executor)
+    return rows.rows.length
+  })
+
+  result.pedestrian_memberships = await runBatches(async () => {
+    const rows = await sql<{ id: string }>`
+      WITH target AS (
+        SELECT p.id, m.id AS membership_id
+        FROM pedestrians AS p
+        JOIN organization_memberships AS m
+          ON m.organization_id = p.organization_id
+         AND m.user_id = p.user_id
+         AND m.status IN ('active', 'suspended')
+        WHERE p.membership_id IS NULL
+        ORDER BY p.id
+        LIMIT ${batchSize}
+      )
+      UPDATE pedestrians AS p
+      SET membership_id = target.membership_id
+      FROM target
+      WHERE p.id = target.id
+      RETURNING p.id
+    `.execute(executor)
+    return rows.rows.length
+  })
+
+  result.member_profiles = await runBatches(async () => {
+    const rows = await sql<{ membership_id: string }>`
+      INSERT INTO organization_member_profiles (membership_id, display_name)
+      SELECT
+        m.id,
+        CASE
+          WHEN p.display_name IS DISTINCT FROM u.display_name THEN p.display_name
+          ELSE NULL
+        END
+      FROM organization_memberships AS m
+      JOIN users AS u ON u.id = m.user_id
+      LEFT JOIN pedestrians AS p ON p.membership_id = m.id
+      LEFT JOIN organization_member_profiles AS profile ON profile.membership_id = m.id
+      WHERE m.id IS NOT NULL
+        AND profile.membership_id IS NULL
+      ORDER BY m.id
+      LIMIT ${batchSize}
+      ON CONFLICT (membership_id) DO NOTHING
+      RETURNING membership_id
+    `.execute(executor)
+    return rows.rows.length
+  })
+
+  for (;;) {
+    const rows = await sql<{
+      height_already_m: boolean
+      height_converted_cm: boolean
+      stride_already_m: boolean
+      stride_converted_cm: boolean
+    }>`
+      WITH target AS (
+        SELECT
+          p.membership_id,
+          p.height,
+          p.stride_length,
+          profile.height_meters IS NULL AND p.height IS NOT NULL AS height_needs_backfill,
+          profile.stride_length_meters IS NULL AND p.stride_length IS NOT NULL
+            AS stride_needs_backfill
+        FROM pedestrians AS p
+        JOIN organization_member_profiles AS profile
+          ON profile.membership_id = p.membership_id
+        WHERE
+          (profile.height_meters IS NULL AND p.height IS NOT NULL)
+          OR (profile.stride_length_meters IS NULL AND p.stride_length IS NOT NULL)
+        ORDER BY p.membership_id
+        LIMIT ${batchSize}
+        FOR UPDATE OF p SKIP LOCKED
+      )
+      UPDATE organization_member_profiles AS profile
+      SET
+        height_meters = CASE
+          WHEN profile.height_meters IS NOT NULL OR target.height IS NULL
+            THEN profile.height_meters
+          WHEN target.height <= 3 THEN round(target.height::numeric, 3)
+          ELSE round((target.height / 100)::numeric, 3)
+        END,
+        stride_length_meters = CASE
+          WHEN profile.stride_length_meters IS NOT NULL OR target.stride_length IS NULL
+            THEN profile.stride_length_meters
+          WHEN target.stride_length <= 3 THEN round(target.stride_length::numeric, 3)
+          ELSE round((target.stride_length / 100)::numeric, 3)
+        END
+      FROM target
+      WHERE profile.membership_id = target.membership_id
+      RETURNING
+        target.height_needs_backfill AND target.height <= 3 AS height_already_m,
+        target.height_needs_backfill AND target.height > 3 AS height_converted_cm,
+        target.stride_needs_backfill AND target.stride_length <= 3 AS stride_already_m,
+        target.stride_needs_backfill AND target.stride_length > 3 AS stride_converted_cm
+    `.execute(executor)
+
+    if (rows.rows.length === 0) break
+    for (const row of rows.rows) {
+      if (row.height_already_m) result.measurement_values_already_m += 1
+      if (row.height_converted_cm) result.measurement_values_converted_cm += 1
+      if (row.stride_already_m) result.measurement_values_already_m += 1
+      if (row.stride_converted_cm) result.measurement_values_converted_cm += 1
+    }
+  }
+
+  result.invite_creators = await runBatches(async () => {
+    const rows = await sql<{ id: string }>`
+      WITH target AS (
+        SELECT invite.id, m.id AS membership_id
+        FROM organization_invites AS invite
+        JOIN organization_memberships AS m
+          ON m.organization_id = invite.organization_id
+         AND m.user_id = invite.created_by_user_id
+         AND m.status IN ('active', 'suspended')
+        WHERE invite.created_by_membership_id IS NULL
+        ORDER BY invite.id
+        LIMIT ${batchSize}
+      )
+      UPDATE organization_invites AS invite
+      SET created_by_membership_id = target.membership_id
+      FROM target
+      WHERE invite.id = target.id
+      RETURNING invite.id
+    `.execute(executor)
+    return rows.rows.length
+  })
+
+  return result
+}
+
+export const backfillMultiOrgAuthCredentials = async (
+  batchSize: number,
+  executor: DbExecutor = db
+): Promise<BackfillResult> => {
+  const result = emptyResult()
+  const coreVerification = await verifyMultiOrgAuthCoreBackfill(executor)
+  if (Object.values(coreVerification).some((count) => count > 0)) {
+    throw new Error('authentication backfill requires completed core backfill')
+  }
+  const report = await getMultiOrgAuthPreflightReport(executor)
+  const blockers = report.issues.filter((issue) => issue.blocking && issue.scope === 'auth')
+  if (blockers.length > 0) {
+    throw new Error(
+      `authentication backfill blocked: ${blockers.map((issue) => issue.code).join(', ')}`
+    )
+  }
+
+  result.auth_settings_unchanged = await sql<{ count: number }>`
+    SELECT count(*)::integer AS count FROM organization_auth_settings
+  `
+    .execute(executor)
+    .then((rows) => rows.rows[0]?.count ?? 0)
+
+  result.local_credentials = await runBatches(async () => {
+    const rows = await sql<{ id: string }>`
+      INSERT INTO organization_local_credentials (
+        membership_id,
+        organization_id,
+        login_email,
+        normalized_login_email,
+        password_hash,
+        password_changed_at,
+        failed_login_attempts,
+        locked_until
+      )
+      SELECT
+        m.id,
+        m.organization_id,
+        u.email,
+        lower(btrim(u.email)),
+        u.password_hash,
+        COALESCE(u.password_changed_at, u.created_at),
+        u.failed_login_attempts,
+        u.locked_until
+      FROM organization_memberships AS m
+      JOIN users AS u ON u.id = m.user_id
+      JOIN organization_auth_settings AS settings
+        ON settings.organization_id = m.organization_id
+       AND settings.local_auth_enabled
+      LEFT JOIN organization_local_credentials AS credential
+        ON credential.membership_id = m.id
+      WHERE m.id IS NOT NULL
+        AND m.status IN ('active', 'suspended')
+        AND u.password_hash IS NOT NULL
+        AND credential.id IS NULL
+      ORDER BY m.id
+      LIMIT ${batchSize}
+      ON CONFLICT (membership_id) DO NOTHING
+      RETURNING id
+    `.execute(executor)
+    return rows.rows.length
+  })
+
+  result.oidc_identities = await runBatches(async () => {
+    const rows = await sql<{ id: string }>`
+      INSERT INTO oidc_identities (
+        user_id,
+        issuer,
+        subject,
+        last_claimed_email,
+        last_claimed_email_verified
+      )
+      SELECT
+        legacy.user_id,
+        ${canonicalGoogleIssuer},
+        legacy.provider_subject,
+        legacy.email,
+        legacy.email_verified
+      FROM auth_identities AS legacy
+      LEFT JOIN oidc_identities AS identity
+        ON identity.issuer = ${canonicalGoogleIssuer}
+       AND identity.subject = legacy.provider_subject
+      WHERE legacy.provider = 'google'
+        AND identity.id IS NULL
+      ORDER BY legacy.id
+      LIMIT ${batchSize}
+      ON CONFLICT (issuer, subject) DO NOTHING
+      RETURNING id
+    `.execute(executor)
+    return rows.rows.length
+  })
+
+  result.oidc_links = await runBatches(async () => {
+    const rows = await sql<{ id: string }>`
+      INSERT INTO organization_member_oidc_identities (
+        membership_id,
+        organization_id,
+        user_id,
+        organization_oidc_provider_id,
+        oidc_identity_id
+      )
+      SELECT
+        m.id,
+        m.organization_id,
+        m.user_id,
+        provider.id,
+        identity.id
+      FROM organization_memberships AS m
+      JOIN organization_auth_settings AS settings
+        ON settings.organization_id = m.organization_id
+       AND settings.oidc_auth_enabled
+      JOIN oidc_identities AS identity
+        ON identity.user_id = m.user_id
+       AND identity.issuer = ${canonicalGoogleIssuer}
+      JOIN organization_oidc_providers AS provider
+        ON provider.organization_id = m.organization_id
+       AND provider.enabled
+       AND provider.issuer = ${canonicalGoogleIssuer}
+      LEFT JOIN organization_member_oidc_identities AS link
+        ON link.membership_id = m.id
+       AND link.organization_oidc_provider_id = provider.id
+       AND link.oidc_identity_id = identity.id
+      WHERE m.id IS NOT NULL
+        AND m.status IN ('active', 'suspended')
+        AND link.id IS NULL
+      ORDER BY m.id
+      LIMIT ${batchSize}
+      ON CONFLICT (
+        membership_id,
+        organization_oidc_provider_id,
+        oidc_identity_id
+      ) DO NOTHING
+      RETURNING id
+    `.execute(executor)
+    return rows.rows.length
+  })
+
+  return result
+}
+
+export interface VerificationResult {
+  pending_contact_emails: number
+  pending_invite_creators: number
+  pending_member_profiles: number
+  pending_memberships: number
+  pending_organization_statuses: number
+  pending_pedestrian_memberships: number
+  pending_profile_measurements: number
+  pending_user_profiles: number
+}
+
+export const verifyMultiOrgAuthCoreBackfill = async (
+  executor: DbExecutor = db
+): Promise<VerificationResult> => {
+  const rows = await sql<VerificationResult>`
+    SELECT
+      (SELECT count(*) FROM organizations WHERE status IS NULL)::integer
+        AS pending_organization_statuses,
+      (SELECT count(*) FROM organization_memberships
+        WHERE id IS NULL OR status IS NULL OR joined_at IS NULL)::integer
+        AS pending_memberships,
+      (SELECT count(*) FROM users WHERE contact_email IS NULL)::integer
+        AS pending_contact_emails,
+      (SELECT count(*) FROM users AS u LEFT JOIN user_profiles AS p ON p.user_id = u.id
+        WHERE p.user_id IS NULL)::integer AS pending_user_profiles,
+      (SELECT count(*) FROM pedestrians
+        WHERE user_id IS NOT NULL AND membership_id IS NULL)::integer
+        AS pending_pedestrian_memberships,
+      (SELECT count(*) FROM organization_memberships AS m
+        LEFT JOIN organization_member_profiles AS profile ON profile.membership_id = m.id
+        WHERE m.id IS NOT NULL AND profile.membership_id IS NULL)::integer
+        AS pending_member_profiles,
+      (SELECT count(*) FROM pedestrians AS p
+        JOIN organization_member_profiles AS profile ON profile.membership_id = p.membership_id
+        WHERE (p.height IS NOT NULL AND profile.height_meters IS NULL)
+           OR (p.stride_length IS NOT NULL AND profile.stride_length_meters IS NULL))::integer
+        AS pending_profile_measurements,
+      (SELECT count(*) FROM organization_invites
+        WHERE created_by_membership_id IS NULL)::integer AS pending_invite_creators
+  `.execute(executor)
+  return (
+    rows.rows[0] ?? {
+      pending_contact_emails: 0,
+      pending_invite_creators: 0,
+      pending_member_profiles: 0,
+      pending_memberships: 0,
+      pending_organization_statuses: 0,
+      pending_pedestrian_memberships: 0,
+      pending_profile_measurements: 0,
+      pending_user_profiles: 0,
+    }
+  )
+}
+
+export const validateMultiOrgAuthExpandConstraints = async (
+  executor: DbExecutor = db
+): Promise<void> => {
+  const verification = await verifyMultiOrgAuthCoreBackfill(executor)
+  if (Object.values(verification).some((count) => count > 0)) {
+    throw new Error(`constraint validation blocked: ${JSON.stringify(verification)}`)
+  }
+
+  await sql
+    .raw(
+      `
+    SET LOCAL lock_timeout = '5s';
+
+    ALTER TABLE users VALIDATE CONSTRAINT users_contact_email_state_chk;
+    ALTER TABLE organizations VALIDATE CONSTRAINT organizations_status_chk;
+    ALTER TABLE organization_memberships
+      VALIDATE CONSTRAINT organization_memberships_status_chk;
+    ALTER TABLE organization_memberships
+      VALIDATE CONSTRAINT organization_memberships_left_at_chk;
+    ALTER TABLE pedestrians
+      VALIDATE CONSTRAINT pedestrians_membership_organization_fkey;
+    ALTER TABLE organization_invites
+      VALIDATE CONSTRAINT organization_invites_creator_org_fkey;
+    ALTER TABLE organization_invites
+      VALIDATE CONSTRAINT organization_invites_redeemed_membership_org_fkey;
+    ALTER TABLE organization_invites
+      VALIDATE CONSTRAINT organization_invites_redemption_state_chk;
+    ALTER TABLE organization_invites
+      VALIDATE CONSTRAINT organization_invites_revoked_redeemed_chk;
+    ALTER TABLE organization_invites
+      VALIDATE CONSTRAINT organization_invites_role_chk;
+
+    ALTER TABLE organizations
+      ADD CONSTRAINT organizations_status_not_null_backfill_chk
+      CHECK (status IS NOT NULL) NOT VALID;
+    ALTER TABLE organization_memberships
+      ADD CONSTRAINT organization_memberships_id_not_null_backfill_chk
+      CHECK (id IS NOT NULL) NOT VALID;
+    ALTER TABLE organization_memberships
+      ADD CONSTRAINT organization_memberships_status_not_null_backfill_chk
+      CHECK (status IS NOT NULL) NOT VALID;
+    ALTER TABLE organization_memberships
+      ADD CONSTRAINT organization_memberships_joined_at_not_null_backfill_chk
+      CHECK (joined_at IS NOT NULL) NOT VALID;
+
+    ALTER TABLE organizations
+      VALIDATE CONSTRAINT organizations_status_not_null_backfill_chk;
+    ALTER TABLE organization_memberships
+      VALIDATE CONSTRAINT organization_memberships_id_not_null_backfill_chk;
+    ALTER TABLE organization_memberships
+      VALIDATE CONSTRAINT organization_memberships_status_not_null_backfill_chk;
+    ALTER TABLE organization_memberships
+      VALIDATE CONSTRAINT organization_memberships_joined_at_not_null_backfill_chk;
+
+    ALTER TABLE organizations ALTER COLUMN status SET NOT NULL;
+    ALTER TABLE organization_memberships ALTER COLUMN id SET NOT NULL;
+    ALTER TABLE organization_memberships ALTER COLUMN status SET NOT NULL;
+    ALTER TABLE organization_memberships ALTER COLUMN joined_at SET NOT NULL;
+
+    ALTER TABLE organizations
+      DROP CONSTRAINT organizations_status_not_null_backfill_chk;
+    ALTER TABLE organization_memberships
+      DROP CONSTRAINT organization_memberships_id_not_null_backfill_chk;
+    ALTER TABLE organization_memberships
+      DROP CONSTRAINT organization_memberships_status_not_null_backfill_chk;
+    ALTER TABLE organization_memberships
+      DROP CONSTRAINT organization_memberships_joined_at_not_null_backfill_chk;
+  `
+    )
+    .execute(executor)
+}

--- a/apps/kaede/src/services/migrations/multi-org-auth-backfill.ts
+++ b/apps/kaede/src/services/migrations/multi-org-auth-backfill.ts
@@ -44,11 +44,22 @@ export interface BackfillResult {
 }
 
 export interface OneShotCutoverResult {
+  already_completed: boolean
   auth: BackfillResult
+  bootstrapped_auth_settings: number
+  bootstrapped_oidc_providers: number
   core: BackfillResult
   revoked_sessions: number
   validated: true
 }
+
+export interface LegacyAuthPolicyBootstrap {
+  google_client_id: string
+  local_auth_enabled: boolean
+  oidc_auth_enabled: boolean
+}
+
+const cutoverMigrationName = 'multi-organization-auth-v1'
 
 const emptyResult = (): BackfillResult => ({
   auth_settings_unchanged: 0,
@@ -808,9 +819,90 @@ export const validateMultiOrgAuthExpandConstraints = async (
  */
 export const executeOneShotMultiOrgAuthCutover = async (
   batchSize: number,
-  database: Kysely<DB> = db
+  database: Kysely<DB> = db,
+  bootstrap?: LegacyAuthPolicyBootstrap
 ): Promise<OneShotCutoverResult> =>
   database.transaction().execute(async (trx) => {
+    await sql`SELECT pg_advisory_xact_lock(hashtext(${cutoverMigrationName}))`.execute(trx)
+
+    const completed = await sql<{ completed: boolean }>`
+      SELECT EXISTS (
+        SELECT 1 FROM application_data_migrations WHERE name = ${cutoverMigrationName}
+      ) AS completed
+    `.execute(trx)
+    if (completed.rows[0]?.completed) {
+      return {
+        already_completed: true,
+        auth: emptyResult(),
+        bootstrapped_auth_settings: 0,
+        bootstrapped_oidc_providers: 0,
+        core: emptyResult(),
+        revoked_sessions: 0,
+        validated: true,
+      }
+    }
+
+    let bootstrappedAuthSettings = 0
+    let bootstrappedOidcProviders = 0
+    if (bootstrap) {
+      if (!bootstrap.local_auth_enabled && !bootstrap.oidc_auth_enabled) {
+        throw new Error('one-shot cutover requires at least one enabled authentication method')
+      }
+
+      const settings = await sql<{ organization_id: string }>`
+        INSERT INTO organization_auth_settings (
+          organization_id,
+          local_auth_enabled,
+          oidc_auth_enabled,
+          membership_grant_ttl_seconds,
+          reauthentication_interval_seconds
+        )
+        SELECT id, ${bootstrap.local_auth_enabled}, ${bootstrap.oidc_auth_enabled}, 28800, 14400
+        FROM organizations
+        ON CONFLICT (organization_id) DO NOTHING
+        RETURNING organization_id
+      `.execute(trx)
+      bootstrappedAuthSettings = settings.rows.length
+
+      if (bootstrap.oidc_auth_enabled) {
+        if (!bootstrap.google_client_id) {
+          throw new Error('one-shot OIDC cutover requires the configured Google client id')
+        }
+        const providers = await sql<{ id: string }>`
+          INSERT INTO organization_oidc_providers (
+            organization_id,
+            name,
+            issuer,
+            client_id,
+            client_secret_ref,
+            scopes,
+            allowed_hosted_domains,
+            enabled
+          )
+          SELECT
+            settings.organization_id,
+            'Google',
+            ${canonicalGoogleIssuer},
+            ${bootstrap.google_client_id},
+            NULL,
+            ARRAY['openid', 'email', 'profile']::text[],
+            NULL,
+            true
+          FROM organization_auth_settings AS settings
+          WHERE settings.oidc_auth_enabled
+            AND NOT EXISTS (
+              SELECT 1
+              FROM organization_oidc_providers AS provider
+              WHERE provider.organization_id = settings.organization_id
+                AND provider.issuer = ${canonicalGoogleIssuer}
+                AND provider.enabled
+            )
+          RETURNING id
+        `.execute(trx)
+        bootstrappedOidcProviders = providers.rows.length
+      }
+    }
+
     const preflight = await getMultiOrgAuthPreflightReport(trx)
     if (preflight.blocking) {
       throw new Error(
@@ -848,8 +940,23 @@ export const executeOneShotMultiOrgAuthCutover = async (
       RETURNING id
     `.execute(trx)
 
+    await sql`
+      INSERT INTO application_data_migrations (name, details)
+      VALUES (
+        ${cutoverMigrationName},
+        jsonb_build_object(
+          'revoked_sessions', ${revokedSessions.rows.length},
+          'bootstrapped_auth_settings', ${bootstrappedAuthSettings},
+          'bootstrapped_oidc_providers', ${bootstrappedOidcProviders}
+        )
+      )
+    `.execute(trx)
+
     return {
+      already_completed: false,
       auth,
+      bootstrapped_auth_settings: bootstrappedAuthSettings,
+      bootstrapped_oidc_providers: bootstrappedOidcProviders,
       core,
       revoked_sessions: revokedSessions.rows.length,
       validated: true,

--- a/apps/kaede/src/services/migrations/multi-org-auth-backfill.ts
+++ b/apps/kaede/src/services/migrations/multi-org-auth-backfill.ts
@@ -940,16 +940,15 @@ export const executeOneShotMultiOrgAuthCutover = async (
       RETURNING id
     `.execute(trx)
 
+    const cutoverDetails = JSON.stringify({
+      revoked_sessions: revokedSessions.rows.length,
+      bootstrapped_auth_settings: bootstrappedAuthSettings,
+      bootstrapped_oidc_providers: bootstrappedOidcProviders,
+    })
+
     await sql`
       INSERT INTO application_data_migrations (name, details)
-      VALUES (
-        ${cutoverMigrationName},
-        jsonb_build_object(
-          'revoked_sessions', ${revokedSessions.rows.length},
-          'bootstrapped_auth_settings', ${bootstrappedAuthSettings},
-          'bootstrapped_oidc_providers', ${bootstrappedOidcProviders}
-        )
-      )
+      VALUES (${cutoverMigrationName}, ${cutoverDetails}::jsonb)
     `.execute(trx)
 
     return {

--- a/apps/kaede/src/services/migrations/multi-org-auth-backfill.ts
+++ b/apps/kaede/src/services/migrations/multi-org-auth-backfill.ts
@@ -23,8 +23,7 @@ export interface PreflightReport {
 }
 
 export interface MeasurementClassification {
-  already_m: number
-  converted_cm: number
+  valid_meters: number
   invalid: number
 }
 
@@ -33,8 +32,7 @@ export interface BackfillResult {
   contact_emails: number
   invite_creators: number
   local_credentials: number
-  measurement_values_already_m: number
-  measurement_values_converted_cm: number
+  measurement_values_copied_meters: number
   memberships: number
   member_profiles: number
   oidc_identities: number
@@ -49,8 +47,7 @@ const emptyResult = (): BackfillResult => ({
   contact_emails: 0,
   invite_creators: 0,
   local_credentials: 0,
-  measurement_values_already_m: 0,
-  measurement_values_converted_cm: 0,
+  measurement_values_copied_meters: 0,
   memberships: 0,
   member_profiles: 0,
   oidc_identities: 0,
@@ -196,8 +193,7 @@ export const getMultiOrgAuthPreflightReport = async (
         {
           blocking: true,
           code: 'PEDESTRIAN_MEASUREMENT_OUT_OF_RANGE',
-          description:
-            'Legacy measurements must be greater than 0 and at most 300 before meter normalization.',
+          description: 'Legacy measurements must be in meters, greater than 0, and at most 3.',
           scope: 'measurements',
         },
         sql<{ sample: string }>`
@@ -205,20 +201,16 @@ export const getMultiOrgAuthPreflightReport = async (
         FROM pedestrians AS p
         WHERE p.height IS NOT NULL
           AND (
-            NOT (p.height > 0 AND p.height <= 300)
-            OR round((CASE WHEN p.height <= 3 THEN p.height ELSE p.height / 100 END)::numeric, 3)
-              <= 0
+            NOT (p.height > 0 AND p.height <= 3)
+            OR round(p.height::numeric, 3) <= 0
           )
         UNION ALL
         SELECT p.id::text || ':stride_length=' || p.stride_length::text AS sample
         FROM pedestrians AS p
         WHERE p.stride_length IS NOT NULL
           AND (
-            NOT (p.stride_length > 0 AND p.stride_length <= 300)
-            OR round((CASE
-                WHEN p.stride_length <= 3 THEN p.stride_length
-                ELSE p.stride_length / 100
-              END)::numeric, 3) <= 0
+            NOT (p.stride_length > 0 AND p.stride_length <= 3)
+            OR round(p.stride_length::numeric, 3) <= 0
           )
       `
       ),
@@ -284,34 +276,20 @@ export const getMultiOrgAuthPreflightReport = async (
                 AND stride_length <= 3
                 AND round(stride_length::numeric, 3) > 0
             )
-        )::integer AS already_m,
-        (
-          count(*) FILTER (
-              WHERE height > 3 AND height <= 300 AND round((height / 100)::numeric, 3) > 0
-            )
-          + count(*) FILTER (
-              WHERE stride_length > 3
-                AND stride_length <= 300
-                AND round((stride_length / 100)::numeric, 3) > 0
-            )
-        )::integer AS converted_cm,
+        )::integer AS valid_meters,
         (
           count(*) FILTER (
               WHERE height IS NOT NULL
                 AND (
-                  NOT (height > 0 AND height <= 300)
-                  OR round((CASE WHEN height <= 3 THEN height ELSE height / 100 END)::numeric, 3)
-                    <= 0
+                  NOT (height > 0 AND height <= 3)
+                  OR round(height::numeric, 3) <= 0
                 )
             )
           + count(*) FILTER (
               WHERE stride_length IS NOT NULL
                 AND (
-                  NOT (stride_length > 0 AND stride_length <= 300)
-                  OR round((CASE
-                      WHEN stride_length <= 3 THEN stride_length
-                      ELSE stride_length / 100
-                    END)::numeric, 3) <= 0
+                  NOT (stride_length > 0 AND stride_length <= 3)
+                  OR round(stride_length::numeric, 3) <= 0
                 )
             )
         )::integer AS invalid
@@ -323,7 +301,7 @@ export const getMultiOrgAuthPreflightReport = async (
   return {
     blocking: issues.some((issue) => issue.blocking),
     issues,
-    measurements: measurementRows.rows[0] ?? { already_m: 0, converted_cm: 0, invalid: 0 },
+    measurements: measurementRows.rows[0] ?? { valid_meters: 0, invalid: 0 },
   }
 }
 
@@ -466,10 +444,8 @@ export const backfillMultiOrgAuthCore = async (
 
   for (;;) {
     const rows = await sql<{
-      height_already_m: boolean
-      height_converted_cm: boolean
-      stride_already_m: boolean
-      stride_converted_cm: boolean
+      height_copied_meters: boolean
+      stride_copied_meters: boolean
     }>`
       WITH target AS (
         SELECT
@@ -494,30 +470,24 @@ export const backfillMultiOrgAuthCore = async (
         height_meters = CASE
           WHEN profile.height_meters IS NOT NULL OR target.height IS NULL
             THEN profile.height_meters
-          WHEN target.height <= 3 THEN round(target.height::numeric, 3)
-          ELSE round((target.height / 100)::numeric, 3)
+          ELSE round(target.height::numeric, 3)
         END,
         stride_length_meters = CASE
           WHEN profile.stride_length_meters IS NOT NULL OR target.stride_length IS NULL
             THEN profile.stride_length_meters
-          WHEN target.stride_length <= 3 THEN round(target.stride_length::numeric, 3)
-          ELSE round((target.stride_length / 100)::numeric, 3)
+          ELSE round(target.stride_length::numeric, 3)
         END
       FROM target
       WHERE profile.membership_id = target.membership_id
       RETURNING
-        target.height_needs_backfill AND target.height <= 3 AS height_already_m,
-        target.height_needs_backfill AND target.height > 3 AS height_converted_cm,
-        target.stride_needs_backfill AND target.stride_length <= 3 AS stride_already_m,
-        target.stride_needs_backfill AND target.stride_length > 3 AS stride_converted_cm
+        target.height_needs_backfill AS height_copied_meters,
+        target.stride_needs_backfill AS stride_copied_meters
     `.execute(executor)
 
     if (rows.rows.length === 0) break
     for (const row of rows.rows) {
-      if (row.height_already_m) result.measurement_values_already_m += 1
-      if (row.height_converted_cm) result.measurement_values_converted_cm += 1
-      if (row.stride_already_m) result.measurement_values_already_m += 1
-      if (row.stride_converted_cm) result.measurement_values_converted_cm += 1
+      if (row.height_copied_meters) result.measurement_values_copied_meters += 1
+      if (row.stride_copied_meters) result.measurement_values_copied_meters += 1
     }
   }
 
@@ -759,8 +729,16 @@ export const validateMultiOrgAuthExpandConstraints = async (
       VALIDATE CONSTRAINT organization_memberships_status_chk;
     ALTER TABLE organization_memberships
       VALIDATE CONSTRAINT organization_memberships_left_at_chk;
+    ALTER TABLE organization_member_profiles
+      VALIDATE CONSTRAINT organization_member_profiles_height_meter_bounds_chk;
+    ALTER TABLE organization_member_profiles
+      VALIDATE CONSTRAINT organization_member_profiles_stride_meter_bounds_chk;
     ALTER TABLE pedestrians
       VALIDATE CONSTRAINT pedestrians_membership_organization_fkey;
+    ALTER TABLE pedestrians
+      VALIDATE CONSTRAINT pedestrians_height_meter_bounds_chk;
+    ALTER TABLE pedestrians
+      VALIDATE CONSTRAINT pedestrians_stride_meter_bounds_chk;
     ALTER TABLE organization_invites
       VALIDATE CONSTRAINT organization_invites_creator_org_fkey;
     ALTER TABLE organization_invites

--- a/apps/kaede/src/services/migrations/multi-org-auth-backfill.ts
+++ b/apps/kaede/src/services/migrations/multi-org-auth-backfill.ts
@@ -1,6 +1,7 @@
 import { sql } from 'kysely'
-import type { RawBuilder } from 'kysely'
+import type { Kysely, RawBuilder } from 'kysely'
 import { db } from '../db/index.js'
+import type { DB } from '../db/index.js'
 import type { DbExecutor } from '../executor.js'
 
 export const canonicalGoogleIssuer = 'https://accounts.google.com'
@@ -40,6 +41,13 @@ export interface BackfillResult {
   organizations: number
   pedestrian_memberships: number
   user_profiles: number
+}
+
+export interface OneShotCutoverResult {
+  auth: BackfillResult
+  core: BackfillResult
+  revoked_sessions: number
+  validated: true
 }
 
 const emptyResult = (): BackfillResult => ({
@@ -789,3 +797,61 @@ export const validateMultiOrgAuthExpandConstraints = async (
     )
     .execute(executor)
 }
+
+/**
+ * Migrates all legacy authentication data during a single maintenance window.
+ *
+ * The application must remain stopped until this transaction and the following
+ * membership primary-key/contract migrations have completed. A failed run rolls
+ * back every data write and session revocation performed here; the application
+ * must never restart against a partially migrated database.
+ */
+export const executeOneShotMultiOrgAuthCutover = async (
+  batchSize: number,
+  database: Kysely<DB> = db
+): Promise<OneShotCutoverResult> =>
+  database.transaction().execute(async (trx) => {
+    const preflight = await getMultiOrgAuthPreflightReport(trx)
+    if (preflight.blocking) {
+      throw new Error(
+        `one-shot cutover blocked: ${preflight.issues
+          .filter((issue) => issue.blocking)
+          .map((issue) => issue.code)
+          .join(', ')}`
+      )
+    }
+
+    const core = await backfillMultiOrgAuthCore(batchSize, trx)
+    const auth = await backfillMultiOrgAuthCredentials(batchSize, trx)
+    const verification = await verifyMultiOrgAuthCoreBackfill(trx)
+    if (Object.values(verification).some((count) => count > 0)) {
+      throw new Error(`one-shot cutover verification failed: ${JSON.stringify(verification)}`)
+    }
+
+    // A second pass must be a no-op. This detects incomplete batch predicates
+    // before the old application/data contract is removed.
+    const authVerification = await backfillMultiOrgAuthCredentials(batchSize, trx)
+    if (
+      authVerification.local_credentials > 0 ||
+      authVerification.oidc_identities > 0 ||
+      authVerification.oidc_links > 0
+    ) {
+      throw new Error(`one-shot auth verification failed: ${JSON.stringify(authVerification)}`)
+    }
+
+    await validateMultiOrgAuthExpandConstraints(trx)
+
+    const revokedSessions = await sql<{ id: string }>`
+      UPDATE sessions
+      SET revoked_at = COALESCE(revoked_at, now())
+      WHERE revoked_at IS NULL
+      RETURNING id
+    `.execute(trx)
+
+    return {
+      auth,
+      core,
+      revoked_sessions: revokedSessions.rows.length,
+      validated: true,
+    }
+  })

--- a/apps/kaede/src/services/nozomi/analyze-client.test.ts
+++ b/apps/kaede/src/services/nozomi/analyze-client.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resetRuntimeConfigForTests } from '../../config/runtime.js'
+import { callbackRequestSchema } from '../../schemas/trajectories.js'
+import { submitAnalyzeRequest } from './analyze-client.js'
+import type { AnalyzeRequestPayload } from './analyze-client.js'
+
+interface TrajectoryAnalysisContract {
+  analyze_request: AnalyzeRequestPayload
+  accepted_response: {
+    trajectory_id: string
+    status: 'accepted'
+  }
+  completed_callback: unknown
+}
+
+const contract = JSON.parse(
+  readFileSync(
+    new URL('../../../../../contracts/kaede-nozomi/trajectory-analysis.json', import.meta.url),
+    'utf8'
+  )
+) as TrajectoryAnalysisContract
+
+describe('Kaede-Nozomi trajectory analysis contract', () => {
+  const originalFetch = globalThis.fetch
+  const originalNozomiInternalEndpoint = process.env.NOZOMI_INTERNAL_ENDPOINT
+  const originalNozomiRequestTimeoutMs = process.env.NOZOMI_REQUEST_TIMEOUT_MS
+
+  beforeEach(() => {
+    process.env.NOZOMI_INTERNAL_ENDPOINT = 'http://nozomi:8000'
+    process.env.NOZOMI_REQUEST_TIMEOUT_MS = '1000'
+    resetRuntimeConfigForTests()
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    vi.restoreAllMocks()
+    if (originalNozomiInternalEndpoint === undefined) {
+      delete process.env.NOZOMI_INTERNAL_ENDPOINT
+    } else {
+      process.env.NOZOMI_INTERNAL_ENDPOINT = originalNozomiInternalEndpoint
+    }
+    if (originalNozomiRequestTimeoutMs === undefined) {
+      delete process.env.NOZOMI_REQUEST_TIMEOUT_MS
+    } else {
+      process.env.NOZOMI_REQUEST_TIMEOUT_MS = originalNozomiRequestTimeoutMs
+    }
+    resetRuntimeConfigForTests()
+  })
+
+  it('organization-aware storage payload is sent without authentication context', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(contract.accepted_response), {
+        status: 202,
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+    globalThis.fetch = fetchMock as typeof fetch
+
+    await expect(submitAnalyzeRequest(contract.analyze_request)).resolves.toEqual(
+      contract.accepted_response
+    )
+
+    const [, request] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(typeof request.body).toBe('string')
+    if (typeof request.body !== 'string') {
+      throw new TypeError('Kaede-Nozomi request body must be JSON text')
+    }
+    expect(JSON.parse(request.body)).toEqual(contract.analyze_request)
+    expect(contract.analyze_request.result_object_key).toMatch(
+      /^organizations\/[0-9a-f-]+\/trajectories\/[0-9a-f-]+\/analyzed\/result\.csv$/
+    )
+    expect(contract.analyze_request).not.toHaveProperty('user_id')
+    expect(contract.analyze_request).not.toHaveProperty('membership_id')
+    expect(contract.analyze_request).not.toHaveProperty('session_id')
+  })
+
+  it('accepts the completed callback emitted by Nozomi', () => {
+    expect(callbackRequestSchema.parse(contract.completed_callback)).toEqual(
+      contract.completed_callback
+    )
+  })
+})

--- a/apps/kaede/src/services/organization-auth-methods/index.ts
+++ b/apps/kaede/src/services/organization-auth-methods/index.ts
@@ -1,0 +1,1 @@
+export { findPublicOrganizationAuthMethodRows } from './repository.js'

--- a/apps/kaede/src/services/organization-auth-methods/repository.ts
+++ b/apps/kaede/src/services/organization-auth-methods/repository.ts
@@ -1,0 +1,29 @@
+import { db } from '../db/index.js'
+import type { DbExecutor } from '../executor.js'
+
+export const findPublicOrganizationAuthMethodRows = async (
+  organizationSlug: string,
+  executor: DbExecutor = db
+) =>
+  executor
+    .selectFrom('organizations as organization')
+    .innerJoin(
+      'organization_auth_settings as settings',
+      'settings.organization_id',
+      'organization.id'
+    )
+    .leftJoin('organization_oidc_providers as provider', (join) =>
+      join
+        .onRef('provider.organization_id', '=', 'organization.id')
+        .on('provider.enabled', '=', true)
+    )
+    .select([
+      'settings.local_auth_enabled',
+      'settings.oidc_auth_enabled',
+      'provider.id as provider_id',
+      'provider.name as provider_display_name',
+    ])
+    .where('organization.slug', '=', organizationSlug)
+    .where('organization.status', '=', 'active')
+    .orderBy('provider.created_at', 'asc')
+    .execute()

--- a/apps/kaede/src/services/organization-auth-settings/index.ts
+++ b/apps/kaede/src/services/organization-auth-settings/index.ts
@@ -1,0 +1,1 @@
+export * from './repository.js'

--- a/apps/kaede/src/services/organization-auth-settings/repository.ts
+++ b/apps/kaede/src/services/organization-auth-settings/repository.ts
@@ -1,0 +1,95 @@
+import { sql } from 'kysely'
+import type { Insertable, Updateable } from 'kysely'
+import type { AuditEvents, OrganizationAuthSettings } from '../db/generated.js'
+import { db } from '../db/index.js'
+import type { DbExecutor } from '../executor.js'
+
+type OrganizationAuthSettingsUpdate = Pick<
+  Updateable<OrganizationAuthSettings>,
+  | 'local_auth_enabled'
+  | 'oidc_auth_enabled'
+  | 'membership_grant_ttl_seconds'
+  | 'reauthentication_interval_seconds'
+>
+
+export const findOrganizationAuthSettings = async (
+  organizationId: string,
+  executor: DbExecutor = db
+) =>
+  executor
+    .selectFrom('organization_auth_settings')
+    .selectAll()
+    .where('organization_id', '=', organizationId)
+    .executeTakeFirst()
+
+export const findOrganizationAuthSettingsForUpdate = async (
+  organizationId: string,
+  executor: DbExecutor
+) =>
+  executor
+    .selectFrom('organization_auth_settings')
+    .selectAll()
+    .where('organization_id', '=', organizationId)
+    .forUpdate()
+    .executeTakeFirst()
+
+export const findActiveOwnerMembership = async (
+  organizationId: string,
+  userId: string,
+  executor: DbExecutor = db
+) =>
+  executor
+    .selectFrom('organization_memberships')
+    .select(['id'])
+    .where('organization_id', '=', organizationId)
+    .where('user_id', '=', userId)
+    .where('role', '=', 'owner')
+    .where('status', '=', 'active')
+    .executeTakeFirst()
+
+export const findActiveOwnerMembershipForUpdate = async (
+  organizationId: string,
+  userId: string,
+  executor: DbExecutor
+) =>
+  executor
+    .selectFrom('organization_memberships')
+    .select(['id'])
+    .where('organization_id', '=', organizationId)
+    .where('user_id', '=', userId)
+    .where('role', '=', 'owner')
+    .where('status', '=', 'active')
+    .forUpdate()
+    .executeTakeFirst()
+
+export const countEnabledOidcProviders = async (
+  organizationId: string,
+  executor: DbExecutor
+): Promise<number> => {
+  const result = await executor
+    .selectFrom('organization_oidc_providers')
+    .select(sql<number>`count(*)::integer`.as('count'))
+    .where('organization_id', '=', organizationId)
+    .where('enabled', '=', true)
+    .executeTakeFirstOrThrow()
+  return result.count
+}
+
+export const updateOrganizationAuthSettings = async (
+  organizationId: string,
+  settings: OrganizationAuthSettingsUpdate,
+  executor: DbExecutor
+) =>
+  executor
+    .updateTable('organization_auth_settings')
+    .set({ ...settings, policy_version: sql`policy_version + 1` })
+    .where('organization_id', '=', organizationId)
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+export const insertOrganizationAuthSettingsAuditEvent = async (
+  event: Insertable<AuditEvents>,
+  executor: DbExecutor
+) => {
+  await executor.insertInto('audit_events').values(event).execute()
+}

--- a/apps/kaede/src/services/organization-authorization/authorization.ts
+++ b/apps/kaede/src/services/organization-authorization/authorization.ts
@@ -1,0 +1,116 @@
+import type { MembershipRole } from '../../schemas/common.js'
+import type { MembershipGrantAuthMethod, MembershipGrantContext } from './repository.js'
+
+export type MembershipReauthenticationReason =
+  | 'grant_missing'
+  | 'grant_revoked'
+  | 'grant_expired'
+  | 'reauthentication_interval_elapsed'
+  | 'policy_changed'
+  | 'auth_method_not_allowed'
+
+export type MembershipGrantAuthorization =
+  | {
+      ok: true
+      membershipId: string
+      role: MembershipRole
+      authMethod: MembershipGrantAuthMethod
+      authenticatedAt: Date
+      expiresAt: Date
+    }
+  | { ok: false; type: 'organization_forbidden' }
+  | { ok: false; type: 'role_forbidden'; membershipId: string }
+  | {
+      ok: false
+      type: 'reauthentication_required'
+      membershipId: string
+      reason: MembershipReauthenticationReason
+      allowedAuthMethods: MembershipGrantAuthMethod[]
+    }
+
+const roleRanks = {
+  member: 1,
+  manager: 2,
+  owner: 3,
+} satisfies Record<MembershipRole, number>
+
+const isMembershipRole = (role: string): role is MembershipRole => role in roleRanks
+
+const allowedAuthMethods = (context: MembershipGrantContext): MembershipGrantAuthMethod[] => {
+  const methods: MembershipGrantAuthMethod[] = []
+  if (context.local_auth_enabled) methods.push('local')
+  if (context.oidc_auth_enabled) methods.push('oidc')
+  return methods
+}
+
+export const evaluateMembershipGrant = (
+  context: MembershipGrantContext | undefined,
+  requiredRole: MembershipRole,
+  now: Date
+): MembershipGrantAuthorization => {
+  if (
+    context?.organization_status !== 'active' ||
+    context.membership_status !== 'active' ||
+    context.membership_left_at !== null ||
+    !isMembershipRole(context.membership_role)
+  ) {
+    return { ok: false, type: 'organization_forbidden' }
+  }
+
+  const reauthenticationRequired = (
+    reason: MembershipReauthenticationReason
+  ): MembershipGrantAuthorization => ({
+    ok: false,
+    type: 'reauthentication_required',
+    membershipId: context.membership_id,
+    reason,
+    allowedAuthMethods: allowedAuthMethods(context),
+  })
+
+  if (
+    !context.grant_auth_method ||
+    !context.grant_policy_version ||
+    !context.grant_authenticated_at ||
+    !context.grant_expires_at
+  ) {
+    return reauthenticationRequired('grant_missing')
+  }
+  if (context.grant_revoked_at) return reauthenticationRequired('grant_revoked')
+  if (context.grant_expires_at <= now) return reauthenticationRequired('grant_expired')
+  if (context.grant_policy_version !== context.current_policy_version) {
+    return reauthenticationRequired('policy_changed')
+  }
+
+  const localAllowed =
+    context.grant_auth_method === 'local' &&
+    context.local_auth_enabled &&
+    context.local_credential_enabled === true
+  const oidcAllowed =
+    context.grant_auth_method === 'oidc' &&
+    context.oidc_auth_enabled &&
+    context.oidc_identity_revoked_at === null &&
+    context.oidc_provider_enabled === true
+  if (!localAllowed && !oidcAllowed) {
+    return reauthenticationRequired('auth_method_not_allowed')
+  }
+
+  if (
+    context.grant_authenticated_at.getTime() + context.reauthentication_interval_seconds * 1000 <=
+    now.getTime()
+  ) {
+    return reauthenticationRequired('reauthentication_interval_elapsed')
+  }
+
+  if (roleRanks[context.membership_role] < roleRanks[requiredRole]) {
+    return { ok: false, type: 'role_forbidden', membershipId: context.membership_id }
+  }
+
+  return {
+    ok: true,
+    membershipId: context.membership_id,
+    role: context.membership_role,
+    authMethod: context.grant_auth_method as MembershipGrantAuthMethod,
+    authenticatedAt: context.grant_authenticated_at,
+    expiresAt: context.grant_expires_at,
+  }
+}

--- a/apps/kaede/src/services/organization-authorization/authorization.ts
+++ b/apps/kaede/src/services/organization-authorization/authorization.ts
@@ -16,7 +16,9 @@ export type MembershipGrantAuthorization =
       role: MembershipRole
       authMethod: MembershipGrantAuthMethod
       authenticatedAt: Date
+      reauthenticationRequiredAt: Date
       expiresAt: Date
+      effectiveExpiresAt: Date
     }
   | { ok: false; type: 'organization_forbidden' }
   | { ok: false; type: 'role_forbidden'; membershipId: string }
@@ -36,10 +38,12 @@ const roleRanks = {
 
 const isMembershipRole = (role: string): role is MembershipRole => role in roleRanks
 
-const allowedAuthMethods = (context: MembershipGrantContext): MembershipGrantAuthMethod[] => {
+export const membershipAllowedAuthMethods = (
+  context: MembershipGrantContext
+): MembershipGrantAuthMethod[] => {
   const methods: MembershipGrantAuthMethod[] = []
   if (context.local_auth_enabled) methods.push('local')
-  if (context.oidc_auth_enabled) methods.push('oidc')
+  if (context.oidc_auth_enabled && context.has_enabled_oidc_provider) methods.push('oidc')
   return methods
 }
 
@@ -50,6 +54,7 @@ export const evaluateMembershipGrant = (
 ): MembershipGrantAuthorization => {
   if (
     context?.organization_status !== 'active' ||
+    !context.auth_settings_available ||
     context.membership_status !== 'active' ||
     context.membership_left_at !== null ||
     !isMembershipRole(context.membership_role)
@@ -64,14 +69,15 @@ export const evaluateMembershipGrant = (
     type: 'reauthentication_required',
     membershipId: context.membership_id,
     reason,
-    allowedAuthMethods: allowedAuthMethods(context),
+    allowedAuthMethods: membershipAllowedAuthMethods(context),
   })
 
   if (
     !context.grant_auth_method ||
     !context.grant_policy_version ||
     !context.grant_authenticated_at ||
-    !context.grant_expires_at
+    !context.grant_expires_at ||
+    context.reauthentication_interval_seconds === null
   ) {
     return reauthenticationRequired('grant_missing')
   }
@@ -105,12 +111,21 @@ export const evaluateMembershipGrant = (
     return { ok: false, type: 'role_forbidden', membershipId: context.membership_id }
   }
 
+  const reauthenticationRequiredAt = new Date(
+    context.grant_authenticated_at.getTime() + context.reauthentication_interval_seconds * 1000
+  )
+
   return {
     ok: true,
     membershipId: context.membership_id,
     role: context.membership_role,
     authMethod: context.grant_auth_method as MembershipGrantAuthMethod,
     authenticatedAt: context.grant_authenticated_at,
+    reauthenticationRequiredAt,
     expiresAt: context.grant_expires_at,
+    effectiveExpiresAt:
+      reauthenticationRequiredAt <= context.grant_expires_at
+        ? reauthenticationRequiredAt
+        : context.grant_expires_at,
   }
 }

--- a/apps/kaede/src/services/organization-authorization/index.ts
+++ b/apps/kaede/src/services/organization-authorization/index.ts
@@ -1,4 +1,4 @@
-export { evaluateMembershipGrant } from './authorization.js'
+export { evaluateMembershipGrant, membershipAllowedAuthMethods } from './authorization.js'
 export type {
   MembershipGrantAuthorization,
   MembershipReauthenticationReason,

--- a/apps/kaede/src/services/organization-authorization/index.ts
+++ b/apps/kaede/src/services/organization-authorization/index.ts
@@ -1,0 +1,7 @@
+export { evaluateMembershipGrant } from './authorization.js'
+export type {
+  MembershipGrantAuthorization,
+  MembershipReauthenticationReason,
+} from './authorization.js'
+export { findMembershipGrantContext, listMembershipGrantContexts } from './repository.js'
+export type { MembershipGrantAuthMethod, MembershipGrantContext } from './repository.js'

--- a/apps/kaede/src/services/organization-authorization/repository.ts
+++ b/apps/kaede/src/services/organization-authorization/repository.ts
@@ -1,0 +1,104 @@
+import { db } from '../db/index.js'
+import type { DbExecutor } from '../executor.js'
+
+export type MembershipGrantAuthMethod = 'local' | 'oidc'
+
+export interface MembershipGrantContext {
+  organization_id: string
+  membership_id: string
+  membership_role: string
+  membership_status: string | null
+  membership_left_at: Date | null
+  organization_status: string | null
+  local_auth_enabled: boolean
+  oidc_auth_enabled: boolean
+  current_policy_version: string
+  reauthentication_interval_seconds: number
+  grant_auth_method: string | null
+  grant_policy_version: string | null
+  grant_authenticated_at: Date | null
+  grant_expires_at: Date | null
+  grant_revoked_at: Date | null
+  local_credential_enabled: boolean | null
+  oidc_identity_revoked_at: Date | null
+  oidc_provider_enabled: boolean | null
+}
+
+const membershipGrantContextQuery = (sessionId: string, userId: string, executor: DbExecutor) =>
+  executor
+    .selectFrom('organization_memberships as membership')
+    .innerJoin('organizations as organization', 'organization.id', 'membership.organization_id')
+    .innerJoin(
+      'organization_auth_settings as auth_settings',
+      'auth_settings.organization_id',
+      'membership.organization_id'
+    )
+    .leftJoin('session_membership_authentications as grant', (join) =>
+      join
+        .onRef('grant.membership_id', '=', 'membership.id')
+        .on('grant.session_id', '=', sessionId)
+        .on('grant.user_id', '=', userId)
+    )
+    .leftJoin('organization_local_credentials as local_credential', (join) =>
+      join
+        .onRef('local_credential.id', '=', 'grant.local_credential_id')
+        .onRef('local_credential.membership_id', '=', 'membership.id')
+    )
+    .leftJoin('organization_member_oidc_identities as oidc_identity', (join) =>
+      join
+        .onRef('oidc_identity.id', '=', 'grant.member_oidc_identity_id')
+        .onRef('oidc_identity.membership_id', '=', 'membership.id')
+    )
+    .leftJoin('organization_oidc_providers as oidc_provider', (join) =>
+      join.onRef('oidc_provider.id', '=', 'oidc_identity.organization_oidc_provider_id')
+    )
+    .select([
+      'membership.organization_id',
+      'membership.id as membership_id',
+      'membership.role as membership_role',
+      'membership.status as membership_status',
+      'membership.left_at as membership_left_at',
+      'organization.status as organization_status',
+      'auth_settings.local_auth_enabled',
+      'auth_settings.oidc_auth_enabled',
+      'auth_settings.policy_version as current_policy_version',
+      'auth_settings.reauthentication_interval_seconds',
+      'grant.auth_method as grant_auth_method',
+      'grant.policy_version as grant_policy_version',
+      'grant.authenticated_at as grant_authenticated_at',
+      'grant.expires_at as grant_expires_at',
+      'grant.revoked_at as grant_revoked_at',
+      'local_credential.enabled as local_credential_enabled',
+      'oidc_identity.revoked_at as oidc_identity_revoked_at',
+      'oidc_provider.enabled as oidc_provider_enabled',
+    ])
+    .where('membership.user_id', '=', userId)
+    .where('membership.status', 'in', ['active', 'suspended'])
+
+export const findMembershipGrantContext = async (
+  sessionId: string,
+  userId: string,
+  organizationId: string,
+  executor: DbExecutor = db
+): Promise<MembershipGrantContext | undefined> => {
+  const context = await membershipGrantContextQuery(sessionId, userId, executor)
+    .where('membership.organization_id', '=', organizationId)
+    .executeTakeFirst()
+
+  if (!context?.membership_id) return undefined
+  return { ...context, membership_id: context.membership_id }
+}
+
+export const listMembershipGrantContexts = async (
+  sessionId: string,
+  userId: string,
+  executor: DbExecutor = db
+): Promise<MembershipGrantContext[]> => {
+  const contexts = await membershipGrantContextQuery(sessionId, userId, executor)
+    .orderBy('organization_id', 'asc')
+    .execute()
+
+  return contexts.filter(
+    (context): context is MembershipGrantContext => context.membership_id !== null
+  )
+}

--- a/apps/kaede/src/services/organization-authorization/repository.ts
+++ b/apps/kaede/src/services/organization-authorization/repository.ts
@@ -7,7 +7,7 @@ export interface MembershipGrantContext {
   organization_id: string
   membership_id: string
   membership_role: string
-  membership_status: string | null
+  membership_status: string
   membership_left_at: Date | null
   organization_status: string | null
   local_auth_enabled: boolean
@@ -85,8 +85,7 @@ export const findMembershipGrantContext = async (
     .where('membership.organization_id', '=', organizationId)
     .executeTakeFirst()
 
-  if (!context?.membership_id) return undefined
-  return { ...context, membership_id: context.membership_id }
+  return context
 }
 
 export const listMembershipGrantContexts = async (
@@ -98,7 +97,5 @@ export const listMembershipGrantContexts = async (
     .orderBy('organization_id', 'asc')
     .execute()
 
-  return contexts.filter(
-    (context): context is MembershipGrantContext => context.membership_id !== null
-  )
+  return contexts
 }

--- a/apps/kaede/src/services/organization-authorization/repository.ts
+++ b/apps/kaede/src/services/organization-authorization/repository.ts
@@ -1,3 +1,4 @@
+import { sql } from 'kysely'
 import { db } from '../db/index.js'
 import type { DbExecutor } from '../executor.js'
 
@@ -5,15 +6,19 @@ export type MembershipGrantAuthMethod = 'local' | 'oidc'
 
 export interface MembershipGrantContext {
   organization_id: string
+  organization_name: string
+  organization_slug: string
   membership_id: string
   membership_role: string
   membership_status: string
   membership_left_at: Date | null
   organization_status: string | null
-  local_auth_enabled: boolean
-  oidc_auth_enabled: boolean
-  current_policy_version: string
-  reauthentication_interval_seconds: number
+  auth_settings_available: boolean
+  local_auth_enabled: boolean | null
+  oidc_auth_enabled: boolean | null
+  has_enabled_oidc_provider: boolean
+  current_policy_version: string | null
+  reauthentication_interval_seconds: number | null
   grant_auth_method: string | null
   grant_policy_version: string | null
   grant_authenticated_at: Date | null
@@ -28,7 +33,7 @@ const membershipGrantContextQuery = (sessionId: string, userId: string, executor
   executor
     .selectFrom('organization_memberships as membership')
     .innerJoin('organizations as organization', 'organization.id', 'membership.organization_id')
-    .innerJoin(
+    .leftJoin(
       'organization_auth_settings as auth_settings',
       'auth_settings.organization_id',
       'membership.organization_id'
@@ -54,13 +59,22 @@ const membershipGrantContextQuery = (sessionId: string, userId: string, executor
     )
     .select([
       'membership.organization_id',
+      'organization.name as organization_name',
+      'organization.slug as organization_slug',
       'membership.id as membership_id',
       'membership.role as membership_role',
       'membership.status as membership_status',
       'membership.left_at as membership_left_at',
       'organization.status as organization_status',
+      sql<boolean>`auth_settings.organization_id IS NOT NULL`.as('auth_settings_available'),
       'auth_settings.local_auth_enabled',
       'auth_settings.oidc_auth_enabled',
+      sql<boolean>`EXISTS (
+        SELECT 1
+        FROM organization_oidc_providers AS available_provider
+        WHERE available_provider.organization_id = membership.organization_id
+          AND available_provider.enabled = true
+      )`.as('has_enabled_oidc_provider'),
       'auth_settings.policy_version as current_policy_version',
       'auth_settings.reauthentication_interval_seconds',
       'grant.auth_method as grant_auth_method',

--- a/apps/kaede/src/services/organization-invites/index.ts
+++ b/apps/kaede/src/services/organization-invites/index.ts
@@ -3,6 +3,7 @@ export {
   findActorMembership,
   findActorMembershipForUpdate,
   findEnabledLocalCredentialByEmail,
+  findInviteContextByIdForUpdate,
   findInviteContextByTokenHash,
   findInviteContextByTokenHashForUpdate,
   findMembershipStateForInvite,

--- a/apps/kaede/src/services/organization-invites/index.ts
+++ b/apps/kaede/src/services/organization-invites/index.ts
@@ -1,0 +1,16 @@
+export {
+  consumeOrganizationInvite,
+  findActorMembership,
+  findActorMembershipForUpdate,
+  findEnabledLocalCredentialByEmail,
+  findInviteContextByTokenHash,
+  findInviteContextByTokenHashForUpdate,
+  findMembershipStateForInvite,
+  findOrganizationInviteForUpdate,
+  insertOrganizationInvite,
+  insertOrganizationLocalCredential,
+  insertOrganizationMembershipForInvite,
+  listOrganizationInvites,
+  revokeOrganizationInvite,
+} from './repository.js'
+export type { OrganizationInvite } from './repository.js'

--- a/apps/kaede/src/services/organization-invites/repository.ts
+++ b/apps/kaede/src/services/organization-invites/repository.ts
@@ -134,6 +134,18 @@ export const findInviteContextByTokenHashForUpdate = async (
     .executeTakeFirst()
 }
 
+export const findInviteContextByIdForUpdate = async (
+  inviteId: string,
+  organizationId: string,
+  executor: DbExecutor
+) => {
+  return inviteContextQuery(executor)
+    .where('invite.id', '=', inviteId)
+    .where('invite.organization_id', '=', organizationId)
+    .forUpdate('invite')
+    .executeTakeFirst()
+}
+
 export const findMembershipStateForInvite = async (
   organizationId: string,
   userId: string,

--- a/apps/kaede/src/services/organization-invites/repository.ts
+++ b/apps/kaede/src/services/organization-invites/repository.ts
@@ -110,6 +110,7 @@ const inviteContextQuery = (executor: DbExecutor) =>
       'invite.revoked_at',
       'invite.redeemed_at',
       'organization.name as organization_name',
+      'organization.slug as organization_slug',
       'organization.status as organization_status',
       'auth_settings.local_auth_enabled',
       'auth_settings.oidc_auth_enabled',

--- a/apps/kaede/src/services/organization-invites/repository.ts
+++ b/apps/kaede/src/services/organization-invites/repository.ts
@@ -1,0 +1,211 @@
+import { sql } from 'kysely'
+import type { Insertable, Selectable } from 'kysely'
+import type {
+  OrganizationInvites,
+  OrganizationLocalCredentials,
+  OrganizationMemberships,
+} from '../db/generated.js'
+import { db } from '../db/index.js'
+import type { DbExecutor } from '../executor.js'
+
+export type OrganizationInvite = Selectable<OrganizationInvites>
+
+export const findActorMembershipForUpdate = async (
+  organizationId: string,
+  userId: string,
+  executor: DbExecutor
+) => {
+  return executor
+    .selectFrom('organization_memberships')
+    .selectAll()
+    .where('organization_id', '=', organizationId)
+    .where('user_id', '=', userId)
+    .where('status', 'in', ['active', 'suspended'])
+    .forUpdate()
+    .executeTakeFirst()
+}
+
+export const findActorMembership = async (
+  organizationId: string,
+  userId: string,
+  executor: DbExecutor = db
+) => {
+  return executor
+    .selectFrom('organization_memberships')
+    .selectAll()
+    .where('organization_id', '=', organizationId)
+    .where('user_id', '=', userId)
+    .where('status', 'in', ['active', 'suspended'])
+    .executeTakeFirst()
+}
+
+export const insertOrganizationInvite = async (
+  invite: Insertable<OrganizationInvites>,
+  executor: DbExecutor
+): Promise<OrganizationInvite> => {
+  return executor
+    .insertInto('organization_invites')
+    .values(invite)
+    .returningAll()
+    .executeTakeFirstOrThrow()
+}
+
+export const listOrganizationInvites = async (
+  organizationId: string,
+  roles: ('member' | 'manager')[],
+  executor: DbExecutor = db
+): Promise<OrganizationInvite[]> => {
+  return executor
+    .selectFrom('organization_invites')
+    .selectAll()
+    .where('organization_id', '=', organizationId)
+    .where('role', 'in', roles)
+    .orderBy('created_at', 'desc')
+    .execute()
+}
+
+export const findOrganizationInviteForUpdate = async (
+  organizationId: string,
+  inviteId: string,
+  executor: DbExecutor
+): Promise<OrganizationInvite | undefined> => {
+  return executor
+    .selectFrom('organization_invites')
+    .selectAll()
+    .where('organization_id', '=', organizationId)
+    .where('id', '=', inviteId)
+    .forUpdate()
+    .executeTakeFirst()
+}
+
+export const revokeOrganizationInvite = async (
+  inviteId: string,
+  revokedAt: Date,
+  executor: DbExecutor
+) => {
+  return executor
+    .updateTable('organization_invites')
+    .set({ revoked_at: revokedAt })
+    .where('id', '=', inviteId)
+    .where('redeemed_at', 'is', null)
+    .where('revoked_at', 'is', null)
+    .returningAll()
+    .executeTakeFirst()
+}
+
+const inviteContextQuery = (executor: DbExecutor) =>
+  executor
+    .selectFrom('organization_invites as invite')
+    .innerJoin('organizations as organization', 'organization.id', 'invite.organization_id')
+    .leftJoin(
+      'organization_auth_settings as auth_settings',
+      'auth_settings.organization_id',
+      'organization.id'
+    )
+    .select([
+      'invite.id as invite_id',
+      'invite.organization_id',
+      'invite.role',
+      'invite.expires_at',
+      'invite.revoked_at',
+      'invite.redeemed_at',
+      'organization.name as organization_name',
+      'organization.status as organization_status',
+      'auth_settings.local_auth_enabled',
+      'auth_settings.oidc_auth_enabled',
+      'auth_settings.policy_version',
+      'auth_settings.membership_grant_ttl_seconds',
+    ])
+
+export const findInviteContextByTokenHash = async (
+  tokenHash: string,
+  executor: DbExecutor = db
+) => {
+  return inviteContextQuery(executor).where('invite.token_hash', '=', tokenHash).executeTakeFirst()
+}
+
+export const findInviteContextByTokenHashForUpdate = async (
+  tokenHash: string,
+  executor: DbExecutor
+) => {
+  return inviteContextQuery(executor)
+    .where('invite.token_hash', '=', tokenHash)
+    .forUpdate('invite')
+    .executeTakeFirst()
+}
+
+export const findMembershipStateForInvite = async (
+  organizationId: string,
+  userId: string,
+  executor: DbExecutor
+) => {
+  return executor
+    .selectFrom('organization_memberships')
+    .selectAll()
+    .where('organization_id', '=', organizationId)
+    .where('user_id', '=', userId)
+    .orderBy(
+      sql<number>`CASE status WHEN 'active' THEN 0 WHEN 'suspended' THEN 1 ELSE 2 END`,
+      'asc'
+    )
+    .orderBy('joined_at', 'desc')
+    .forUpdate()
+    .executeTakeFirst()
+}
+
+export const findEnabledLocalCredentialByEmail = async (
+  organizationId: string,
+  normalizedLoginEmail: string,
+  executor: DbExecutor
+) => {
+  return executor
+    .selectFrom('organization_local_credentials')
+    .select(['id'])
+    .where('organization_id', '=', organizationId)
+    .where('normalized_login_email', '=', normalizedLoginEmail)
+    .where('enabled', '=', true)
+    .executeTakeFirst()
+}
+
+export const insertOrganizationMembershipForInvite = async (
+  membership: Insertable<OrganizationMemberships>,
+  executor: DbExecutor
+) => {
+  return executor
+    .insertInto('organization_memberships')
+    .values(membership)
+    .returningAll()
+    .executeTakeFirstOrThrow()
+}
+
+export const insertOrganizationLocalCredential = async (
+  credential: Insertable<OrganizationLocalCredentials>,
+  executor: DbExecutor
+) => {
+  return executor
+    .insertInto('organization_local_credentials')
+    .values(credential)
+    .returningAll()
+    .executeTakeFirstOrThrow()
+}
+
+export const consumeOrganizationInvite = async (
+  inviteId: string,
+  membershipId: string,
+  consumedAt: Date,
+  executor: DbExecutor
+) => {
+  return executor
+    .updateTable('organization_invites')
+    .set({
+      redeemed_at: consumedAt,
+      redeemed_membership_id: membershipId,
+      used_count: 1,
+    })
+    .where('id', '=', inviteId)
+    .where('redeemed_at', 'is', null)
+    .where('revoked_at', 'is', null)
+    .where('expires_at', '>', consumedAt)
+    .returningAll()
+    .executeTakeFirst()
+}

--- a/apps/kaede/src/services/organization-local-auth/index.ts
+++ b/apps/kaede/src/services/organization-local-auth/index.ts
@@ -1,0 +1,9 @@
+export {
+  findLocalCredentialContextForUpdate,
+  findOrganizationLocalAuthPolicyBySlug,
+  hasLocalAuthenticationGrantBySessionId,
+  insertAuthenticationEvent,
+  normalizeLocalLoginEmail,
+  updateLocalCredentialAttempts,
+  upsertLocalMembershipGrant,
+} from './repository.js'

--- a/apps/kaede/src/services/organization-local-auth/repository.ts
+++ b/apps/kaede/src/services/organization-local-auth/repository.ts
@@ -1,0 +1,127 @@
+import type { Insertable, Selectable } from 'kysely'
+import type {
+  AuthenticationEvents,
+  OrganizationLocalCredentials,
+  SessionMembershipAuthentications,
+} from '../db/generated.js'
+import { db } from '../db/index.js'
+import type { DbExecutor } from '../executor.js'
+
+export type OrganizationLocalCredential = Selectable<OrganizationLocalCredentials>
+
+export const normalizeLocalLoginEmail = (email: string) => email.trim().toLowerCase()
+
+export const findOrganizationLocalAuthPolicyBySlug = async (
+  organizationSlug: string,
+  executor: DbExecutor = db
+) => {
+  return executor
+    .selectFrom('organizations as organization')
+    .innerJoin(
+      'organization_auth_settings as auth_settings',
+      'auth_settings.organization_id',
+      'organization.id'
+    )
+    .select([
+      'organization.id as organization_id',
+      'organization.status as organization_status',
+      'auth_settings.local_auth_enabled',
+      'auth_settings.policy_version',
+      'auth_settings.membership_grant_ttl_seconds',
+    ])
+    .where('organization.slug', '=', organizationSlug)
+    .executeTakeFirst()
+}
+
+export const findLocalCredentialContextForUpdate = async (
+  organizationId: string,
+  normalizedLoginEmail: string,
+  executor: DbExecutor
+) => {
+  return executor
+    .selectFrom('organization_local_credentials as credential')
+    .innerJoin(
+      'organization_memberships as membership',
+      'membership.id',
+      'credential.membership_id'
+    )
+    .innerJoin('users as user', 'user.id', 'membership.user_id')
+    .select([
+      'credential.id as credential_id',
+      'credential.membership_id',
+      'credential.organization_id',
+      'credential.password_hash',
+      'credential.failed_login_attempts',
+      'credential.locked_until',
+      'credential.enabled as credential_enabled',
+      'membership.user_id',
+      'membership.role as membership_role',
+      'membership.status as membership_status',
+      'user.status as user_status',
+    ])
+    .where('credential.organization_id', '=', organizationId)
+    .where('credential.normalized_login_email', '=', normalizedLoginEmail)
+    .where('credential.enabled', '=', true)
+    .forUpdate()
+    .executeTakeFirst()
+}
+
+export const updateLocalCredentialAttempts = async (
+  credentialId: string,
+  values: { failed_login_attempts: number; locked_until: Date | null },
+  executor: DbExecutor
+) => {
+  return executor
+    .updateTable('organization_local_credentials')
+    .set(values)
+    .where('id', '=', credentialId)
+    .executeTakeFirst()
+}
+
+export const hasLocalAuthenticationGrantBySessionId = async (
+  sessionId: string,
+  executor: DbExecutor = db
+) => {
+  const grant = await executor
+    .selectFrom('session_membership_authentications')
+    .select('session_id')
+    .where('session_id', '=', sessionId)
+    .where('auth_method', '=', 'local')
+    .executeTakeFirst()
+
+  return grant !== undefined
+}
+
+export const upsertLocalMembershipGrant = async (
+  grant: Insertable<SessionMembershipAuthentications>,
+  executor: DbExecutor
+) => {
+  return executor
+    .insertInto('session_membership_authentications')
+    .values(grant)
+    .onConflict((oc) =>
+      oc.columns(['session_id', 'membership_id']).doUpdateSet({
+        user_id: grant.user_id,
+        auth_method: grant.auth_method,
+        policy_version: grant.policy_version,
+        local_credential_id: grant.local_credential_id,
+        member_oidc_identity_id: null,
+        authenticated_at: grant.authenticated_at,
+        expires_at: grant.expires_at,
+        revoked_at: null,
+      })
+    )
+    .returningAll()
+    .executeTakeFirstOrThrow()
+}
+
+export const insertAuthenticationEvent = async (
+  event: Insertable<AuthenticationEvents>,
+  executor: DbExecutor
+) => {
+  return executor
+    .insertInto('authentication_events')
+    .values(event)
+    .returningAll()
+    .executeTakeFirstOrThrow()
+}

--- a/apps/kaede/src/services/organization-local-credentials/index.ts
+++ b/apps/kaede/src/services/organization-local-credentials/index.ts
@@ -1,0 +1,1 @@
+export * from './repository.js'

--- a/apps/kaede/src/services/organization-local-credentials/repository.ts
+++ b/apps/kaede/src/services/organization-local-credentials/repository.ts
@@ -1,0 +1,171 @@
+import type { Insertable, Updateable } from 'kysely'
+import type { AuditEvents, OrganizationLocalCredentials } from '../db/generated.js'
+import { db } from '../db/index.js'
+import type { DbExecutor } from '../executor.js'
+
+export const findLocalCredentialMembershipContext = async (
+  organizationId: string,
+  userId: string,
+  executor: DbExecutor = db,
+  lock = false
+) => {
+  let query = executor
+    .selectFrom('organization_memberships as membership')
+    .innerJoin('organizations as organization', 'organization.id', 'membership.organization_id')
+    .innerJoin(
+      'organization_auth_settings as settings',
+      'settings.organization_id',
+      'organization.id'
+    )
+    .select([
+      'membership.id as membership_id',
+      'membership.organization_id',
+      'membership.user_id',
+      'settings.local_auth_enabled',
+      'settings.policy_version',
+      'settings.reauthentication_interval_seconds',
+    ])
+    .where('membership.organization_id', '=', organizationId)
+    .where('membership.user_id', '=', userId)
+    .where('membership.status', '=', 'active')
+    .where('organization.status', '=', 'active')
+
+  if (lock) query = query.forUpdate('membership')
+  return query.executeTakeFirst()
+}
+
+export const findLocalCredentialByMembership = async (
+  membershipId: string,
+  executor: DbExecutor = db,
+  lock = false
+) => {
+  let query = executor
+    .selectFrom('organization_local_credentials')
+    .selectAll()
+    .where('membership_id', '=', membershipId)
+
+  if (lock) query = query.forUpdate()
+  return query.executeTakeFirst()
+}
+
+export const findRecentCredentialManagementGrant = async (
+  sessionId: string,
+  membershipId: string,
+  userId: string,
+  policyVersion: string,
+  reauthenticatedAfter: Date,
+  now: Date,
+  executor: DbExecutor
+) =>
+  executor
+    .selectFrom('session_membership_authentications')
+    .select('session_id')
+    .where('session_id', '=', sessionId)
+    .where('membership_id', '=', membershipId)
+    .where('user_id', '=', userId)
+    .where('policy_version', '=', policyVersion)
+    .where('authenticated_at', '>=', reauthenticatedAfter)
+    .where('expires_at', '>', now)
+    .where('revoked_at', 'is', null)
+    .executeTakeFirst()
+
+export const findRecentUserSession = async (
+  sessionId: string,
+  userId: string,
+  authenticatedAfter: Date,
+  now: Date,
+  executor: DbExecutor
+) =>
+  executor
+    .selectFrom('sessions')
+    .select('id')
+    .where('id', '=', sessionId)
+    .where('user_id', '=', userId)
+    .where('created_at', '>=', authenticatedAfter)
+    .where('expires_at', '>', now)
+    .where('revoked_at', 'is', null)
+    .executeTakeFirst()
+
+export const hasUsableOidcLink = async (
+  membershipId: string,
+  organizationId: string,
+  executor: DbExecutor
+) => {
+  const link = await executor
+    .selectFrom('organization_member_oidc_identities as link')
+    .innerJoin(
+      'organization_oidc_providers as provider',
+      'provider.id',
+      'link.organization_oidc_provider_id'
+    )
+    .innerJoin(
+      'organization_auth_settings as settings',
+      'settings.organization_id',
+      'link.organization_id'
+    )
+    .select('link.id')
+    .where('link.membership_id', '=', membershipId)
+    .where('link.organization_id', '=', organizationId)
+    .where('link.revoked_at', 'is', null)
+    .where('provider.enabled', '=', true)
+    .where('settings.oidc_auth_enabled', '=', true)
+    .executeTakeFirst()
+  return link !== undefined
+}
+
+export const findEnabledLocalCredentialByNormalizedEmail = async (
+  organizationId: string,
+  normalizedLoginEmail: string,
+  excludedCredentialId: string | undefined,
+  executor: DbExecutor
+) => {
+  let query = executor
+    .selectFrom('organization_local_credentials')
+    .select('id')
+    .where('organization_id', '=', organizationId)
+    .where('normalized_login_email', '=', normalizedLoginEmail)
+    .where('enabled', '=', true)
+
+  if (excludedCredentialId) query = query.where('id', '!=', excludedCredentialId)
+  return query.executeTakeFirst()
+}
+
+export const insertManagedLocalCredential = async (
+  credential: Insertable<OrganizationLocalCredentials>,
+  executor: DbExecutor
+) =>
+  executor
+    .insertInto('organization_local_credentials')
+    .values(credential)
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+export const updateManagedLocalCredential = async (
+  credentialId: string,
+  values: Updateable<OrganizationLocalCredentials>,
+  executor: DbExecutor
+) =>
+  executor
+    .updateTable('organization_local_credentials')
+    .set(values)
+    .where('id', '=', credentialId)
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+export const revokeGrantsFromLocalCredential = async (
+  credentialId: string,
+  revokedAt: Date,
+  executor: DbExecutor
+) =>
+  executor
+    .updateTable('session_membership_authentications')
+    .set({ revoked_at: revokedAt, updated_at: revokedAt })
+    .where('local_credential_id', '=', credentialId)
+    .where('auth_method', '=', 'local')
+    .where('revoked_at', 'is', null)
+    .executeTakeFirst()
+
+export const insertLocalCredentialAuditEvent = async (
+  event: Insertable<AuditEvents>,
+  executor: DbExecutor
+) => executor.insertInto('audit_events').values(event).executeTakeFirst()

--- a/apps/kaede/src/services/organization-oidc-auth/index.ts
+++ b/apps/kaede/src/services/organization-oidc-auth/index.ts
@@ -1,0 +1,2 @@
+export * from './repository.js'
+export * from './security.js'

--- a/apps/kaede/src/services/organization-oidc-auth/repository.ts
+++ b/apps/kaede/src/services/organization-oidc-auth/repository.ts
@@ -228,6 +228,21 @@ export const findActiveOidcMembershipLink = async (
     .where('link.revoked_at', 'is', null)
     .executeTakeFirst()
 
+export const revokeActiveOidcMembershipLink = async (
+  providerId: string,
+  identityId: string,
+  revokedAt: Date,
+  executor: DbExecutor
+) =>
+  executor
+    .updateTable('organization_member_oidc_identities')
+    .set({ revoked_at: revokedAt })
+    .where('organization_oidc_provider_id', '=', providerId)
+    .where('oidc_identity_id', '=', identityId)
+    .where('revoked_at', 'is', null)
+    .returningAll()
+    .executeTakeFirst()
+
 export const upsertOidcMembershipLink = async (
   link: Insertable<OrganizationMemberOidcIdentities>,
   executor: DbExecutor

--- a/apps/kaede/src/services/organization-oidc-auth/repository.ts
+++ b/apps/kaede/src/services/organization-oidc-auth/repository.ts
@@ -1,0 +1,350 @@
+import { sql } from 'kysely'
+import type { Insertable } from 'kysely'
+import type {
+  AuditEvents,
+  AuthenticationEvents,
+  OidcIdentities,
+  OidcLoginTransactions,
+  OrganizationMemberOidcIdentities,
+  OrganizationOidcProviders,
+  SessionMembershipAuthentications,
+} from '../db/generated.js'
+import { db } from '../db/index.js'
+import type { DbExecutor } from '../executor.js'
+
+export const findOrganizationOidcProviderContext = async (
+  organizationSlug: string,
+  providerId: string,
+  executor: DbExecutor = db
+) =>
+  executor
+    .selectFrom('organization_oidc_providers as provider')
+    .innerJoin('organizations as organization', 'organization.id', 'provider.organization_id')
+    .innerJoin(
+      'organization_auth_settings as settings',
+      'settings.organization_id',
+      'organization.id'
+    )
+    .select([
+      'provider.id as provider_id',
+      'provider.organization_id',
+      'provider.name as provider_name',
+      'provider.issuer',
+      'provider.client_id',
+      'provider.scopes',
+      'provider.allowed_hosted_domains',
+      'provider.enabled as provider_enabled',
+      'organization.status as organization_status',
+      'settings.oidc_auth_enabled',
+      'settings.policy_version',
+      'settings.membership_grant_ttl_seconds',
+      'settings.reauthentication_interval_seconds',
+    ])
+    .where('organization.slug', '=', organizationSlug)
+    .where('provider.id', '=', providerId)
+    .executeTakeFirst()
+
+export const findOrganizationOidcProviderContextById = async (
+  providerId: string,
+  executor: DbExecutor = db
+) =>
+  executor
+    .selectFrom('organization_oidc_providers as provider')
+    .innerJoin('organizations as organization', 'organization.id', 'provider.organization_id')
+    .innerJoin(
+      'organization_auth_settings as settings',
+      'settings.organization_id',
+      'organization.id'
+    )
+    .select([
+      'provider.id as provider_id',
+      'provider.organization_id',
+      'provider.name as provider_name',
+      'provider.issuer',
+      'provider.client_id',
+      'provider.scopes',
+      'provider.allowed_hosted_domains',
+      'provider.enabled as provider_enabled',
+      'organization.status as organization_status',
+      'settings.oidc_auth_enabled',
+      'settings.policy_version',
+      'settings.membership_grant_ttl_seconds',
+      'settings.reauthentication_interval_seconds',
+    ])
+    .where('provider.id', '=', providerId)
+    .executeTakeFirst()
+
+export const insertOidcLoginTransaction = async (
+  transaction: Insertable<OidcLoginTransactions>,
+  executor: DbExecutor = db
+) =>
+  executor
+    .insertInto('oidc_login_transactions')
+    .values(transaction)
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+export const claimOidcLoginTransaction = async (
+  stateHash: string,
+  now: Date,
+  executor: DbExecutor = db
+) =>
+  executor
+    .updateTable('oidc_login_transactions')
+    .set({ consumed_at: now })
+    .where('state_hash', '=', stateHash)
+    .where('consumed_at', 'is', null)
+    .where('expires_at', '>', now)
+    .returningAll()
+    .executeTakeFirst()
+
+export const oidcLoginTransactionStateExists = async (
+  stateHash: string,
+  executor: DbExecutor = db
+) =>
+  Boolean(
+    await executor
+      .selectFrom('oidc_login_transactions')
+      .select('id')
+      .where('state_hash', '=', stateHash)
+      .executeTakeFirst()
+  )
+
+export const findActiveInviteIdByTokenHash = async (
+  organizationId: string,
+  tokenHash: string,
+  now: Date,
+  executor: DbExecutor = db
+) =>
+  executor
+    .selectFrom('organization_invites')
+    .select('id')
+    .where('organization_id', '=', organizationId)
+    .where('token_hash', '=', tokenHash)
+    .where('revoked_at', 'is', null)
+    .where('redeemed_at', 'is', null)
+    .where('expires_at', '>', now)
+    .executeTakeFirst()
+
+export const findActiveMembershipByOrganizationAndUser = async (
+  organizationId: string,
+  userId: string,
+  executor: DbExecutor = db
+) =>
+  executor
+    .selectFrom('organization_memberships')
+    .selectAll()
+    .where('organization_id', '=', organizationId)
+    .where('user_id', '=', userId)
+    .where('status', '=', 'active')
+    .executeTakeFirst()
+
+export const findValidSessionById = async (
+  sessionId: string,
+  now: Date,
+  executor: DbExecutor = db
+) =>
+  executor
+    .selectFrom('sessions')
+    .selectAll()
+    .where('id', '=', sessionId)
+    .where('revoked_at', 'is', null)
+    .where('expires_at', '>', now)
+    .executeTakeFirst()
+
+export const findRecentMembershipGrant = async (
+  sessionId: string,
+  organizationId: string,
+  userId: string,
+  policyVersion: string,
+  reauthenticatedAfter: Date,
+  now: Date,
+  executor: DbExecutor = db
+) =>
+  executor
+    .selectFrom('session_membership_authentications as grant')
+    .innerJoin('organization_memberships as membership', 'membership.id', 'grant.membership_id')
+    .select(['grant.session_id', 'grant.membership_id'])
+    .where('grant.session_id', '=', sessionId)
+    .where('grant.user_id', '=', userId)
+    .where('membership.organization_id', '=', organizationId)
+    .where('membership.status', '=', 'active')
+    .where('grant.policy_version', '=', policyVersion)
+    .where('grant.authenticated_at', '>=', reauthenticatedAfter)
+    .where('grant.expires_at', '>', now)
+    .where('grant.revoked_at', 'is', null)
+    .executeTakeFirst()
+
+export const findOidcIdentity = async (
+  issuer: string,
+  subject: string,
+  executor: DbExecutor = db
+) =>
+  executor
+    .selectFrom('oidc_identities')
+    .selectAll()
+    .where('issuer', '=', issuer)
+    .where('subject', '=', subject)
+    .executeTakeFirst()
+
+export const insertOidcIdentity = async (
+  identity: Insertable<OidcIdentities>,
+  executor: DbExecutor
+) =>
+  executor.insertInto('oidc_identities').values(identity).returningAll().executeTakeFirstOrThrow()
+
+export const updateOidcIdentityClaims = async (
+  identityId: string,
+  values: { last_claimed_email: string | null; last_claimed_email_verified: boolean | null },
+  executor: DbExecutor
+) =>
+  executor
+    .updateTable('oidc_identities')
+    .set(values)
+    .where('id', '=', identityId)
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+export const findActiveOidcMembershipLink = async (
+  providerId: string,
+  identityId: string,
+  executor: DbExecutor = db
+) =>
+  executor
+    .selectFrom('organization_member_oidc_identities as link')
+    .innerJoin('organization_memberships as membership', 'membership.id', 'link.membership_id')
+    .innerJoin('users as user', 'user.id', 'link.user_id')
+    .select([
+      'link.id as link_id',
+      'link.membership_id',
+      'link.organization_id',
+      'link.user_id',
+      'membership.role as membership_role',
+      'membership.status as membership_status',
+      'user.status as user_status',
+    ])
+    .where('link.organization_oidc_provider_id', '=', providerId)
+    .where('link.oidc_identity_id', '=', identityId)
+    .where('link.revoked_at', 'is', null)
+    .executeTakeFirst()
+
+export const upsertOidcMembershipLink = async (
+  link: Insertable<OrganizationMemberOidcIdentities>,
+  executor: DbExecutor
+) => {
+  const existing = await executor
+    .selectFrom('organization_member_oidc_identities')
+    .selectAll()
+    .where('membership_id', '=', link.membership_id)
+    .where('organization_oidc_provider_id', '=', link.organization_oidc_provider_id)
+    .where('oidc_identity_id', '=', link.oidc_identity_id)
+    .executeTakeFirst()
+
+  if (existing) {
+    return executor
+      .updateTable('organization_member_oidc_identities')
+      .set({ revoked_at: null })
+      .where('id', '=', existing.id)
+      .returningAll()
+      .executeTakeFirstOrThrow()
+  }
+
+  return executor
+    .insertInto('organization_member_oidc_identities')
+    .values(link)
+    .returningAll()
+    .executeTakeFirstOrThrow()
+}
+
+export const upsertOidcMembershipGrant = async (
+  grant: Insertable<SessionMembershipAuthentications>,
+  executor: DbExecutor
+) =>
+  executor
+    .insertInto('session_membership_authentications')
+    .values(grant)
+    .onConflict((oc) =>
+      oc.columns(['session_id', 'membership_id']).doUpdateSet({
+        user_id: grant.user_id,
+        auth_method: 'oidc',
+        policy_version: grant.policy_version,
+        local_credential_id: null,
+        member_oidc_identity_id: grant.member_oidc_identity_id,
+        authenticated_at: grant.authenticated_at,
+        expires_at: grant.expires_at,
+        revoked_at: null,
+      })
+    )
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+export const insertOidcAuthenticationEvent = async (
+  event: Insertable<AuthenticationEvents>,
+  executor: DbExecutor
+) =>
+  executor
+    .insertInto('authentication_events')
+    .values(event)
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+export const insertOidcAuditEvent = async (event: Insertable<AuditEvents>, executor: DbExecutor) =>
+  executor.insertInto('audit_events').values(event).executeTakeFirst()
+
+export const listOidcProviders = async (organizationId: string, executor: DbExecutor = db) =>
+  executor
+    .selectFrom('organization_oidc_providers')
+    .selectAll()
+    .where('organization_id', '=', organizationId)
+    .orderBy('created_at', 'asc')
+    .execute()
+
+export const insertOidcProvider = async (
+  provider: Insertable<OrganizationOidcProviders>,
+  executor: DbExecutor
+) =>
+  executor
+    .insertInto('organization_oidc_providers')
+    .values(provider)
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+export const updateOidcProvider = async (
+  organizationId: string,
+  providerId: string,
+  provider: Partial<Insertable<OrganizationOidcProviders>>,
+  executor: DbExecutor
+) =>
+  executor
+    .updateTable('organization_oidc_providers')
+    .set(provider)
+    .where('organization_id', '=', organizationId)
+    .where('id', '=', providerId)
+    .returningAll()
+    .executeTakeFirst()
+
+export const findActiveOwnerMembershipForUpdate = async (
+  organizationId: string,
+  userId: string,
+  executor: DbExecutor
+) =>
+  executor
+    .selectFrom('organization_memberships')
+    .selectAll()
+    .where('organization_id', '=', organizationId)
+    .where('user_id', '=', userId)
+    .where('role', '=', 'owner')
+    .where('status', '=', 'active')
+    .forUpdate()
+    .executeTakeFirst()
+
+export const incrementOrganizationPolicyVersion = async (
+  organizationId: string,
+  executor: DbExecutor
+) =>
+  executor
+    .updateTable('organization_auth_settings')
+    .set({ policy_version: sql`policy_version + 1` })
+    .where('organization_id', '=', organizationId)
+    .returningAll()
+    .executeTakeFirstOrThrow()

--- a/apps/kaede/src/services/organization-oidc-auth/security.test.ts
+++ b/apps/kaede/src/services/organization-oidc-auth/security.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import {
+  canonicalizeOidcIssuer,
+  decryptPkceCodeVerifier,
+  encryptPkceCodeVerifier,
+  isHostedDomainAllowed,
+  normalizeHostedDomains,
+} from './security.js'
+
+describe('organization OIDC security helpers', () => {
+  it('Google issuer aliasesをcanonical issuerへ統一する', () => {
+    expect(canonicalizeOidcIssuer('accounts.google.com')).toBe('https://accounts.google.com')
+    expect(canonicalizeOidcIssuer('https://accounts.google.com')).toBe(
+      'https://accounts.google.com'
+    )
+    expect(canonicalizeOidcIssuer('https://issuer.example.test')).toBe(
+      'https://issuer.example.test'
+    )
+  })
+
+  it('PKCE verifierを暗号化して復号できる', () => {
+    const encrypted = encryptPkceCodeVerifier('code-verifier', 'transaction-secret')
+
+    expect(encrypted).not.toContain('code-verifier')
+    expect(decryptPkceCodeVerifier(encrypted, 'transaction-secret')).toBe('code-verifier')
+    expect(() => decryptPkceCodeVerifier(encrypted, 'wrong-secret')).toThrow()
+  })
+
+  it('Hosted Domain未設定なら個人Googleと任意Workspaceを許可する', () => {
+    expect(isHostedDomainAllowed(null, null)).toBe(true)
+    expect(isHostedDomainAllowed('other-workspace.example', null)).toBe(true)
+  })
+
+  it('Hosted Domain設定時だけhd一致を要求する', () => {
+    const allowed = normalizeHostedDomains([' Company-A.Example ', 'company-a.example'])
+
+    expect(allowed).toEqual(['company-a.example'])
+    expect(isHostedDomainAllowed('COMPANY-A.EXAMPLE', allowed)).toBe(true)
+    expect(isHostedDomainAllowed(null, allowed)).toBe(false)
+    expect(isHostedDomainAllowed('company-b.example', allowed)).toBe(false)
+  })
+})

--- a/apps/kaede/src/services/organization-oidc-auth/security.ts
+++ b/apps/kaede/src/services/organization-oidc-auth/security.ts
@@ -1,0 +1,58 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto'
+
+const GOOGLE_CANONICAL_ISSUER = 'https://accounts.google.com'
+const GOOGLE_ISSUER_ALIASES = new Set(['accounts.google.com', GOOGLE_CANONICAL_ISSUER])
+
+export const canonicalizeOidcIssuer = (issuer: string) =>
+  GOOGLE_ISSUER_ALIASES.has(issuer) ? GOOGLE_CANONICAL_ISSUER : issuer
+
+export const isGoogleIssuer = (issuer: string) => GOOGLE_ISSUER_ALIASES.has(issuer)
+
+export const hashOidcState = (state: string) =>
+  createHash('sha256').update(state).digest('base64url')
+
+const encryptionKey = (secret: string) => createHash('sha256').update(secret).digest()
+
+export const encryptPkceCodeVerifier = (codeVerifier: string, secret: string) => {
+  const iv = randomBytes(12)
+  const cipher = createCipheriv('aes-256-gcm', encryptionKey(secret), iv)
+  const ciphertext = Buffer.concat([cipher.update(codeVerifier, 'utf8'), cipher.final()])
+
+  return Buffer.concat([iv, cipher.getAuthTag(), ciphertext]).toString('base64url')
+}
+
+export const decryptPkceCodeVerifier = (encrypted: string, secret: string) => {
+  const payload = Buffer.from(encrypted, 'base64url')
+  if (payload.length <= 28) {
+    throw new Error('encrypted PKCE verifier is invalid')
+  }
+
+  const iv = payload.subarray(0, 12)
+  const authTag = payload.subarray(12, 28)
+  const ciphertext = payload.subarray(28)
+  const decipher = createDecipheriv('aes-256-gcm', encryptionKey(secret), iv)
+  decipher.setAuthTag(authTag)
+
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8')
+}
+
+export const normalizeHostedDomains = (domains: string[] | null | undefined) => {
+  if (!domains || domains.length === 0) return null
+
+  const normalized = [...new Set(domains.map((domain) => domain.trim().toLowerCase()))]
+  if (normalized.some((domain) => !/^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/.test(domain))) {
+    throw new Error('allowed hosted domain is invalid')
+  }
+
+  return normalized
+}
+
+export const isHostedDomainAllowed = (
+  hostedDomain: string | null,
+  allowedHostedDomains: string[] | null
+) => {
+  if (allowedHostedDomains === null) return true
+  if (!hostedDomain) return false
+
+  return allowedHostedDomains.includes(hostedDomain.trim().toLowerCase())
+}

--- a/apps/kaede/src/services/organization-oidc-links/index.ts
+++ b/apps/kaede/src/services/organization-oidc-links/index.ts
@@ -1,0 +1,1 @@
+export * from './repository.js'

--- a/apps/kaede/src/services/organization-oidc-links/repository.ts
+++ b/apps/kaede/src/services/organization-oidc-links/repository.ts
@@ -1,0 +1,162 @@
+import { sql } from 'kysely'
+import type { Insertable } from 'kysely'
+import type { AuditEvents, AuthenticationEvents } from '../db/generated.js'
+import { db } from '../db/index.js'
+import type { DbExecutor } from '../executor.js'
+
+const activeMembershipQuery = (executor: DbExecutor) =>
+  executor.selectFrom('organization_memberships').selectAll().where('status', '=', 'active')
+
+export const findActiveMembership = async (
+  organizationId: string,
+  userId: string,
+  executor: DbExecutor = db
+) =>
+  activeMembershipQuery(executor)
+    .where('organization_id', '=', organizationId)
+    .where('user_id', '=', userId)
+    .executeTakeFirst()
+
+export const findActiveMembershipForUpdate = async (
+  organizationId: string,
+  userId: string,
+  executor: DbExecutor
+) =>
+  activeMembershipQuery(executor)
+    .where('organization_id', '=', organizationId)
+    .where('user_id', '=', userId)
+    .forUpdate()
+    .executeTakeFirst()
+
+export const listActiveOrganizationOidcLinks = async (
+  membershipId: string,
+  executor: DbExecutor = db
+) =>
+  executor
+    .selectFrom('organization_member_oidc_identities as link')
+    .innerJoin(
+      'organization_oidc_providers as provider',
+      'provider.id',
+      'link.organization_oidc_provider_id'
+    )
+    .select([
+      'link.id',
+      'link.created_at as linked_at',
+      'provider.id as provider_id',
+      'provider.name as provider_name',
+      'provider.enabled as provider_enabled',
+    ])
+    .where('link.membership_id', '=', membershipId)
+    .where('link.revoked_at', 'is', null)
+    .orderBy('link.created_at', 'asc')
+    .execute()
+
+export const findOrganizationAuthSettingsForUpdate = async (
+  organizationId: string,
+  executor: DbExecutor
+) =>
+  executor
+    .selectFrom('organization_auth_settings')
+    .select(['local_auth_enabled', 'oidc_auth_enabled'])
+    .where('organization_id', '=', organizationId)
+    .forUpdate()
+    .executeTakeFirst()
+
+export const findActiveOrganizationOidcLinkForUpdate = async (
+  organizationId: string,
+  membershipId: string,
+  linkId: string,
+  executor: DbExecutor
+) =>
+  executor
+    .selectFrom('organization_member_oidc_identities as link')
+    .innerJoin(
+      'organization_oidc_providers as provider',
+      'provider.id',
+      'link.organization_oidc_provider_id'
+    )
+    .select([
+      'link.id',
+      'link.oidc_identity_id',
+      'link.organization_oidc_provider_id as provider_id',
+      'provider.enabled as provider_enabled',
+    ])
+    .where('link.id', '=', linkId)
+    .where('link.organization_id', '=', organizationId)
+    .where('link.membership_id', '=', membershipId)
+    .where('link.revoked_at', 'is', null)
+    .forUpdate('link')
+    .executeTakeFirst()
+
+export const hasEnabledLocalCredential = async (
+  membershipId: string,
+  executor: DbExecutor
+): Promise<boolean> =>
+  Boolean(
+    await executor
+      .selectFrom('organization_local_credentials')
+      .select('id')
+      .where('membership_id', '=', membershipId)
+      .where('enabled', '=', true)
+      .executeTakeFirst()
+  )
+
+export const countOtherUsableOidcLinks = async (
+  membershipId: string,
+  excludedLinkId: string,
+  executor: DbExecutor
+): Promise<number> => {
+  const result = await executor
+    .selectFrom('organization_member_oidc_identities as link')
+    .innerJoin(
+      'organization_oidc_providers as provider',
+      'provider.id',
+      'link.organization_oidc_provider_id'
+    )
+    .select(sql<number>`count(*)::integer`.as('count'))
+    .where('link.membership_id', '=', membershipId)
+    .where('link.id', '!=', excludedLinkId)
+    .where('link.revoked_at', 'is', null)
+    .where('provider.enabled', '=', true)
+    .executeTakeFirstOrThrow()
+  return result.count
+}
+
+export const revokeOrganizationOidcLink = async (
+  linkId: string,
+  revokedAt: Date,
+  executor: DbExecutor
+) =>
+  executor
+    .updateTable('organization_member_oidc_identities')
+    .set({ revoked_at: revokedAt })
+    .where('id', '=', linkId)
+    .where('revoked_at', 'is', null)
+    .returningAll()
+    .executeTakeFirst()
+
+export const revokeActiveGrantsForOidcLink = async (
+  membershipId: string,
+  linkId: string,
+  revokedAt: Date,
+  executor: DbExecutor
+) => {
+  const result = await executor
+    .updateTable('session_membership_authentications')
+    .set({ revoked_at: revokedAt, updated_at: revokedAt })
+    .where('membership_id', '=', membershipId)
+    .where('member_oidc_identity_id', '=', linkId)
+    .where('revoked_at', 'is', null)
+    .executeTakeFirst()
+  return Number(result.numUpdatedRows)
+}
+
+export const insertOidcLinkAuditEvent = async (
+  event: Insertable<AuditEvents>,
+  executor: DbExecutor
+) => executor.insertInto('audit_events').values(event).executeTakeFirst()
+
+export const insertOidcLinkAuthenticationEvent = async (
+  event: Insertable<AuthenticationEvents>,
+  executor: DbExecutor
+) => executor.insertInto('authentication_events').values(event).executeTakeFirst()

--- a/apps/kaede/src/services/organization-session-auth/index.ts
+++ b/apps/kaede/src/services/organization-session-auth/index.ts
@@ -1,0 +1,5 @@
+export {
+  findCurrentMembershipForSessionLogout,
+  insertOrganizationSessionAuthenticationEvent,
+  revokeCurrentSessionMembershipGrant,
+} from './repository.js'

--- a/apps/kaede/src/services/organization-session-auth/repository.ts
+++ b/apps/kaede/src/services/organization-session-auth/repository.ts
@@ -1,0 +1,41 @@
+import type { Insertable } from 'kysely'
+import type { AuthenticationEvents } from '../db/generated.js'
+import { db } from '../db/index.js'
+import type { DbExecutor } from '../executor.js'
+
+export const findCurrentMembershipForSessionLogout = async (
+  organizationId: string,
+  userId: string,
+  executor: DbExecutor = db
+) =>
+  executor
+    .selectFrom('organization_memberships')
+    .select(['id', 'organization_id', 'user_id', 'status'])
+    .where('organization_id', '=', organizationId)
+    .where('user_id', '=', userId)
+    .where('status', 'in', ['active', 'suspended'])
+    .executeTakeFirst()
+
+export const revokeCurrentSessionMembershipGrant = async (
+  sessionId: string,
+  membershipId: string,
+  userId: string,
+  revokedAt: Date,
+  executor: DbExecutor
+) => {
+  const result = await executor
+    .updateTable('session_membership_authentications')
+    .set({ revoked_at: revokedAt, updated_at: revokedAt })
+    .where('session_id', '=', sessionId)
+    .where('membership_id', '=', membershipId)
+    .where('user_id', '=', userId)
+    .where('revoked_at', 'is', null)
+    .executeTakeFirst()
+
+  return result.numUpdatedRows > 0n
+}
+
+export const insertOrganizationSessionAuthenticationEvent = async (
+  event: Insertable<AuthenticationEvents>,
+  executor: DbExecutor
+) => executor.insertInto('authentication_events').values(event).executeTakeFirst()

--- a/apps/kaede/src/services/organizations/index.ts
+++ b/apps/kaede/src/services/organizations/index.ts
@@ -1,6 +1,7 @@
 export {
   findOrganizationById,
   findOrganizationBySlug,
+  insertDefaultOrganizationAuthSettings,
   insertOrganization,
   listOrganizations,
 } from './organization-repository.js'

--- a/apps/kaede/src/services/organizations/organization-repository.ts
+++ b/apps/kaede/src/services/organizations/organization-repository.ts
@@ -1,5 +1,5 @@
 import type { Insertable, Selectable } from 'kysely'
-import type { Organizations } from '../db/generated.js'
+import type { OrganizationAuthSettings, Organizations } from '../db/generated.js'
 import { db } from '../db/index.js'
 import type { DbExecutor } from '../executor.js'
 
@@ -37,6 +37,20 @@ export const insertOrganization = async (
     .values(newOrganization)
     .returningAll()
     .executeTakeFirstOrThrow()
+}
+
+export const insertDefaultOrganizationAuthSettings = async (
+  organizationId: string,
+  executor: DbExecutor = db
+): Promise<void> => {
+  const settings: Insertable<OrganizationAuthSettings> = {
+    organization_id: organizationId,
+    local_auth_enabled: true,
+    oidc_auth_enabled: false,
+    membership_grant_ttl_seconds: 28_800,
+    reauthentication_interval_seconds: 14_400,
+  }
+  await executor.insertInto('organization_auth_settings').values(settings).executeTakeFirstOrThrow()
 }
 
 export const listOrganizations = async (executor: DbExecutor = db): Promise<Organization[]> => {

--- a/apps/kaede/src/services/profiles/index.ts
+++ b/apps/kaede/src/services/profiles/index.ts
@@ -1,0 +1,16 @@
+export {
+  findMemberProfileContextById,
+  findMemberProfileContextByUser,
+  findUserProfileContext,
+  insertAuditEvent,
+  upsertOrganizationMemberProfile,
+  upsertUserProfile,
+} from './profile-repository.js'
+export type {
+  MemberProfileContext,
+  OrganizationMemberProfile,
+  OrganizationMemberProfileUpdate,
+  UserProfile,
+  UserProfileContext,
+  UserProfileUpdate,
+} from './profile-repository.js'

--- a/apps/kaede/src/services/profiles/profile-repository.ts
+++ b/apps/kaede/src/services/profiles/profile-repository.ts
@@ -10,12 +10,10 @@ export type OrganizationMemberProfileUpdate = Updateable<OrganizationMemberProfi
 
 export interface UserProfileContext {
   user_id: string
-  legacy_display_name: string
-  legacy_updated_at: Date
-  display_name: string | null
-  locale: string | null
-  timezone: string | null
-  profile_updated_at: Date | null
+  display_name: string
+  locale: string
+  timezone: string
+  profile_updated_at: Date
 }
 
 export interface MemberProfileContext extends UserProfileContext {
@@ -33,11 +31,9 @@ export interface MemberProfileContext extends UserProfileContext {
 const userProfileContextQuery = (executor: DbExecutor) =>
   executor
     .selectFrom('users as user')
-    .leftJoin('user_profiles as profile', 'profile.user_id', 'user.id')
+    .innerJoin('user_profiles as profile', 'profile.user_id', 'user.id')
     .select([
       'user.id as user_id',
-      'user.display_name as legacy_display_name',
-      'user.updated_at as legacy_updated_at',
       'profile.display_name as display_name',
       'profile.locale as locale',
       'profile.timezone as timezone',
@@ -55,7 +51,7 @@ const memberProfileContextQuery = (executor: DbExecutor) =>
   executor
     .selectFrom('organization_memberships as membership')
     .innerJoin('users as user', 'user.id', 'membership.user_id')
-    .leftJoin('user_profiles as user_profile', 'user_profile.user_id', 'user.id')
+    .innerJoin('user_profiles as user_profile', 'user_profile.user_id', 'user.id')
     .leftJoin('organization_member_profiles as member_profile', (join) =>
       join.onRef('member_profile.membership_id', '=', 'membership.id')
     )
@@ -66,8 +62,6 @@ const memberProfileContextQuery = (executor: DbExecutor) =>
       'membership.role as role',
       'membership.status as status',
       'user.id as user_id',
-      'user.display_name as legacy_display_name',
-      'user.updated_at as legacy_updated_at',
       'user_profile.display_name as display_name',
       'user_profile.locale as locale',
       'user_profile.timezone as timezone',

--- a/apps/kaede/src/services/profiles/profile-repository.ts
+++ b/apps/kaede/src/services/profiles/profile-repository.ts
@@ -1,0 +1,135 @@
+import type { Insertable, Selectable, Updateable } from 'kysely'
+import type { AuditEvents, OrganizationMemberProfiles, UserProfiles } from '../db/generated.js'
+import { db } from '../db/index.js'
+import type { DbExecutor } from '../executor.js'
+
+export type UserProfile = Selectable<UserProfiles>
+export type UserProfileUpdate = Updateable<UserProfiles>
+export type OrganizationMemberProfile = Selectable<OrganizationMemberProfiles>
+export type OrganizationMemberProfileUpdate = Updateable<OrganizationMemberProfiles>
+
+export interface UserProfileContext {
+  user_id: string
+  legacy_display_name: string
+  legacy_updated_at: Date
+  display_name: string | null
+  locale: string | null
+  timezone: string | null
+  profile_updated_at: Date | null
+}
+
+export interface MemberProfileContext extends UserProfileContext {
+  membership_id: string | null
+  organization_id: string
+  membership_user_id: string
+  role: string
+  status: string | null
+  override_display_name: string | null
+  height_meters: string | null
+  stride_length_meters: string | null
+  member_profile_updated_at: Date | null
+}
+
+const userProfileContextQuery = (executor: DbExecutor) =>
+  executor
+    .selectFrom('users as user')
+    .leftJoin('user_profiles as profile', 'profile.user_id', 'user.id')
+    .select([
+      'user.id as user_id',
+      'user.display_name as legacy_display_name',
+      'user.updated_at as legacy_updated_at',
+      'profile.display_name as display_name',
+      'profile.locale as locale',
+      'profile.timezone as timezone',
+      'profile.updated_at as profile_updated_at',
+    ])
+
+export const findUserProfileContext = async (
+  userId: string,
+  executor: DbExecutor = db
+): Promise<UserProfileContext | undefined> => {
+  return userProfileContextQuery(executor).where('user.id', '=', userId).executeTakeFirst()
+}
+
+const memberProfileContextQuery = (executor: DbExecutor) =>
+  executor
+    .selectFrom('organization_memberships as membership')
+    .innerJoin('users as user', 'user.id', 'membership.user_id')
+    .leftJoin('user_profiles as user_profile', 'user_profile.user_id', 'user.id')
+    .leftJoin('organization_member_profiles as member_profile', (join) =>
+      join.onRef('member_profile.membership_id', '=', 'membership.id')
+    )
+    .select([
+      'membership.id as membership_id',
+      'membership.organization_id as organization_id',
+      'membership.user_id as membership_user_id',
+      'membership.role as role',
+      'membership.status as status',
+      'user.id as user_id',
+      'user.display_name as legacy_display_name',
+      'user.updated_at as legacy_updated_at',
+      'user_profile.display_name as display_name',
+      'user_profile.locale as locale',
+      'user_profile.timezone as timezone',
+      'user_profile.updated_at as profile_updated_at',
+      'member_profile.display_name as override_display_name',
+      'member_profile.height_meters as height_meters',
+      'member_profile.stride_length_meters as stride_length_meters',
+      'member_profile.updated_at as member_profile_updated_at',
+    ])
+
+export const findMemberProfileContextByUser = async (
+  organizationId: string,
+  userId: string,
+  executor: DbExecutor = db
+): Promise<MemberProfileContext | undefined> => {
+  return memberProfileContextQuery(executor)
+    .where('membership.organization_id', '=', organizationId)
+    .where('membership.user_id', '=', userId)
+    .where('membership.status', 'in', ['active', 'suspended'])
+    .executeTakeFirst()
+}
+
+export const findMemberProfileContextById = async (
+  organizationId: string,
+  membershipId: string,
+  executor: DbExecutor = db
+): Promise<MemberProfileContext | undefined> => {
+  return memberProfileContextQuery(executor)
+    .where('membership.organization_id', '=', organizationId)
+    .where('membership.id', '=', membershipId)
+    .executeTakeFirst()
+}
+
+export const upsertUserProfile = async (
+  profile: Insertable<UserProfiles>,
+  update: UserProfileUpdate,
+  executor: DbExecutor = db
+): Promise<UserProfile> => {
+  return executor
+    .insertInto('user_profiles')
+    .values(profile)
+    .onConflict((conflict) => conflict.column('user_id').doUpdateSet(update))
+    .returningAll()
+    .executeTakeFirstOrThrow()
+}
+
+export const upsertOrganizationMemberProfile = async (
+  profile: Insertable<OrganizationMemberProfiles>,
+  update: OrganizationMemberProfileUpdate,
+  executor: DbExecutor = db
+): Promise<OrganizationMemberProfile> => {
+  return executor
+    .insertInto('organization_member_profiles')
+    .values(profile)
+    .onConflict((conflict) => conflict.column('membership_id').doUpdateSet(update))
+    .returningAll()
+    .executeTakeFirstOrThrow()
+}
+
+export const insertAuditEvent = async (
+  event: Insertable<AuditEvents>,
+  executor: DbExecutor = db
+) => {
+  await executor.insertInto('audit_events').values(event).execute()
+}

--- a/apps/kaede/src/services/users/user-repository.ts
+++ b/apps/kaede/src/services/users/user-repository.ts
@@ -10,6 +10,7 @@ export type NewOrganizationMembership = Insertable<OrganizationMemberships>
 export type OrganizationMembership = Selectable<OrganizationMemberships>
 
 export interface OrganizationUserRow {
+  membership_id: string
   user_id: string
   email: string
   display_name: string
@@ -109,6 +110,7 @@ const organizationUsersQuery = (executor: DbExecutor) =>
     .innerJoin('users as user', 'user.id', 'membership.user_id')
     .leftJoin('pedestrians as pedestrian', 'pedestrian.user_id', 'user.id')
     .select([
+      'membership.id as membership_id',
       'user.id as user_id',
       'user.email as email',
       'user.display_name as display_name',

--- a/apps/kaede/src/services/users/user-repository.ts
+++ b/apps/kaede/src/services/users/user-repository.ts
@@ -69,6 +69,7 @@ export const findOrganizationMembership = async (
     .selectAll()
     .where('organization_id', '=', organizationId)
     .where('user_id', '=', userId)
+    .where('status', '=', 'active')
     .executeTakeFirst()
 }
 
@@ -91,9 +92,12 @@ export const upsertOrganizationMembership = async (
     .insertInto('organization_memberships')
     .values(membership)
     .onConflict((oc) =>
-      oc.columns(['organization_id', 'user_id']).doUpdateSet({
-        role: membership.role,
-      })
+      oc
+        .columns(['organization_id', 'user_id'])
+        .where('status', 'in', ['active', 'suspended'])
+        .doUpdateSet({
+          role: membership.role,
+        })
     )
     .returningAll()
     .executeTakeFirstOrThrow()
@@ -122,6 +126,7 @@ const organizationUsersQuery = (executor: DbExecutor) =>
       'pedestrian.created_at as pedestrian_created_at',
       'pedestrian.updated_at as pedestrian_updated_at',
     ])
+    .where('membership.status', 'in', ['active', 'suspended'])
 
 export const listOrganizationUsers = async (
   organizationId: string,
@@ -158,6 +163,7 @@ export const listUserOrganizationMemberships = async (
       'membership.role as role',
     ])
     .where('membership.user_id', '=', userId)
+    .where('membership.status', 'in', ['active', 'suspended'])
     .orderBy('organization.name', 'asc')
     .execute()
 }

--- a/apps/kaede/src/usecases/auth/index.ts
+++ b/apps/kaede/src/usecases/auth/index.ts
@@ -3,6 +3,7 @@ import type {
   ActivationCompleteRequest,
   ActivationVerifyRequest,
   ActivationVerifyResponse,
+  AuthMeResponse,
   AuthUserResponse,
   ChangePasswordRequest,
   LoginRequest,
@@ -31,7 +32,9 @@ import type { DbExecutor } from '../../services/executor.js'
 import {
   evaluateMembershipGrant,
   listMembershipGrantContexts,
+  membershipAllowedAuthMethods,
 } from '../../services/organization-authorization/index.js'
+import type { MembershipGrantContext } from '../../services/organization-authorization/index.js'
 import {
   findUserByEmail,
   findUserById,
@@ -76,6 +79,10 @@ export type ActiveSessionUserResult =
       ok: false
       error: ActiveSessionUserError
     }
+
+export type GetMeResult =
+  | { ok: true; value: AuthMeResponse }
+  | { ok: false; error: ActiveSessionUserError }
 
 export interface LoginResultValue extends AuthUserResponse {
   sessionToken: string
@@ -174,19 +181,9 @@ const mapActiveSessionError = (
 const buildAuthUserResponse = async (
   user: User,
   sessionAuthMethod: 'password' | 'oidc',
-  executor?: DbExecutor,
-  grantOptions?: { sessionId: string; now: Date }
+  executor?: DbExecutor
 ): Promise<AuthUserResponse> => {
   const memberships = await listUserOrganizationMemberships(user.id, executor)
-  const grantContexts = grantOptions
-    ? await listMembershipGrantContexts(grantOptions.sessionId, user.id, executor)
-    : []
-  const grantsByOrganizationId = new Map(
-    grantContexts.map((context) => [context.organization_id, context])
-  )
-  const currentMemberships = grantOptions
-    ? memberships.filter((membership) => grantsByOrganizationId.has(membership.organization_id))
-    : memberships
 
   return {
     session_auth_method: sessionAuthMethod,
@@ -199,38 +196,155 @@ const buildAuthUserResponse = async (
       account_state: deriveAccountState({
         globalRole: user.global_role as 'none' | 'admin',
         status: user.status as 'pending_activation' | 'active' | 'disabled',
-        membershipCount: currentMemberships.length,
+        membershipCount: memberships.length,
       }),
       password_changed_at: toIsoOrNull(user.password_changed_at),
-      memberships: currentMemberships.map((membership) => {
-        const context = grantsByOrganizationId.get(membership.organization_id)
-        const authorization = grantOptions
-          ? evaluateMembershipGrant(context, 'member', grantOptions.now)
-          : undefined
-        const grantState = !authorization
-          ? undefined
-          : authorization.ok
-            ? {
-                status: 'granted' as const,
-                auth_method: authorization.authMethod,
-                authenticated_at: authorization.authenticatedAt.toISOString(),
-                expires_at: authorization.expiresAt.toISOString(),
-              }
-            : authorization.type === 'reauthentication_required'
-              ? {
-                  status: 'reauthentication_required' as const,
-                  reason: authorization.reason,
-                  allowed_auth_methods: authorization.allowedAuthMethods,
-                }
-              : { status: 'forbidden' as const }
+      memberships: memberships.map((membership) => ({
+        organization_id: membership.organization_id,
+        organization_name: membership.organization_name,
+        role: membership.role as 'member' | 'manager' | 'owner',
+      })),
+    },
+  }
+}
 
-        return {
-          organization_id: membership.organization_id,
-          organization_name: membership.organization_name,
-          role: membership.role as 'member' | 'manager' | 'owner',
-          ...(grantState ? { grant_state: grantState } : {}),
-        }
+const grantTimeline = (context: MembershipGrantContext) => {
+  const authenticatedAt = context.grant_authenticated_at
+  const expiresAt = context.grant_expires_at
+  const intervalSeconds = context.reauthentication_interval_seconds
+  if (!authenticatedAt || !expiresAt || intervalSeconds === null) {
+    return {
+      authenticated_at: null,
+      reauthentication_required_at: null,
+      expires_at: expiresAt?.toISOString() ?? null,
+      effective_expires_at: null,
+    }
+  }
+
+  const reauthenticationRequiredAt = new Date(authenticatedAt.getTime() + intervalSeconds * 1000)
+  const effectiveExpiresAt =
+    reauthenticationRequiredAt <= expiresAt ? reauthenticationRequiredAt : expiresAt
+  return {
+    authenticated_at: authenticatedAt.toISOString(),
+    reauthentication_required_at: reauthenticationRequiredAt.toISOString(),
+    expires_at: expiresAt.toISOString(),
+    effective_expires_at: effectiveExpiresAt.toISOString(),
+  }
+}
+
+const membershipGrantState = (
+  context: MembershipGrantContext,
+  now: Date
+): AuthMeResponse['user']['memberships'][number]['grant_state'] => {
+  if (context.membership_status === 'suspended') {
+    return {
+      status: 'forbidden',
+      reason: 'membership_suspended',
+      auth_method: null,
+      authenticated_at: null,
+      reauthentication_required_at: null,
+      expires_at: null,
+      effective_expires_at: null,
+    }
+  }
+  if (context.organization_status !== 'active') {
+    return {
+      status: 'forbidden',
+      reason: 'organization_unavailable',
+      auth_method: null,
+      authenticated_at: null,
+      reauthentication_required_at: null,
+      expires_at: null,
+      effective_expires_at: null,
+    }
+  }
+  if (!context.auth_settings_available) {
+    return {
+      status: 'forbidden',
+      reason: 'auth_settings_unavailable',
+      auth_method: null,
+      authenticated_at: null,
+      reauthentication_required_at: null,
+      expires_at: null,
+      effective_expires_at: null,
+    }
+  }
+
+  const authorization = evaluateMembershipGrant(context, 'member', now)
+  if (authorization.ok) {
+    return {
+      status: 'granted',
+      reason: null,
+      auth_method: authorization.authMethod,
+      authenticated_at: authorization.authenticatedAt.toISOString(),
+      reauthentication_required_at: authorization.reauthenticationRequiredAt.toISOString(),
+      expires_at: authorization.expiresAt.toISOString(),
+      effective_expires_at: authorization.effectiveExpiresAt.toISOString(),
+    }
+  }
+
+  if (authorization.type === 'reauthentication_required') {
+    const timeline = grantTimeline(context)
+    return {
+      status: 'reauthentication_required',
+      reason: authorization.reason,
+      auth_method:
+        context.grant_auth_method === 'local' || context.grant_auth_method === 'oidc'
+          ? context.grant_auth_method
+          : null,
+      ...timeline,
+    }
+  }
+
+  return {
+    status: 'forbidden',
+    reason: 'organization_unavailable',
+    auth_method: null,
+    authenticated_at: null,
+    reauthentication_required_at: null,
+    expires_at: null,
+    effective_expires_at: null,
+  }
+}
+
+const buildAuthMeResponse = async (
+  user: User,
+  sessionAuthMethod: 'password' | 'oidc',
+  sessionId: string,
+  now: Date,
+  executor?: DbExecutor
+): Promise<AuthMeResponse> => {
+  const memberships = await listMembershipGrantContexts(sessionId, user.id, executor)
+
+  return {
+    session_auth_method: sessionAuthMethod,
+    user: {
+      user_id: user.id,
+      email: user.email,
+      display_name: user.display_name,
+      global_role: user.global_role as 'none' | 'admin',
+      status: user.status as 'pending_activation' | 'active' | 'disabled',
+      account_state: deriveAccountState({
+        globalRole: user.global_role as 'none' | 'admin',
+        status: user.status as 'pending_activation' | 'active' | 'disabled',
+        membershipCount: memberships.length,
       }),
+      password_changed_at: toIsoOrNull(user.password_changed_at),
+      memberships: memberships.map((membership) => ({
+        membership_id: membership.membership_id,
+        organization_id: membership.organization_id,
+        organization_name: membership.organization_name,
+        organization_slug: membership.organization_slug,
+        role: membership.membership_role as 'member' | 'manager' | 'owner',
+        status: membership.membership_status as 'active' | 'suspended',
+        allowed_auth_methods:
+          membership.membership_status === 'active' &&
+          membership.organization_status === 'active' &&
+          membership.auth_settings_available
+            ? membershipAllowedAuthMethods(membership)
+            : [],
+        grant_state: membershipGrantState(membership, now),
+      })),
     },
   }
 }
@@ -635,7 +749,7 @@ export const getMe = async (
   sessionToken: string | undefined,
   now: Date = new Date(),
   executor?: DbExecutor
-): Promise<AuthResult<AuthUserResponse>> => {
+): Promise<GetMeResult> => {
   if (!sessionToken) {
     return {
       ok: false,
@@ -670,11 +784,12 @@ export const getMe = async (
 
   return {
     ok: true,
-    value: await buildAuthUserResponse(
+    value: await buildAuthMeResponse(
       user,
       sessionResult.session.auth_method as 'password' | 'oidc',
-      executor,
-      { sessionId: sessionResult.session.id, now }
+      sessionResult.session.id,
+      now,
+      executor
     ),
   }
 }

--- a/apps/kaede/src/usecases/auth/index.ts
+++ b/apps/kaede/src/usecases/auth/index.ts
@@ -29,6 +29,10 @@ import { hashPassword, verifyPassword } from '../../services/auth/password.js'
 import { db } from '../../services/db/index.js'
 import type { DbExecutor } from '../../services/executor.js'
 import {
+  evaluateMembershipGrant,
+  listMembershipGrantContexts,
+} from '../../services/organization-authorization/index.js'
+import {
   findUserByEmail,
   findUserById,
   insertUser,
@@ -170,9 +174,19 @@ const mapActiveSessionError = (
 const buildAuthUserResponse = async (
   user: User,
   sessionAuthMethod: 'password' | 'oidc',
-  executor?: DbExecutor
+  executor?: DbExecutor,
+  grantOptions?: { sessionId: string; now: Date }
 ): Promise<AuthUserResponse> => {
   const memberships = await listUserOrganizationMemberships(user.id, executor)
+  const grantContexts = grantOptions
+    ? await listMembershipGrantContexts(grantOptions.sessionId, user.id, executor)
+    : []
+  const grantsByOrganizationId = new Map(
+    grantContexts.map((context) => [context.organization_id, context])
+  )
+  const currentMemberships = grantOptions
+    ? memberships.filter((membership) => grantsByOrganizationId.has(membership.organization_id))
+    : memberships
 
   return {
     session_auth_method: sessionAuthMethod,
@@ -185,14 +199,38 @@ const buildAuthUserResponse = async (
       account_state: deriveAccountState({
         globalRole: user.global_role as 'none' | 'admin',
         status: user.status as 'pending_activation' | 'active' | 'disabled',
-        membershipCount: memberships.length,
+        membershipCount: currentMemberships.length,
       }),
       password_changed_at: toIsoOrNull(user.password_changed_at),
-      memberships: memberships.map((membership) => ({
-        organization_id: membership.organization_id,
-        organization_name: membership.organization_name,
-        role: membership.role as 'member' | 'manager' | 'owner',
-      })),
+      memberships: currentMemberships.map((membership) => {
+        const context = grantsByOrganizationId.get(membership.organization_id)
+        const authorization = grantOptions
+          ? evaluateMembershipGrant(context, 'member', grantOptions.now)
+          : undefined
+        const grantState = !authorization
+          ? undefined
+          : authorization.ok
+            ? {
+                status: 'granted' as const,
+                auth_method: authorization.authMethod,
+                authenticated_at: authorization.authenticatedAt.toISOString(),
+                expires_at: authorization.expiresAt.toISOString(),
+              }
+            : authorization.type === 'reauthentication_required'
+              ? {
+                  status: 'reauthentication_required' as const,
+                  reason: authorization.reason,
+                  allowed_auth_methods: authorization.allowedAuthMethods,
+                }
+              : { status: 'forbidden' as const }
+
+        return {
+          organization_id: membership.organization_id,
+          organization_name: membership.organization_name,
+          role: membership.role as 'member' | 'manager' | 'owner',
+          ...(grantState ? { grant_state: grantState } : {}),
+        }
+      }),
     },
   }
 }
@@ -635,7 +673,8 @@ export const getMe = async (
     value: await buildAuthUserResponse(
       user,
       sessionResult.session.auth_method as 'password' | 'oidc',
-      executor
+      executor,
+      { sessionId: sessionResult.session.id, now }
     ),
   }
 }

--- a/apps/kaede/src/usecases/membership-administration/index.ts
+++ b/apps/kaede/src/usecases/membership-administration/index.ts
@@ -1,0 +1,1 @@
+export { updateOrganizationMembership } from './update.js'

--- a/apps/kaede/src/usecases/membership-administration/update.ts
+++ b/apps/kaede/src/usecases/membership-administration/update.ts
@@ -1,0 +1,129 @@
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import type { UpdateMembershipRequest } from '../../schemas/membership-administration.js'
+import { db } from '../../services/db/index.js'
+import type { DbExecutor } from '../../services/executor.js'
+import {
+  countActiveOwners,
+  findCurrentMembershipByUserForUpdate,
+  findMembershipByIdForUpdate,
+  insertMembershipAdministrationAuditEvent,
+  lockOrganizationForMembershipAdministration,
+  revokeAllMembershipGrants,
+  revokeMembershipAuthenticationSources,
+  updateManagedMembership,
+} from '../../services/membership-administration/index.js'
+
+export type MembershipAdministrationError =
+  | 'AUTH_FORBIDDEN'
+  | 'MEMBERSHIP_NOT_FOUND'
+  | 'MEMBERSHIP_ROLE_FORBIDDEN'
+  | 'MEMBERSHIP_LEFT'
+  | 'MEMBERSHIP_LAST_OWNER'
+
+const response = (membership: {
+  id: string
+  organization_id: string
+  user_id: string
+  role: string
+  status: string
+  joined_at: Date
+  left_at: Date | null
+  updated_at: Date
+}) => ({
+  id: membership.id,
+  organization_id: membership.organization_id,
+  user_id: membership.user_id,
+  role: membership.role as 'member' | 'manager' | 'owner',
+  status: membership.status as 'active' | 'suspended' | 'left',
+  joined_at: membership.joined_at.toISOString(),
+  left_at: membership.left_at?.toISOString() ?? null,
+  updated_at: membership.updated_at.toISOString(),
+})
+
+export const updateOrganizationMembership = async (
+  actor: RequestActor,
+  organizationId: string,
+  membershipId: string,
+  payload: UpdateMembershipRequest,
+  now = new Date(),
+  executor?: DbExecutor
+) => {
+  if (actor.type !== 'user') {
+    return { ok: false, error: { type: 'AUTH_FORBIDDEN' as const } } as const
+  }
+  const base = executor ?? db
+  const run = async (trx: DbExecutor) => {
+    const organization = await lockOrganizationForMembershipAdministration(organizationId, trx)
+    if (!organization) {
+      return { ok: false, error: { type: 'MEMBERSHIP_NOT_FOUND' as const } } as const
+    }
+    const actorMembership = await findCurrentMembershipByUserForUpdate(
+      organizationId,
+      actor.user_id,
+      trx
+    )
+    if (actorMembership?.status !== 'active') {
+      return { ok: false, error: { type: 'AUTH_FORBIDDEN' as const } } as const
+    }
+    const target = await findMembershipByIdForUpdate(organizationId, membershipId, trx)
+    if (!target) return { ok: false, error: { type: 'MEMBERSHIP_NOT_FOUND' as const } } as const
+    if (target.status === 'left') {
+      return { ok: false, error: { type: 'MEMBERSHIP_LEFT' as const } } as const
+    }
+
+    const nextRole = payload.role ?? (target.role as 'member' | 'manager' | 'owner')
+    const nextStatus = payload.status ?? (target.status as 'active' | 'suspended')
+    const managerAllowed =
+      actorMembership.role === 'manager' && target.role === 'member' && nextRole === 'member'
+    const ownerAllowed = actorMembership.role === 'owner'
+    if (!managerAllowed && !ownerAllowed) {
+      return { ok: false, error: { type: 'MEMBERSHIP_ROLE_FORBIDDEN' as const } } as const
+    }
+
+    const removesActiveOwner =
+      target.role === 'owner' &&
+      target.status === 'active' &&
+      (nextRole !== 'owner' || nextStatus !== 'active')
+    if (removesActiveOwner && (await countActiveOwners(organizationId, trx)) <= 1) {
+      return { ok: false, error: { type: 'MEMBERSHIP_LAST_OWNER' as const } } as const
+    }
+
+    const changedFields = [
+      ...(nextRole === target.role ? [] : ['role']),
+      ...(nextStatus === target.status ? [] : ['status']),
+    ]
+    if (changedFields.length === 0) return { ok: true, value: response(target) } as const
+
+    const updated = await updateManagedMembership(
+      target.id,
+      {
+        role: nextRole,
+        status: nextStatus,
+        left_at: nextStatus === 'left' ? now : null,
+        updated_at: now,
+      },
+      trx
+    )
+    await revokeAllMembershipGrants(target.id, now, trx)
+    if (nextStatus === 'left') {
+      await revokeMembershipAuthenticationSources(target.id, now, trx)
+    }
+    await insertMembershipAdministrationAuditEvent(
+      {
+        action: 'update',
+        actor_user_id: actor.user_id,
+        actor_membership_id: actorMembership.id,
+        organization_id: organizationId,
+        target_type: 'organization_membership',
+        target_id: target.id,
+        changed_fields: changedFields,
+        before_values: { role: target.role, status: target.status },
+        after_values: { role: updated.role, status: updated.status },
+      },
+      trx
+    )
+
+    return { ok: true, value: response(updated) } as const
+  }
+  return 'transaction' in base ? base.transaction().execute(run) : run(base)
+}

--- a/apps/kaede/src/usecases/organization-auth-methods/index.test.ts
+++ b/apps/kaede/src/usecases/organization-auth-methods/index.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getPublicOrganizationAuthMethods } from './index.js'
+
+const { findRowsMock } = vi.hoisted(() => ({ findRowsMock: vi.fn() }))
+
+vi.mock('../../services/organization-auth-methods/index.js', () => ({
+  findPublicOrganizationAuthMethodRows: findRowsMock,
+}))
+
+describe('getPublicOrganizationAuthMethods', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('OIDC無効時はprovider rowがあっても公開しない', async () => {
+    findRowsMock.mockResolvedValue([
+      {
+        local_auth_enabled: true,
+        oidc_auth_enabled: false,
+        provider_id: '11111111-1111-4111-8111-111111111111',
+        provider_display_name: 'Disabled by policy',
+      },
+    ])
+
+    await expect(getPublicOrganizationAuthMethods('example-org')).resolves.toEqual({
+      local_auth_enabled: true,
+      allowed_auth_methods: ['local'],
+      oidc_providers: [],
+    })
+  })
+
+  it('Organizationが利用不可なら存在理由を区別しない空responseを返す', async () => {
+    findRowsMock.mockResolvedValue([])
+
+    await expect(getPublicOrganizationAuthMethods('unknown-org')).resolves.toEqual({
+      local_auth_enabled: false,
+      allowed_auth_methods: [],
+      oidc_providers: [],
+    })
+  })
+})

--- a/apps/kaede/src/usecases/organization-auth-methods/index.ts
+++ b/apps/kaede/src/usecases/organization-auth-methods/index.ts
@@ -1,0 +1,35 @@
+import type { OrganizationAuthMethodsResponse } from '../../schemas/organization-auth-methods.js'
+import type { DbExecutor } from '../../services/executor.js'
+import { findPublicOrganizationAuthMethodRows } from '../../services/organization-auth-methods/index.js'
+
+const unavailableResponse = (): OrganizationAuthMethodsResponse => ({
+  local_auth_enabled: false,
+  allowed_auth_methods: [],
+  oidc_providers: [],
+})
+
+export const getPublicOrganizationAuthMethods = async (
+  organizationSlug: string,
+  executor?: DbExecutor
+): Promise<OrganizationAuthMethodsResponse> => {
+  const rows = await findPublicOrganizationAuthMethodRows(organizationSlug, executor)
+  if (rows.length === 0) return unavailableResponse()
+  const first = rows[0]
+
+  const oidcProviders = first.oidc_auth_enabled
+    ? rows.flatMap((row) =>
+        row.provider_id && row.provider_display_name
+          ? [{ id: row.provider_id, display_name: row.provider_display_name }]
+          : []
+      )
+    : []
+  const allowedAuthMethods: ('local' | 'oidc')[] = []
+  if (first.local_auth_enabled) allowedAuthMethods.push('local')
+  if (oidcProviders.length > 0) allowedAuthMethods.push('oidc')
+
+  return {
+    local_auth_enabled: first.local_auth_enabled,
+    allowed_auth_methods: allowedAuthMethods,
+    oidc_providers: oidcProviders,
+  }
+}

--- a/apps/kaede/src/usecases/organization-auth-settings/index.test.ts
+++ b/apps/kaede/src/usecases/organization-auth-settings/index.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import type { DbExecutor } from '../../services/executor.js'
+
+const mocks = vi.hoisted(() => ({
+  countEnabledOidcProviders: vi.fn(),
+  findActiveOwnerMembership: vi.fn(),
+  findActiveOwnerMembershipForUpdate: vi.fn(),
+  findOrganizationAuthSettings: vi.fn(),
+  findOrganizationAuthSettingsForUpdate: vi.fn(),
+  insertOrganizationAuthSettingsAuditEvent: vi.fn(),
+  updateOrganizationAuthSettings: vi.fn(),
+}))
+
+vi.mock('../../services/organization-auth-settings/index.js', () => mocks)
+vi.mock('../../services/db/index.js', () => ({ db: {} }))
+
+import { getOrganizationAuthSettings, patchOrganizationAuthSettings } from './index.js'
+
+const executor = {} as DbExecutor
+const organizationId = '11111111-1111-4111-8111-111111111111'
+const userId = '22222222-2222-4222-8222-222222222222'
+const membershipId = '33333333-3333-4333-8333-333333333333'
+const createdAt = new Date('2026-08-11T00:00:00.000Z')
+const updatedAt = new Date('2026-08-11T01:00:00.000Z')
+
+const actor: RequestActor = {
+  type: 'user',
+  user_id: userId,
+  email: 'owner@example.com',
+  global_role: 'none',
+  account_state: 'active',
+  memberships: [{ organization_id: organizationId, organization_name: 'Example', role: 'owner' }],
+}
+
+const settings = {
+  organization_id: organizationId,
+  local_auth_enabled: true,
+  oidc_auth_enabled: false,
+  policy_version: '1',
+  membership_grant_ttl_seconds: 28_800,
+  reauthentication_interval_seconds: 14_400,
+  created_at: createdAt,
+  updated_at: createdAt,
+}
+
+describe('organization auth settings usecases', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.findActiveOwnerMembership.mockResolvedValue({ id: membershipId })
+    mocks.findActiveOwnerMembershipForUpdate.mockResolvedValue({ id: membershipId })
+    mocks.findOrganizationAuthSettings.mockResolvedValue(settings)
+    mocks.findOrganizationAuthSettingsForUpdate.mockResolvedValue(settings)
+    mocks.countEnabledOidcProviders.mockResolvedValue(1)
+    mocks.updateOrganizationAuthSettings.mockImplementation((_organizationId, next) =>
+      Promise.resolve({
+        ...settings,
+        ...next,
+        policy_version: '2',
+        updated_at: updatedAt,
+      })
+    )
+  })
+
+  it('active ownerへ認証設定を返す', async () => {
+    await expect(getOrganizationAuthSettings(actor, organizationId, executor)).resolves.toEqual({
+      ok: true,
+      value: {
+        organization_id: organizationId,
+        local_auth_enabled: true,
+        oidc_auth_enabled: false,
+        policy_version: 1,
+        membership_grant_ttl_seconds: 28_800,
+        reauthentication_interval_seconds: 14_400,
+        created_at: createdAt.toISOString(),
+        updated_at: createdAt.toISOString(),
+      },
+    })
+  })
+
+  it('active ownerでなければ取得を拒否する', async () => {
+    mocks.findActiveOwnerMembership.mockResolvedValue(undefined)
+
+    await expect(getOrganizationAuthSettings(actor, organizationId, executor)).resolves.toEqual({
+      ok: false,
+      error: { type: 'AUTH_DASHBOARD_FORBIDDEN' },
+    })
+    expect(mocks.findOrganizationAuthSettings).not.toHaveBeenCalled()
+  })
+
+  it('実質変更時だけpolicy versionを1増加させAuditを記録する', async () => {
+    const result = await patchOrganizationAuthSettings(
+      actor,
+      organizationId,
+      { membership_grant_ttl_seconds: 36_000, reauthentication_interval_seconds: 18_000 },
+      executor
+    )
+
+    expect(result).toMatchObject({ ok: true, value: { policy_version: 2 } })
+    expect(mocks.updateOrganizationAuthSettings).toHaveBeenCalledOnce()
+    expect(mocks.updateOrganizationAuthSettings).toHaveBeenCalledWith(
+      organizationId,
+      {
+        local_auth_enabled: true,
+        oidc_auth_enabled: false,
+        membership_grant_ttl_seconds: 36_000,
+        reauthentication_interval_seconds: 18_000,
+      },
+      executor
+    )
+    expect(mocks.insertOrganizationAuthSettingsAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actor_user_id: userId,
+        actor_membership_id: membershipId,
+        organization_id: organizationId,
+        target_type: 'organization_auth_settings',
+        target_id: organizationId,
+        action: 'update',
+        changed_fields: ['membership_grant_ttl_seconds', 'reauthentication_interval_seconds'],
+        before_values: {
+          membership_grant_ttl_seconds: 28_800,
+          reauthentication_interval_seconds: 14_400,
+          policy_version: 1,
+        },
+        after_values: {
+          membership_grant_ttl_seconds: 36_000,
+          reauthentication_interval_seconds: 18_000,
+          policy_version: 2,
+        },
+      }),
+      executor
+    )
+  })
+
+  it('同じ値へのPATCHではversion更新もAuditも行わない', async () => {
+    const result = await patchOrganizationAuthSettings(
+      actor,
+      organizationId,
+      { local_auth_enabled: true },
+      executor
+    )
+
+    expect(result).toMatchObject({ ok: true, value: { policy_version: 1 } })
+    expect(mocks.updateOrganizationAuthSettings).not.toHaveBeenCalled()
+    expect(mocks.insertOrganizationAuthSettingsAuditEvent).not.toHaveBeenCalled()
+  })
+
+  it('すべての認証方式を無効にできない', async () => {
+    const result = await patchOrganizationAuthSettings(
+      actor,
+      organizationId,
+      { local_auth_enabled: false },
+      executor
+    )
+
+    expect(result).toEqual({
+      ok: false,
+      error: { type: 'ORGANIZATION_AUTH_SETTINGS_INVALID' },
+    })
+    expect(mocks.updateOrganizationAuthSettings).not.toHaveBeenCalled()
+  })
+
+  it('再認証期間がGrant TTLを超える設定を拒否する', async () => {
+    const result = await patchOrganizationAuthSettings(
+      actor,
+      organizationId,
+      { reauthentication_interval_seconds: 28_801 },
+      executor
+    )
+
+    expect(result).toEqual({
+      ok: false,
+      error: { type: 'ORGANIZATION_AUTH_SETTINGS_INVALID' },
+    })
+  })
+
+  it('OIDCを有効化するときはenabled Providerを要求する', async () => {
+    mocks.countEnabledOidcProviders.mockResolvedValue(0)
+
+    const result = await patchOrganizationAuthSettings(
+      actor,
+      organizationId,
+      { oidc_auth_enabled: true },
+      executor
+    )
+
+    expect(result).toEqual({ ok: false, error: { type: 'OIDC_PROVIDER_REQUIRED' } })
+    expect(mocks.updateOrganizationAuthSettings).not.toHaveBeenCalled()
+  })
+
+  it('transaction内の再確認でactive ownerでなければ更新を拒否する', async () => {
+    mocks.findActiveOwnerMembershipForUpdate.mockResolvedValue(undefined)
+
+    const result = await patchOrganizationAuthSettings(
+      actor,
+      organizationId,
+      { membership_grant_ttl_seconds: 36_000 },
+      executor
+    )
+
+    expect(result).toEqual({ ok: false, error: { type: 'AUTH_DASHBOARD_FORBIDDEN' } })
+    expect(mocks.updateOrganizationAuthSettings).not.toHaveBeenCalled()
+  })
+
+  it('認証設定行がなければ404用errorを返す', async () => {
+    mocks.findOrganizationAuthSettingsForUpdate.mockResolvedValue(undefined)
+
+    const result = await patchOrganizationAuthSettings(
+      actor,
+      organizationId,
+      { membership_grant_ttl_seconds: 36_000 },
+      executor
+    )
+
+    expect(result).toEqual({
+      ok: false,
+      error: { type: 'ORGANIZATION_AUTH_SETTINGS_NOT_FOUND' },
+    })
+    expect(mocks.updateOrganizationAuthSettings).not.toHaveBeenCalled()
+  })
+})

--- a/apps/kaede/src/usecases/organization-auth-settings/index.ts
+++ b/apps/kaede/src/usecases/organization-auth-settings/index.ts
@@ -1,0 +1,150 @@
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import type { UpdateOrganizationAuthSettingsRequest } from '../../schemas/organization-auth-settings.js'
+import type { Json } from '../../services/db/index.js'
+import { db } from '../../services/db/index.js'
+import type { DbExecutor } from '../../services/executor.js'
+import {
+  countEnabledOidcProviders,
+  findActiveOwnerMembership,
+  findActiveOwnerMembershipForUpdate,
+  findOrganizationAuthSettings,
+  findOrganizationAuthSettingsForUpdate,
+  insertOrganizationAuthSettingsAuditEvent,
+  updateOrganizationAuthSettings,
+} from '../../services/organization-auth-settings/index.js'
+
+export type OrganizationAuthSettingsError =
+  | { type: 'AUTH_DASHBOARD_FORBIDDEN' }
+  | { type: 'ORGANIZATION_AUTH_SETTINGS_NOT_FOUND' }
+  | { type: 'ORGANIZATION_AUTH_SETTINGS_INVALID' }
+  | { type: 'OIDC_PROVIDER_REQUIRED' }
+
+type Result<T> = { ok: true; value: T } | { ok: false; error: OrganizationAuthSettingsError }
+
+const runInTransaction = async <T>(
+  executor: DbExecutor | undefined,
+  callback: (trx: DbExecutor) => Promise<T>
+): Promise<T> => {
+  const baseExecutor = executor ?? db
+  return 'transaction' in baseExecutor
+    ? baseExecutor.transaction().execute((trx) => callback(trx))
+    : callback(baseExecutor)
+}
+
+const toResponse = (settings: {
+  organization_id: string
+  local_auth_enabled: boolean
+  oidc_auth_enabled: boolean
+  policy_version: string
+  membership_grant_ttl_seconds: number
+  reauthentication_interval_seconds: number
+  created_at: Date
+  updated_at: Date
+}) => ({
+  organization_id: settings.organization_id,
+  local_auth_enabled: settings.local_auth_enabled,
+  oidc_auth_enabled: settings.oidc_auth_enabled,
+  policy_version: Number(settings.policy_version),
+  membership_grant_ttl_seconds: settings.membership_grant_ttl_seconds,
+  reauthentication_interval_seconds: settings.reauthentication_interval_seconds,
+  created_at: settings.created_at.toISOString(),
+  updated_at: settings.updated_at.toISOString(),
+})
+
+const requireUserId = (actor: RequestActor): string | undefined =>
+  actor.type === 'user' ? actor.user_id : undefined
+
+export const getOrganizationAuthSettings = async (
+  actor: RequestActor,
+  organizationId: string,
+  executor: DbExecutor = db
+): Promise<Result<ReturnType<typeof toResponse>>> => {
+  const userId = requireUserId(actor)
+  if (!userId || !(await findActiveOwnerMembership(organizationId, userId, executor))) {
+    return { ok: false, error: { type: 'AUTH_DASHBOARD_FORBIDDEN' } }
+  }
+
+  const settings = await findOrganizationAuthSettings(organizationId, executor)
+  if (!settings) {
+    return { ok: false, error: { type: 'ORGANIZATION_AUTH_SETTINGS_NOT_FOUND' } }
+  }
+  return { ok: true, value: toResponse(settings) }
+}
+
+export const patchOrganizationAuthSettings = async (
+  actor: RequestActor,
+  organizationId: string,
+  payload: UpdateOrganizationAuthSettingsRequest,
+  executor?: DbExecutor
+): Promise<Result<ReturnType<typeof toResponse>>> => {
+  const userId = requireUserId(actor)
+  if (!userId) return { ok: false, error: { type: 'AUTH_DASHBOARD_FORBIDDEN' } }
+
+  return runInTransaction(executor, async (trx) => {
+    // Provider管理を含むowner操作と同じ順序でlockし、role/status変更とも直列化する。
+    const owner = await findActiveOwnerMembershipForUpdate(organizationId, userId, trx)
+    if (!owner) return { ok: false, error: { type: 'AUTH_DASHBOARD_FORBIDDEN' } }
+
+    const current = await findOrganizationAuthSettingsForUpdate(organizationId, trx)
+    if (!current) {
+      return { ok: false, error: { type: 'ORGANIZATION_AUTH_SETTINGS_NOT_FOUND' } }
+    }
+
+    const next = {
+      local_auth_enabled: payload.local_auth_enabled ?? current.local_auth_enabled,
+      oidc_auth_enabled: payload.oidc_auth_enabled ?? current.oidc_auth_enabled,
+      membership_grant_ttl_seconds:
+        payload.membership_grant_ttl_seconds ?? current.membership_grant_ttl_seconds,
+      reauthentication_interval_seconds:
+        payload.reauthentication_interval_seconds ?? current.reauthentication_interval_seconds,
+    }
+
+    if (
+      (!next.local_auth_enabled && !next.oidc_auth_enabled) ||
+      next.membership_grant_ttl_seconds <= 0 ||
+      next.reauthentication_interval_seconds <= 0 ||
+      next.reauthentication_interval_seconds > next.membership_grant_ttl_seconds
+    ) {
+      return { ok: false, error: { type: 'ORGANIZATION_AUTH_SETTINGS_INVALID' } }
+    }
+
+    if (
+      !current.oidc_auth_enabled &&
+      next.oidc_auth_enabled &&
+      (await countEnabledOidcProviders(organizationId, trx)) === 0
+    ) {
+      return { ok: false, error: { type: 'OIDC_PROVIDER_REQUIRED' } }
+    }
+
+    const changedFields = (Object.keys(next) as (keyof typeof next)[]).filter(
+      (field) => current[field] !== next[field]
+    )
+    if (changedFields.length === 0) return { ok: true, value: toResponse(current) }
+
+    const updated = await updateOrganizationAuthSettings(organizationId, next, trx)
+    const beforeValues = Object.fromEntries(changedFields.map((field) => [field, current[field]]))
+    const afterValues = Object.fromEntries(changedFields.map((field) => [field, updated[field]]))
+    await insertOrganizationAuthSettingsAuditEvent(
+      {
+        actor_user_id: userId,
+        actor_membership_id: owner.id,
+        organization_id: organizationId,
+        target_type: 'organization_auth_settings',
+        target_id: organizationId,
+        action: 'update',
+        changed_fields: changedFields,
+        before_values: {
+          ...beforeValues,
+          policy_version: Number(current.policy_version),
+        } as Json,
+        after_values: {
+          ...afterValues,
+          policy_version: Number(updated.policy_version),
+        } as Json,
+      },
+      trx
+    )
+
+    return { ok: true, value: toResponse(updated) }
+  })
+}

--- a/apps/kaede/src/usecases/organization-invites/index.test.ts
+++ b/apps/kaede/src/usecases/organization-invites/index.test.ts
@@ -24,6 +24,17 @@ const invites = vi.hoisted(() => ({
   listOrganizationInvites: vi.fn(),
   revokeOrganizationInvite: vi.fn(),
 }))
+const oidc = vi.hoisted(() => ({
+  canonicalizeOidcIssuer: vi.fn(),
+  findOidcIdentity: vi.fn(),
+  findOrganizationOidcProviderContextById: vi.fn(),
+  insertOidcIdentity: vi.fn(),
+  listOidcProviders: vi.fn(),
+  revokeActiveOidcMembershipLink: vi.fn(),
+  updateOidcIdentityClaims: vi.fn(),
+  upsertOidcMembershipGrant: vi.fn(),
+  upsertOidcMembershipLink: vi.fn(),
+}))
 const local = vi.hoisted(() => ({
   insertAuthenticationEvent: vi.fn(),
   normalizeLocalLoginEmail: vi.fn((email: string) => email.trim().toLowerCase()),
@@ -39,6 +50,7 @@ const users = vi.hoisted(() => ({ findUserById: vi.fn(), insertUser: vi.fn() }))
 vi.mock('../../services/auth/index.js', () => auth)
 vi.mock('../../services/organization-invites/index.js', () => invites)
 vi.mock('../../services/organization-local-auth/index.js', () => local)
+vi.mock('../../services/organization-oidc-auth/index.js', () => oidc)
 vi.mock('../../services/profiles/index.js', () => profiles)
 vi.mock('../../services/users/index.js', () => users)
 vi.mock('../../services/db/index.js', () => ({ db: {} }))
@@ -86,6 +98,7 @@ const inviteContext = (overrides: Record<string, unknown> = {}) => ({
   revoked_at: null,
   redeemed_at: null,
   organization_name: 'Example',
+  organization_slug: 'example',
   organization_status: 'active',
   local_auth_enabled: true,
   oidc_auth_enabled: true,
@@ -101,6 +114,10 @@ describe('organization invite usecases', () => {
     auth.hashActivationToken.mockImplementation((token: string) => `hash:${token}`)
     auth.hashPassword.mockResolvedValue('password-hash')
     invites.findInviteContextByTokenHash.mockResolvedValue(inviteContext())
+    oidc.listOidcProviders.mockResolvedValue([
+      { id: '55555555-5555-4555-8555-555555555555', name: 'Google', enabled: true },
+      { id: '66666666-6666-4666-8666-666666666666', name: 'Disabled', enabled: false },
+    ])
     profiles.insertAuditEvent.mockResolvedValue(undefined)
   })
 
@@ -176,10 +193,11 @@ describe('organization invite usecases', () => {
     expect(result).toEqual({
       ok: true,
       value: {
-        organization: { name: 'Example' },
+        organization: { id: organizationId, name: 'Example', slug: 'example' },
         role: 'member',
         expires_at: '2026-08-18T10:00:00.000Z',
         authentication_methods: { local: true, oidc: true },
+        oidc_providers: [{ id: '55555555-5555-4555-8555-555555555555', display_name: 'Google' }],
       },
     })
     expect(JSON.stringify(result)).not.toContain('plain-token')

--- a/apps/kaede/src/usecases/organization-invites/index.test.ts
+++ b/apps/kaede/src/usecases/organization-invites/index.test.ts
@@ -1,0 +1,323 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import type { DbExecutor } from '../../services/executor.js'
+
+const auth = vi.hoisted(() => ({
+  createSession: vi.fn(),
+  findValidSessionByToken: vi.fn(),
+  generateActivationToken: vi.fn(),
+  hashActivationToken: vi.fn(),
+  hashPassword: vi.fn(),
+}))
+const invites = vi.hoisted(() => ({
+  consumeOrganizationInvite: vi.fn(),
+  findActorMembership: vi.fn(),
+  findActorMembershipForUpdate: vi.fn(),
+  findEnabledLocalCredentialByEmail: vi.fn(),
+  findInviteContextByTokenHash: vi.fn(),
+  findInviteContextByTokenHashForUpdate: vi.fn(),
+  findMembershipStateForInvite: vi.fn(),
+  findOrganizationInviteForUpdate: vi.fn(),
+  insertOrganizationInvite: vi.fn(),
+  insertOrganizationLocalCredential: vi.fn(),
+  insertOrganizationMembershipForInvite: vi.fn(),
+  listOrganizationInvites: vi.fn(),
+  revokeOrganizationInvite: vi.fn(),
+}))
+const local = vi.hoisted(() => ({
+  insertAuthenticationEvent: vi.fn(),
+  normalizeLocalLoginEmail: vi.fn((email: string) => email.trim().toLowerCase()),
+  upsertLocalMembershipGrant: vi.fn(),
+}))
+const profiles = vi.hoisted(() => ({
+  insertAuditEvent: vi.fn(),
+  upsertOrganizationMemberProfile: vi.fn(),
+  upsertUserProfile: vi.fn(),
+}))
+const users = vi.hoisted(() => ({ findUserById: vi.fn(), insertUser: vi.fn() }))
+
+vi.mock('../../services/auth/index.js', () => auth)
+vi.mock('../../services/organization-invites/index.js', () => invites)
+vi.mock('../../services/organization-local-auth/index.js', () => local)
+vi.mock('../../services/profiles/index.js', () => profiles)
+vi.mock('../../services/users/index.js', () => users)
+vi.mock('../../services/db/index.js', () => ({ db: {} }))
+
+import {
+  acceptOrganizationInviteWithLocalCredential,
+  issueOrganizationInvite,
+  reissueInvite,
+  verifyOrganizationInvite,
+} from './index.js'
+
+const executor = {} as DbExecutor
+const now = new Date('2026-08-11T10:00:00.000Z')
+const organizationId = '11111111-1111-4111-8111-111111111111'
+const actorUserId = '22222222-2222-4222-8222-222222222222'
+const actorMembershipId = '33333333-3333-4333-8333-333333333333'
+const inviteId = '44444444-4444-4444-8444-444444444444'
+
+const actor = (role: 'member' | 'manager' | 'owner'): RequestActor => ({
+  type: 'user',
+  user_id: actorUserId,
+  email: 'actor@example.test',
+  global_role: 'none',
+  account_state: 'active',
+  memberships: [{ organization_id: organizationId, organization_name: 'Org', role }],
+})
+
+const actorMembership = (role: string) => ({
+  id: actorMembershipId,
+  organization_id: organizationId,
+  user_id: actorUserId,
+  role,
+  status: 'active',
+  joined_at: now,
+  left_at: null,
+  created_at: now,
+  updated_at: now,
+})
+
+const inviteContext = (overrides: Record<string, unknown> = {}) => ({
+  invite_id: inviteId,
+  organization_id: organizationId,
+  role: 'member',
+  expires_at: new Date('2026-08-18T10:00:00.000Z'),
+  revoked_at: null,
+  redeemed_at: null,
+  organization_name: 'Example',
+  organization_status: 'active',
+  local_auth_enabled: true,
+  oidc_auth_enabled: true,
+  policy_version: 1,
+  membership_grant_ttl_seconds: 3600,
+  ...overrides,
+})
+
+describe('organization invite usecases', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    auth.generateActivationToken.mockReturnValue('plain-token')
+    auth.hashActivationToken.mockImplementation((token: string) => `hash:${token}`)
+    auth.hashPassword.mockResolvedValue('password-hash')
+    invites.findInviteContextByTokenHash.mockResolvedValue(inviteContext())
+    profiles.insertAuditEvent.mockResolvedValue(undefined)
+  })
+
+  it('managerはmember Inviteを発行でき、平文tokenではなくhashだけを保存する', async () => {
+    invites.findActorMembershipForUpdate.mockResolvedValue(actorMembership('manager'))
+    invites.insertOrganizationInvite.mockImplementation((value: object) =>
+      Promise.resolve({ ...value, id: inviteId, created_at: now, updated_at: now })
+    )
+
+    const result = await issueOrganizationInvite(
+      actor('manager'),
+      organizationId,
+      { role: 'member' },
+      now,
+      executor
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      value: { token: 'plain-token', expires_at: '2026-08-18T10:00:00.000Z' },
+    })
+    expect(invites.insertOrganizationInvite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token_hash: 'hash:plain-token',
+        max_uses: 1,
+        used_count: 0,
+        email: 'single-use-invite@invalid.local',
+      }),
+      executor
+    )
+    expect(JSON.stringify(invites.insertOrganizationInvite.mock.calls[0]?.[0])).not.toContain(
+      '"token":"plain-token"'
+    )
+  })
+
+  it('managerはmanager Inviteを発行できない', async () => {
+    invites.findActorMembershipForUpdate.mockResolvedValue(actorMembership('manager'))
+    await expect(
+      issueOrganizationInvite(actor('manager'), organizationId, { role: 'manager' }, now, executor)
+    ).resolves.toEqual({ ok: false, error: { type: 'AUTH_DASHBOARD_FORBIDDEN' } })
+    expect(invites.insertOrganizationInvite).not.toHaveBeenCalled()
+  })
+
+  it('ownerはmanager Inviteを発行できる', async () => {
+    invites.findActorMembershipForUpdate.mockResolvedValue(actorMembership('owner'))
+    invites.insertOrganizationInvite.mockImplementation((value: object) =>
+      Promise.resolve({ ...value, id: inviteId, created_at: now, updated_at: now })
+    )
+    await expect(
+      issueOrganizationInvite(actor('owner'), organizationId, { role: 'manager' }, now, executor)
+    ).resolves.toMatchObject({ ok: true })
+  })
+
+  it('再発行は旧Inviteをrevokeし、新しいInvite INSERTのtokenだけ返す', async () => {
+    invites.findOrganizationInviteForUpdate.mockResolvedValue({ ...inviteContext(), id: inviteId })
+    invites.findActorMembershipForUpdate.mockResolvedValue(actorMembership('owner'))
+    invites.revokeOrganizationInvite.mockResolvedValue({ id: inviteId })
+    const replacementId = '55555555-5555-4555-8555-555555555555'
+    invites.insertOrganizationInvite.mockImplementation((value: object) =>
+      Promise.resolve({ ...value, id: replacementId, created_at: now, updated_at: now })
+    )
+
+    const result = await reissueInvite(actor('owner'), organizationId, inviteId, now, executor)
+
+    expect(result).toMatchObject({ ok: true, value: { token: 'plain-token' } })
+    expect(invites.revokeOrganizationInvite).toHaveBeenCalledWith(inviteId, now, executor)
+    expect(invites.insertOrganizationInvite).toHaveBeenCalledOnce()
+  })
+
+  it('verifyは認証方式だけを返しtoken/hash/IDを露出しない', async () => {
+    invites.findInviteContextByTokenHash.mockResolvedValue(inviteContext())
+    const result = await verifyOrganizationInvite('plain-token', now, executor)
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        organization: { name: 'Example' },
+        role: 'member',
+        expires_at: '2026-08-18T10:00:00.000Z',
+        authentication_methods: { local: true, oidc: true },
+      },
+    })
+    expect(JSON.stringify(result)).not.toContain('plain-token')
+    expect(JSON.stringify(result)).not.toContain(inviteId)
+  })
+
+  it('legacy owner Inviteを無効として扱う', async () => {
+    invites.findInviteContextByTokenHash.mockResolvedValue(inviteContext({ role: 'owner' }))
+    await expect(verifyOrganizationInvite('plain-token', now, executor)).resolves.toEqual({
+      ok: false,
+      error: { type: 'INVITE_INVALID' },
+    })
+  })
+
+  it.each([
+    ['active', 'INVITE_ALREADY_MEMBER'],
+    ['suspended', 'INVITE_MEMBERSHIP_SUSPENDED'],
+  ] as const)('%s MembershipはInviteを消費せず先に拒否する', async (status, errorType) => {
+    invites.findInviteContextByTokenHashForUpdate.mockResolvedValue(inviteContext())
+    auth.findValidSessionByToken.mockResolvedValue({
+      ok: true,
+      session: { id: 'session-id', user_id: actorUserId, expires_at: new Date('2026-08-12') },
+    })
+    users.findUserById.mockResolvedValue({ id: actorUserId, status: 'active' })
+    invites.findMembershipStateForInvite.mockResolvedValue({ status })
+
+    const result = await acceptOrganizationInviteWithLocalCredential(
+      'session-token',
+      { token: 'plain-token', login_email: 'member@example.test', password: 'password' },
+      {},
+      now,
+      executor
+    )
+
+    expect(result).toEqual({ ok: false, error: { type: errorType } })
+    expect(invites.findEnabledLocalCredentialByEmail).not.toHaveBeenCalled()
+    expect(invites.consumeOrganizationInvite).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['invalid', undefined, 'INVITE_INVALID'],
+    [
+      'expired',
+      inviteContext({ expires_at: new Date('2026-08-11T09:59:59.000Z') }),
+      'INVITE_EXPIRED',
+    ],
+    ['local disabled', inviteContext({ local_auth_enabled: false }), 'AUTH_METHOD_NOT_ALLOWED'],
+  ])('%s InviteはArgon2計算前に拒否する', async (_label, context, errorType) => {
+    invites.findInviteContextByTokenHash.mockResolvedValue(context)
+
+    const result = await acceptOrganizationInviteWithLocalCredential(
+      undefined,
+      {
+        token: 'invalid-token',
+        login_email: 'member@example.test',
+        password: 'password',
+        contact_email: 'contact@example.test',
+        profile: { display_name: 'Member', locale: 'ja-JP', timezone: 'Asia/Tokyo' },
+      },
+      {},
+      now,
+      executor
+    )
+
+    expect(result).toEqual({ ok: false, error: { type: errorType } })
+    expect(auth.hashPassword).not.toHaveBeenCalled()
+    expect(invites.findInviteContextByTokenHashForUpdate).not.toHaveBeenCalled()
+  })
+
+  it('新規Local受領はUserからGrantまでを作りInviteを1回だけ消費する', async () => {
+    const membershipId = '66666666-6666-4666-8666-666666666666'
+    invites.findInviteContextByTokenHashForUpdate.mockResolvedValue(inviteContext())
+    invites.findMembershipStateForInvite.mockResolvedValue(undefined)
+    invites.findEnabledLocalCredentialByEmail.mockResolvedValue(undefined)
+    users.insertUser.mockResolvedValue({})
+    profiles.upsertUserProfile.mockResolvedValue({})
+    invites.insertOrganizationMembershipForInvite.mockImplementation((value: object) =>
+      Promise.resolve({ ...value, id: membershipId, created_at: now, updated_at: now })
+    )
+    profiles.upsertOrganizationMemberProfile.mockResolvedValue({})
+    invites.insertOrganizationLocalCredential.mockResolvedValue({ id: 'credential-id' })
+    invites.consumeOrganizationInvite.mockResolvedValue({ id: inviteId })
+    auth.createSession.mockResolvedValue({
+      token: 'new-session-token',
+      session: {
+        id: 'session-id',
+        user_id: actorUserId,
+        expires_at: new Date('2026-08-18T10:00:00.000Z'),
+      },
+    })
+    local.upsertLocalMembershipGrant.mockResolvedValue({
+      authenticated_at: now,
+      expires_at: new Date('2026-08-11T11:00:00.000Z'),
+    })
+
+    const result = await acceptOrganizationInviteWithLocalCredential(
+      undefined,
+      {
+        token: 'plain-token',
+        login_email: ' Member@Example.Test ',
+        password: 'password',
+        contact_email: 'contact@example.test',
+        profile: { display_name: 'Member', locale: 'ja-JP', timezone: 'Asia/Tokyo' },
+      },
+      {},
+      now,
+      executor
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        sessionToken: 'new-session-token',
+        membership: {
+          id: membershipId,
+          organization_id: organizationId,
+          role: 'member',
+          status: 'active',
+        },
+        grant: { auth_method: 'local' },
+      },
+    })
+    expect(invites.insertOrganizationLocalCredential).toHaveBeenCalledWith(
+      expect.objectContaining({
+        normalized_login_email: 'member@example.test',
+        password_hash: 'password-hash',
+      }),
+      executor
+    )
+    expect(invites.consumeOrganizationInvite).toHaveBeenCalledWith(
+      inviteId,
+      membershipId,
+      now,
+      executor
+    )
+    expect(local.insertAuthenticationEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ event_type: 'local_invite_accept', outcome: 'success' }),
+      executor
+    )
+  })
+})

--- a/apps/kaede/src/usecases/organization-invites/index.ts
+++ b/apps/kaede/src/usecases/organization-invites/index.ts
@@ -45,6 +45,7 @@ import {
   updateOidcIdentityClaims,
   upsertOidcMembershipGrant,
   upsertOidcMembershipLink,
+  listOidcProviders,
 } from '../../services/organization-oidc-auth/index.js'
 import {
   insertAuditEvent,
@@ -351,16 +352,26 @@ export const verifyOrganizationInvite = async (
     now
   )
   if (!valid.ok) return valid
+  const oidcProviders = valid.context.oidc_auth_enabled
+    ? (await listOidcProviders(valid.context.organization_id, executor))
+        .filter((provider) => provider.enabled)
+        .map((provider) => ({ id: provider.id, display_name: provider.name }))
+    : []
   return {
     ok: true,
     value: {
-      organization: { name: valid.context.organization_name },
+      organization: {
+        id: valid.context.organization_id,
+        name: valid.context.organization_name,
+        slug: valid.context.organization_slug,
+      },
       role: valid.context.role as InviteRole,
       expires_at: valid.context.expires_at.toISOString(),
       authentication_methods: {
         local: valid.context.local_auth_enabled === true,
         oidc: valid.context.oidc_auth_enabled === true,
       },
+      oidc_providers: oidcProviders,
     },
   } as const
 }

--- a/apps/kaede/src/usecases/organization-invites/index.ts
+++ b/apps/kaede/src/usecases/organization-invites/index.ts
@@ -22,6 +22,7 @@ import {
   findEnabledLocalCredentialByEmail,
   findInviteContextByTokenHash,
   findInviteContextByTokenHashForUpdate,
+  findInviteContextByIdForUpdate,
   findMembershipStateForInvite,
   findOrganizationInviteForUpdate,
   insertOrganizationInvite,
@@ -36,11 +37,25 @@ import {
   upsertLocalMembershipGrant,
 } from '../../services/organization-local-auth/index.js'
 import {
+  canonicalizeOidcIssuer,
+  findOidcIdentity,
+  findOrganizationOidcProviderContextById,
+  insertOidcIdentity,
+  revokeActiveOidcMembershipLink,
+  updateOidcIdentityClaims,
+  upsertOidcMembershipGrant,
+  upsertOidcMembershipLink,
+} from '../../services/organization-oidc-auth/index.js'
+import {
   insertAuditEvent,
   upsertOrganizationMemberProfile,
   upsertUserProfile,
 } from '../../services/profiles/index.js'
 import { findUserById, insertUser } from '../../services/users/index.js'
+import type {
+  CompleteOrganizationOidcResult,
+  OrganizationOidcInviteCompletionContext,
+} from '../organization-oidc-auth/callback.js'
 
 const INVITE_TTL_MS = 7 * 24 * 60 * 60 * 1000
 const LEGACY_INVITE_EMAIL = 'single-use-invite@invalid.local'
@@ -579,3 +594,246 @@ export const acceptOrganizationInviteWithLocalCredential = async (
     }
   })
 }
+
+export const acceptOrganizationInviteWithOidc = async (
+  context: OrganizationOidcInviteCompletionContext
+): Promise<CompleteOrganizationOidcResult> =>
+  runInTransaction(context.executor, async (trx) => {
+    const valid = validateInviteContext(
+      await findInviteContextByIdForUpdate(context.inviteId, context.organizationId, trx),
+      context.now
+    )
+    if (!valid.ok) {
+      return { ...valid, return_to: context.returnTo }
+    }
+    if (!valid.context.oidc_auth_enabled) {
+      return {
+        ok: false,
+        error: { type: 'AUTH_METHOD_NOT_ALLOWED' },
+        return_to: context.returnTo,
+      }
+    }
+
+    const provider = await findOrganizationOidcProviderContextById(context.providerId, trx)
+    if (
+      provider?.organization_id !== valid.context.organization_id ||
+      provider.organization_status !== 'active' ||
+      !provider.oidc_auth_enabled ||
+      !provider.provider_enabled
+    ) {
+      return {
+        ok: false,
+        error: { type: 'AUTH_METHOD_NOT_ALLOWED' },
+        return_to: context.returnTo,
+      }
+    }
+
+    let activeSession
+    if (context.transactionSessionId) {
+      if (!context.callbackSessionToken) {
+        return {
+          ok: false,
+          error: { type: 'AUTH_SESSION_REQUIRED' },
+          return_to: context.returnTo,
+        }
+      }
+      const foundSession = await findValidSessionByToken(
+        context.callbackSessionToken,
+        context.now,
+        trx
+      )
+      if (!foundSession.ok || foundSession.session.id !== context.transactionSessionId) {
+        return {
+          ok: false,
+          error: { type: 'AUTH_SESSION_REQUIRED' },
+          return_to: context.returnTo,
+        }
+      }
+      activeSession = foundSession.session
+    } else if (context.callbackSessionToken) {
+      return {
+        ok: false,
+        error: { type: 'AUTH_IDENTITY_USER_MISMATCH' },
+        return_to: context.returnTo,
+      }
+    }
+
+    const issuer = canonicalizeOidcIssuer(context.claims.issuer)
+    let identity = await findOidcIdentity(issuer, context.claims.sub, trx)
+    if (identity && activeSession && identity.user_id !== activeSession.user_id) {
+      return {
+        ok: false,
+        error: { type: 'AUTH_IDENTITY_USER_MISMATCH' },
+        return_to: context.returnTo,
+      }
+    }
+
+    const existingUserId = identity?.user_id ?? activeSession?.user_id
+    const userId = existingUserId ?? randomUUID()
+    if (existingUserId) {
+      const user = await findUserById(userId, trx)
+      if (user?.status !== 'active') {
+        return {
+          ok: false,
+          error: { type: 'AUTH_USER_DISABLED' },
+          return_to: context.returnTo,
+        }
+      }
+    }
+
+    // Membership conflict is checked before creating any User/Identity rows. Returning an
+    // expected conflict must not leave callback-side mutations committed.
+    const priorMembership = await findMembershipStateForInvite(
+      valid.context.organization_id,
+      userId,
+      trx
+    )
+    const conflict = membershipConflict(priorMembership?.status ?? null)
+    if (conflict) {
+      return { ok: false, error: conflict, return_to: context.returnTo }
+    }
+
+    if (!existingUserId) {
+      const displayName = context.claims.name.trim()
+      const contactEmail = context.claims.email.trim()
+      await insertUser(
+        {
+          id: userId,
+          email: `${userId}@invite.local.invalid`,
+          display_name: displayName,
+          password_hash: null,
+          password_changed_at: null,
+          status: 'active',
+          global_role: 'none',
+          contact_email: contactEmail,
+          normalized_contact_email: contactEmail.toLowerCase(),
+          contact_email_verified_at: context.now,
+          locked_until: null,
+        },
+        trx
+      )
+      await upsertUserProfile(
+        {
+          user_id: userId,
+          display_name: displayName,
+          locale: 'ja-JP',
+          timezone: 'Asia/Tokyo',
+        },
+        { display_name: displayName, locale: 'ja-JP', timezone: 'Asia/Tokyo' },
+        trx
+      )
+    }
+
+    if (!identity) {
+      identity = await insertOidcIdentity(
+        {
+          user_id: userId,
+          issuer,
+          subject: context.claims.sub,
+          last_claimed_email: context.claims.email,
+          last_claimed_email_verified: context.claims.emailVerified,
+        },
+        trx
+      )
+    } else {
+      identity = await updateOidcIdentityClaims(
+        identity.id,
+        {
+          last_claimed_email: context.claims.email,
+          last_claimed_email_verified: context.claims.emailVerified,
+        },
+        trx
+      )
+    }
+
+    const membership = await insertOrganizationMembershipForInvite(
+      {
+        id: randomUUID(),
+        organization_id: valid.context.organization_id,
+        user_id: userId,
+        role: valid.context.role,
+        status: 'active',
+        joined_at: context.now,
+        left_at: null,
+      },
+      trx
+    )
+    if (!membership.id) {
+      // This cannot occur for newly inserted rows. Throw so an executor supplied by an
+      // outer transaction also observes the failure and rolls the whole acceptance back.
+      throw new Error('Inserted Organization Membership has no id')
+    }
+    await upsertOrganizationMemberProfile(
+      {
+        membership_id: membership.id,
+        display_name: null,
+        height_meters: null,
+        stride_length_meters: null,
+      },
+      { display_name: null, height_meters: null, stride_length_meters: null },
+      trx
+    )
+
+    await revokeActiveOidcMembershipLink(provider.provider_id, identity.id, context.now, trx)
+    const link = await upsertOidcMembershipLink(
+      {
+        membership_id: membership.id,
+        organization_id: valid.context.organization_id,
+        user_id: userId,
+        organization_oidc_provider_id: provider.provider_id,
+        oidc_identity_id: identity.id,
+        revoked_at: null,
+      },
+      trx
+    )
+    if (
+      !(await consumeOrganizationInvite(valid.context.invite_id, membership.id, context.now, trx))
+    ) {
+      // The locked Invite was revalidated above, so a conditional consume miss signals an
+      // invariant violation. Propagate it to guarantee rollback instead of committing links.
+      throw new Error('Locked Organization Invite could not be consumed')
+    }
+
+    let createdSessionToken: string | undefined
+    if (!activeSession) {
+      const created = await createSession({ authMethod: 'oidc', userId, now: context.now }, trx)
+      activeSession = created.session
+      createdSessionToken = created.token
+    }
+    await upsertOidcMembershipGrant(
+      {
+        session_id: activeSession.id,
+        membership_id: membership.id,
+        user_id: userId,
+        auth_method: 'oidc',
+        policy_version: provider.policy_version,
+        local_credential_id: null,
+        member_oidc_identity_id: link.id,
+        authenticated_at: context.now,
+        expires_at: new Date(context.now.getTime() + provider.membership_grant_ttl_seconds * 1000),
+        revoked_at: null,
+      },
+      trx
+    )
+    await insertAuthenticationEvent(
+      {
+        event_type: 'oidc_invite_accept',
+        outcome: 'success',
+        user_id: userId,
+        organization_id: valid.context.organization_id,
+        membership_id: membership.id,
+        session_id: activeSession.id,
+        auth_method: 'oidc',
+        credential_reference_id: identity.id,
+      },
+      trx
+    )
+
+    return {
+      ok: true,
+      value: {
+        return_to: context.returnTo,
+        sessionToken: createdSessionToken,
+      },
+    }
+  })

--- a/apps/kaede/src/usecases/organization-invites/index.ts
+++ b/apps/kaede/src/usecases/organization-invites/index.ts
@@ -1,0 +1,581 @@
+import { randomUUID } from 'node:crypto'
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import type {
+  AcceptLocalOrganizationInviteRequest,
+  CreateOrganizationInviteRequest,
+  InviteRole,
+} from '../../schemas/organization-invites.js'
+import {
+  createSession,
+  findValidSessionByToken,
+  generateActivationToken,
+  hashActivationToken,
+  hashPassword,
+} from '../../services/auth/index.js'
+import type { Json } from '../../services/db/index.js'
+import { db } from '../../services/db/index.js'
+import type { DbExecutor } from '../../services/executor.js'
+import {
+  consumeOrganizationInvite,
+  findActorMembership,
+  findActorMembershipForUpdate,
+  findEnabledLocalCredentialByEmail,
+  findInviteContextByTokenHash,
+  findInviteContextByTokenHashForUpdate,
+  findMembershipStateForInvite,
+  findOrganizationInviteForUpdate,
+  insertOrganizationInvite,
+  insertOrganizationLocalCredential,
+  insertOrganizationMembershipForInvite,
+  listOrganizationInvites,
+  revokeOrganizationInvite,
+} from '../../services/organization-invites/index.js'
+import {
+  insertAuthenticationEvent,
+  normalizeLocalLoginEmail,
+  upsertLocalMembershipGrant,
+} from '../../services/organization-local-auth/index.js'
+import {
+  insertAuditEvent,
+  upsertOrganizationMemberProfile,
+  upsertUserProfile,
+} from '../../services/profiles/index.js'
+import { findUserById, insertUser } from '../../services/users/index.js'
+
+const INVITE_TTL_MS = 7 * 24 * 60 * 60 * 1000
+const LEGACY_INVITE_EMAIL = 'single-use-invite@invalid.local'
+
+export type OrganizationInviteError =
+  | { type: 'AUTH_DASHBOARD_FORBIDDEN' }
+  | { type: 'AUTH_ORGANIZATION_FORBIDDEN' }
+  | { type: 'INVITE_NOT_FOUND' }
+  | { type: 'INVITE_INVALID' }
+  | { type: 'INVITE_EXPIRED' }
+  | { type: 'INVITE_ALREADY_REDEEMED' }
+  | { type: 'INVITE_ALREADY_REVOKED' }
+  | { type: 'INVITE_ALREADY_MEMBER' }
+  | { type: 'INVITE_MEMBERSHIP_SUSPENDED' }
+  | { type: 'AUTH_METHOD_NOT_ALLOWED' }
+  | { type: 'LOCAL_LOGIN_EMAIL_CONFLICT' }
+  | { type: 'INVITE_NEW_USER_PROFILE_REQUIRED' }
+  | { type: 'INVITE_EXISTING_USER_PROFILE_NOT_ALLOWED' }
+  | { type: 'AUTH_SESSION_EXPIRED' }
+  | { type: 'AUTH_SESSION_REVOKED' }
+  | { type: 'AUTH_USER_DISABLED' }
+  | { type: 'MEMBERSHIP_PROFILE_UNAVAILABLE' }
+
+type Result<T> = { ok: true; value: T } | { ok: false; error: OrganizationInviteError }
+
+const runInTransaction = async <T>(
+  executor: DbExecutor | undefined,
+  callback: (trx: DbExecutor) => Promise<T>
+): Promise<T> => {
+  const baseExecutor = executor ?? db
+  return 'transaction' in baseExecutor
+    ? baseExecutor.transaction().execute((trx) => callback(trx))
+    : callback(baseExecutor)
+}
+
+const requireUser = (actor: RequestActor) =>
+  actor.type === 'user'
+    ? ({ ok: true, actor } as const)
+    : ({ ok: false, error: { type: 'AUTH_DASHBOARD_FORBIDDEN' } } as const)
+
+const permittedRoles = (role: string): InviteRole[] => {
+  if (role === 'owner') return ['member', 'manager']
+  if (role === 'manager') return ['member']
+  return []
+}
+
+const requireIssuer = async (
+  actor: RequestActor,
+  organizationId: string,
+  inviteRole: InviteRole | undefined,
+  executor: DbExecutor,
+  lock: boolean
+) => {
+  const user = requireUser(actor)
+  if (!user.ok) return user
+  const membership = lock
+    ? await findActorMembershipForUpdate(organizationId, user.actor.user_id, executor)
+    : await findActorMembership(organizationId, user.actor.user_id, executor)
+  if (!membership?.id || membership.status !== 'active') {
+    return { ok: false, error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' } } as const
+  }
+  const activeMembership = { ...membership, id: membership.id }
+  const allowed = permittedRoles(membership.role)
+  if (allowed.length === 0 || (inviteRole && !allowed.includes(inviteRole))) {
+    return { ok: false, error: { type: 'AUTH_DASHBOARD_FORBIDDEN' } } as const
+  }
+  return { ok: true, user: user.actor, membership: activeMembership, allowed } as const
+}
+
+const inviteStatus = (
+  invite: {
+    redeemed_at: Date | null
+    revoked_at: Date | null
+    expires_at: Date
+  },
+  now: Date
+) => {
+  if (invite.redeemed_at) return 'redeemed' as const
+  if (invite.revoked_at) return 'revoked' as const
+  if (invite.expires_at <= now) return 'expired' as const
+  return 'active' as const
+}
+
+const insertInvite = async (
+  organizationId: string,
+  role: InviteRole,
+  actorUserId: string,
+  actorMembershipId: string,
+  now: Date,
+  executor: DbExecutor
+) => {
+  const token = generateActivationToken()
+  const invite = await insertOrganizationInvite(
+    {
+      organization_id: organizationId,
+      token_hash: hashActivationToken(token),
+      role,
+      expires_at: new Date(now.getTime() + INVITE_TTL_MS),
+      revoked_at: null,
+      redeemed_at: null,
+      redeemed_membership_id: null,
+      created_by_membership_id: actorMembershipId,
+      created_by_user_id: actorUserId,
+      email: LEGACY_INVITE_EMAIL,
+      max_uses: 1,
+      used_count: 0,
+    },
+    executor
+  )
+  return { token, invite }
+}
+
+export const issueOrganizationInvite = async (
+  actor: RequestActor,
+  organizationId: string,
+  payload: CreateOrganizationInviteRequest,
+  now = new Date(),
+  executor?: DbExecutor
+): Promise<Result<{ token: string; expires_at: string }>> =>
+  runInTransaction(executor, async (trx) => {
+    const issuer = await requireIssuer(actor, organizationId, payload.role, trx, true)
+    if (!issuer.ok) return issuer
+    const created = await insertInvite(
+      organizationId,
+      payload.role,
+      issuer.user.user_id,
+      issuer.membership.id,
+      now,
+      trx
+    )
+    await insertAuditEvent(
+      {
+        actor_user_id: issuer.user.user_id,
+        actor_membership_id: issuer.membership.id,
+        organization_id: organizationId,
+        target_type: 'organization_invite',
+        target_id: created.invite.id,
+        action: 'issue',
+        changed_fields: ['role', 'expires_at'],
+        before_values: null,
+        after_values: {
+          role: payload.role,
+          expires_at: created.invite.expires_at.toISOString(),
+        } as Json,
+      },
+      trx
+    )
+    return {
+      ok: true,
+      value: { token: created.token, expires_at: created.invite.expires_at.toISOString() },
+    }
+  })
+
+export const getOrganizationInvites = async (
+  actor: RequestActor,
+  organizationId: string,
+  now = new Date(),
+  executor?: DbExecutor
+) => {
+  const issuer = await requireIssuer(actor, organizationId, undefined, executor ?? db, false)
+  if (!issuer.ok) return issuer
+  const invites = await listOrganizationInvites(organizationId, issuer.allowed, executor)
+  return {
+    ok: true,
+    value: {
+      invites: invites.map((invite) => ({
+        id: invite.id,
+        role: invite.role as InviteRole,
+        status: inviteStatus(invite, now),
+        expires_at: invite.expires_at.toISOString(),
+        created_at: invite.created_at.toISOString(),
+      })),
+    },
+  } as const
+}
+
+const lockedInviteForActor = async (
+  actor: RequestActor,
+  organizationId: string,
+  inviteId: string,
+  executor: DbExecutor
+) => {
+  const invite = await findOrganizationInviteForUpdate(organizationId, inviteId, executor)
+  if (!invite) return { ok: false, error: { type: 'INVITE_NOT_FOUND' } } as const
+  const issuer = await requireIssuer(
+    actor,
+    organizationId,
+    invite.role as InviteRole,
+    executor,
+    true
+  )
+  if (!issuer.ok) return issuer
+  return { ok: true, invite, issuer } as const
+}
+
+export const revokeInvite = async (
+  actor: RequestActor,
+  organizationId: string,
+  inviteId: string,
+  now = new Date(),
+  executor?: DbExecutor
+): Promise<Result<{ revoked: true }>> =>
+  runInTransaction(executor, async (trx) => {
+    const context = await lockedInviteForActor(actor, organizationId, inviteId, trx)
+    if (!context.ok) return context
+    if (context.invite.redeemed_at) return { ok: false, error: { type: 'INVITE_ALREADY_REDEEMED' } }
+    if (context.invite.revoked_at) return { ok: false, error: { type: 'INVITE_ALREADY_REVOKED' } }
+    const revoked = await revokeOrganizationInvite(inviteId, now, trx)
+    if (!revoked) return { ok: false, error: { type: 'INVITE_INVALID' } }
+    await insertAuditEvent(
+      {
+        actor_user_id: context.issuer.user.user_id,
+        actor_membership_id: context.issuer.membership.id,
+        organization_id: organizationId,
+        target_type: 'organization_invite',
+        target_id: inviteId,
+        action: 'revoke',
+        changed_fields: ['revoked_at'],
+        before_values: { revoked_at: null } as Json,
+        after_values: { revoked_at: now.toISOString() } as Json,
+      },
+      trx
+    )
+    return { ok: true, value: { revoked: true } }
+  })
+
+export const reissueInvite = async (
+  actor: RequestActor,
+  organizationId: string,
+  inviteId: string,
+  now = new Date(),
+  executor?: DbExecutor
+): Promise<Result<{ token: string; expires_at: string }>> =>
+  runInTransaction(executor, async (trx) => {
+    const context = await lockedInviteForActor(actor, organizationId, inviteId, trx)
+    if (!context.ok) return context
+    if (context.invite.redeemed_at) return { ok: false, error: { type: 'INVITE_ALREADY_REDEEMED' } }
+    if (context.invite.revoked_at) return { ok: false, error: { type: 'INVITE_ALREADY_REVOKED' } }
+    const revoked = await revokeOrganizationInvite(inviteId, now, trx)
+    if (!revoked) return { ok: false, error: { type: 'INVITE_INVALID' } }
+    const created = await insertInvite(
+      organizationId,
+      context.invite.role as InviteRole,
+      context.issuer.user.user_id,
+      context.issuer.membership.id,
+      now,
+      trx
+    )
+    await insertAuditEvent(
+      {
+        actor_user_id: context.issuer.user.user_id,
+        actor_membership_id: context.issuer.membership.id,
+        organization_id: organizationId,
+        target_type: 'organization_invite',
+        target_id: created.invite.id,
+        action: 'reissue',
+        changed_fields: ['revoked_at', 'replacement_invite_id'],
+        before_values: { invite_id: inviteId } as Json,
+        after_values: { invite_id: created.invite.id } as Json,
+      },
+      trx
+    )
+    return {
+      ok: true,
+      value: { token: created.token, expires_at: created.invite.expires_at.toISOString() },
+    }
+  })
+
+const validateInviteContext = (
+  context: Awaited<ReturnType<typeof findInviteContextByTokenHash>>,
+  now: Date
+) => {
+  if (
+    !context ||
+    context.revoked_at ||
+    context.organization_status !== 'active' ||
+    (context.role !== 'member' && context.role !== 'manager')
+  ) {
+    return { ok: false, error: { type: 'INVITE_INVALID' } } as const
+  }
+  if (context.redeemed_at) return { ok: false, error: { type: 'INVITE_ALREADY_REDEEMED' } } as const
+  if (context.expires_at <= now) return { ok: false, error: { type: 'INVITE_EXPIRED' } } as const
+  return { ok: true, context } as const
+}
+
+export const verifyOrganizationInvite = async (
+  token: string,
+  now = new Date(),
+  executor?: DbExecutor
+) => {
+  const valid = validateInviteContext(
+    await findInviteContextByTokenHash(hashActivationToken(token), executor),
+    now
+  )
+  if (!valid.ok) return valid
+  return {
+    ok: true,
+    value: {
+      organization: { name: valid.context.organization_name },
+      role: valid.context.role as InviteRole,
+      expires_at: valid.context.expires_at.toISOString(),
+      authentication_methods: {
+        local: valid.context.local_auth_enabled === true,
+        oidc: valid.context.oidc_auth_enabled === true,
+      },
+    },
+  } as const
+}
+
+const membershipConflict = (status: string | null) => {
+  if (status === 'active') return { type: 'INVITE_ALREADY_MEMBER' } as const
+  if (status === 'suspended') return { type: 'INVITE_MEMBERSHIP_SUSPENDED' } as const
+  return undefined
+}
+
+export interface InviteAcceptanceMetadata {
+  requestId?: string
+  userAgent?: string
+}
+
+export const acceptOrganizationInviteWithLocalCredential = async (
+  sessionToken: string | undefined,
+  payload: AcceptLocalOrganizationInviteRequest,
+  metadata: InviteAcceptanceMetadata = {},
+  now = new Date(),
+  executor?: DbExecutor
+): Promise<
+  Result<{
+    sessionToken?: string
+    session: { expires_at: string }
+    membership: { id: string; organization_id: string; role: InviteRole; status: 'active' }
+    grant: { auth_method: 'local'; authenticated_at: string; expires_at: string }
+  }>
+> => {
+  // Argon2は高コストなので、無効token/policyを軽量なreadで先に拒否する。
+  // 正しさはtransaction内のFOR UPDATE + 再検証で保証する。
+  const tokenHash = hashActivationToken(payload.token)
+  const prechecked = validateInviteContext(
+    await findInviteContextByTokenHash(tokenHash, executor),
+    now
+  )
+  if (!prechecked.ok) return prechecked
+  if (!prechecked.context.local_auth_enabled) {
+    return { ok: false, error: { type: 'AUTH_METHOD_NOT_ALLOWED' } }
+  }
+  const passwordHash = await hashPassword(payload.password)
+  return runInTransaction(executor, async (trx) => {
+    const valid = validateInviteContext(
+      await findInviteContextByTokenHashForUpdate(tokenHash, trx),
+      now
+    )
+    if (!valid.ok) return valid
+    if (!valid.context.local_auth_enabled)
+      return { ok: false, error: { type: 'AUTH_METHOD_NOT_ALLOWED' } }
+
+    let userId: string
+    let activeSession
+    let createdSessionToken: string | undefined
+    if (sessionToken) {
+      if (payload.contact_email !== undefined || payload.profile !== undefined) {
+        return { ok: false, error: { type: 'INVITE_EXISTING_USER_PROFILE_NOT_ALLOWED' } }
+      }
+      const foundSession = await findValidSessionByToken(sessionToken, now, trx)
+      if (!foundSession.ok) {
+        return {
+          ok: false,
+          error: {
+            type:
+              foundSession.error === 'SESSION_EXPIRED'
+                ? 'AUTH_SESSION_EXPIRED'
+                : 'AUTH_SESSION_REVOKED',
+          },
+        }
+      }
+      activeSession = foundSession.session
+      userId = activeSession.user_id
+      const user = await findUserById(userId, trx)
+      if (user?.status !== 'active') return { ok: false, error: { type: 'AUTH_USER_DISABLED' } }
+    } else {
+      if (!payload.contact_email || !payload.profile) {
+        return { ok: false, error: { type: 'INVITE_NEW_USER_PROFILE_REQUIRED' } }
+      }
+      userId = randomUUID()
+    }
+
+    const priorMembership = await findMembershipStateForInvite(
+      valid.context.organization_id,
+      userId,
+      trx
+    )
+    const conflict = membershipConflict(priorMembership?.status ?? null)
+    if (conflict) return { ok: false, error: conflict }
+
+    const normalizedLoginEmail = normalizeLocalLoginEmail(payload.login_email)
+    if (
+      await findEnabledLocalCredentialByEmail(
+        valid.context.organization_id,
+        normalizedLoginEmail,
+        trx
+      )
+    ) {
+      return { ok: false, error: { type: 'LOCAL_LOGIN_EMAIL_CONFLICT' } }
+    }
+
+    if (!sessionToken) {
+      const profile = payload.profile
+      const contactEmail = payload.contact_email
+      if (!profile || !contactEmail) {
+        return { ok: false, error: { type: 'INVITE_NEW_USER_PROFILE_REQUIRED' } }
+      }
+      const normalizedContactEmail = contactEmail.trim()
+      await insertUser(
+        {
+          id: userId,
+          email: `${userId}@invite.local.invalid`,
+          display_name: profile.display_name,
+          password_hash: null,
+          password_changed_at: null,
+          status: 'active',
+          global_role: 'none',
+          contact_email: normalizedContactEmail,
+          normalized_contact_email: normalizedContactEmail.toLowerCase(),
+          contact_email_verified_at: null,
+          locked_until: null,
+        },
+        trx
+      )
+      await upsertUserProfile(
+        {
+          user_id: userId,
+          display_name: profile.display_name,
+          locale: profile.locale,
+          timezone: profile.timezone,
+        },
+        profile,
+        trx
+      )
+    }
+
+    const membership = await insertOrganizationMembershipForInvite(
+      {
+        id: randomUUID(),
+        organization_id: valid.context.organization_id,
+        user_id: userId,
+        role: valid.context.role,
+        status: 'active',
+        joined_at: now,
+        left_at: null,
+      },
+      trx
+    )
+    if (!membership.id) return { ok: false, error: { type: 'MEMBERSHIP_PROFILE_UNAVAILABLE' } }
+    await upsertOrganizationMemberProfile(
+      {
+        membership_id: membership.id,
+        display_name: null,
+        height_meters: null,
+        stride_length_meters: null,
+      },
+      { display_name: null, height_meters: null, stride_length_meters: null },
+      trx
+    )
+    const credential = await insertOrganizationLocalCredential(
+      {
+        membership_id: membership.id,
+        organization_id: valid.context.organization_id,
+        login_email: payload.login_email.trim(),
+        normalized_login_email: normalizedLoginEmail,
+        password_hash: passwordHash,
+        password_changed_at: now,
+        failed_login_attempts: 0,
+        locked_until: null,
+        enabled: true,
+      },
+      trx
+    )
+    if (!(await consumeOrganizationInvite(valid.context.invite_id, membership.id, now, trx))) {
+      return { ok: false, error: { type: 'INVITE_INVALID' } }
+    }
+
+    if (!activeSession) {
+      const created = await createSession({ authMethod: 'password', userId, now }, trx)
+      activeSession = created.session
+      createdSessionToken = created.token
+    }
+    const grantExpiresAt = new Date(
+      now.getTime() + (valid.context.membership_grant_ttl_seconds ?? 0) * 1000
+    )
+    const grant = await upsertLocalMembershipGrant(
+      {
+        session_id: activeSession.id,
+        membership_id: membership.id,
+        user_id: userId,
+        auth_method: 'local',
+        policy_version: valid.context.policy_version ?? 1,
+        local_credential_id: credential.id,
+        member_oidc_identity_id: null,
+        authenticated_at: now,
+        expires_at: grantExpiresAt,
+        revoked_at: null,
+      },
+      trx
+    )
+    await insertAuthenticationEvent(
+      {
+        event_type: 'local_invite_accept',
+        outcome: 'success',
+        user_id: userId,
+        organization_id: valid.context.organization_id,
+        membership_id: membership.id,
+        session_id: activeSession.id,
+        auth_method: 'local',
+        credential_reference_id: credential.id,
+        request_id: metadata.requestId ?? null,
+        user_agent: metadata.userAgent ?? null,
+      },
+      trx
+    )
+    return {
+      ok: true,
+      value: {
+        sessionToken: createdSessionToken,
+        session: { expires_at: activeSession.expires_at.toISOString() },
+        membership: {
+          id: membership.id,
+          organization_id: membership.organization_id,
+          role: membership.role as InviteRole,
+          status: 'active',
+        },
+        grant: {
+          auth_method: 'local',
+          authenticated_at: grant.authenticated_at.toISOString(),
+          expires_at: grant.expires_at.toISOString(),
+        },
+      },
+    }
+  })
+}

--- a/apps/kaede/src/usecases/organization-local-auth/index.ts
+++ b/apps/kaede/src/usecases/organization-local-auth/index.ts
@@ -1,0 +1,6 @@
+export { loginToOrganizationWithLocalCredential } from './login.js'
+export type {
+  LocalOrganizationLoginError,
+  LocalOrganizationLoginMetadata,
+  LocalOrganizationLoginResult,
+} from './login.js'

--- a/apps/kaede/src/usecases/organization-local-auth/login.ts
+++ b/apps/kaede/src/usecases/organization-local-auth/login.ts
@@ -1,0 +1,268 @@
+import type { LocalOrganizationLoginRequest } from '../../schemas/organization-local-auth.js'
+import { createSession, findValidSessionByToken } from '../../services/auth/index.js'
+import { verifyPassword } from '../../services/auth/password.js'
+import { db } from '../../services/db/index.js'
+import type { DbExecutor } from '../../services/executor.js'
+import {
+  findLocalCredentialContextForUpdate,
+  findOrganizationLocalAuthPolicyBySlug,
+  insertAuthenticationEvent,
+  normalizeLocalLoginEmail,
+  updateLocalCredentialAttempts,
+  upsertLocalMembershipGrant,
+} from '../../services/organization-local-auth/index.js'
+
+const MAX_FAILED_LOGIN_ATTEMPTS = 5
+const LOGIN_LOCK_DURATION_MS = 15 * 60 * 1000
+const DUMMY_PASSWORD_HASH =
+  '$argon2id$v=19$m=65536,t=3,p=4$x+P5/ReUqXmnmvL6nvl/sw$U6rmJ/nwCpXHwg93wQKEQxKBgVGC6n+ZSV1KumkR8i8'
+
+export type LocalOrganizationLoginError =
+  | { type: 'AUTH_INVALID_CREDENTIALS' }
+  | { type: 'AUTH_METHOD_NOT_ALLOWED' }
+  | { type: 'AUTH_CREDENTIAL_LOCKED' }
+  | { type: 'AUTH_IDENTITY_USER_MISMATCH' }
+  | { type: 'AUTH_MEMBERSHIP_NOT_ACTIVE' }
+  | { type: 'AUTH_USER_DISABLED' }
+  | { type: 'AUTH_SESSION_EXPIRED' }
+  | { type: 'AUTH_SESSION_REVOKED' }
+
+export type LocalOrganizationLoginResult =
+  | {
+      ok: true
+      value: {
+        sessionToken?: string
+        session: { id: string; expires_at: string }
+        membership: {
+          id: string
+          organization_id: string
+          role: 'member' | 'manager' | 'owner'
+          status: 'active'
+        }
+        grant: {
+          auth_method: 'local'
+          authenticated_at: string
+          expires_at: string
+        }
+        return_to: string
+      }
+    }
+  | { ok: false; error: LocalOrganizationLoginError }
+
+export interface LocalOrganizationLoginMetadata {
+  requestId?: string
+  userAgent?: string
+}
+
+const runInTransaction = async <T>(
+  executor: DbExecutor | undefined,
+  callback: (trx: DbExecutor) => Promise<T>
+): Promise<T> => {
+  const baseExecutor = executor ?? db
+
+  if ('transaction' in baseExecutor) {
+    return baseExecutor.transaction().execute((trx) => callback(trx))
+  }
+
+  return callback(baseExecutor)
+}
+
+const sessionError = (
+  error: 'SESSION_NOT_FOUND' | 'SESSION_EXPIRED' | 'SESSION_REVOKED'
+): LocalOrganizationLoginError => {
+  switch (error) {
+    case 'SESSION_EXPIRED':
+      return { type: 'AUTH_SESSION_EXPIRED' }
+    case 'SESSION_REVOKED':
+      return { type: 'AUTH_SESSION_REVOKED' }
+    case 'SESSION_NOT_FOUND':
+      return { type: 'AUTH_INVALID_CREDENTIALS' }
+  }
+}
+
+export const loginToOrganizationWithLocalCredential = async (
+  organizationSlug: string,
+  sessionToken: string | undefined,
+  payload: LocalOrganizationLoginRequest,
+  metadata: LocalOrganizationLoginMetadata = {},
+  now: Date = new Date(),
+  executor?: DbExecutor
+): Promise<LocalOrganizationLoginResult> => {
+  return runInTransaction(executor, async (trx) => {
+    const policy = await findOrganizationLocalAuthPolicyBySlug(organizationSlug, trx)
+
+    if (!policy?.local_auth_enabled || policy.organization_status !== 'active') {
+      return { ok: false, error: { type: 'AUTH_METHOD_NOT_ALLOWED' } } as const
+    }
+
+    const normalizedLoginEmail = normalizeLocalLoginEmail(payload.login_email)
+    const credential = await findLocalCredentialContextForUpdate(
+      policy.organization_id,
+      normalizedLoginEmail,
+      trx
+    )
+
+    if (!credential) {
+      await verifyPassword(DUMMY_PASSWORD_HASH, payload.password)
+      await insertAuthenticationEvent(
+        {
+          event_type: 'local_login',
+          outcome: 'failure',
+          failure_code: 'AUTH_INVALID_CREDENTIALS',
+          organization_id: policy.organization_id,
+          auth_method: 'local',
+          request_id: metadata.requestId ?? null,
+          user_agent: metadata.userAgent ?? null,
+        },
+        trx
+      )
+      return { ok: false, error: { type: 'AUTH_INVALID_CREDENTIALS' } } as const
+    }
+
+    const eventType = sessionToken ? 'local_reauthenticate' : 'local_login'
+    const eventContext = {
+      event_type: eventType,
+      user_id: credential.user_id,
+      organization_id: credential.organization_id,
+      membership_id: credential.membership_id,
+      auth_method: 'local' as const,
+      credential_reference_id: credential.credential_id,
+      request_id: metadata.requestId ?? null,
+      user_agent: metadata.userAgent ?? null,
+    }
+
+    if (credential.locked_until && credential.locked_until > now) {
+      await insertAuthenticationEvent(
+        {
+          ...eventContext,
+          outcome: 'failure',
+          failure_code: 'AUTH_CREDENTIAL_LOCKED',
+        },
+        trx
+      )
+      return { ok: false, error: { type: 'AUTH_CREDENTIAL_LOCKED' } } as const
+    }
+
+    const passwordMatches = await verifyPassword(credential.password_hash, payload.password)
+
+    if (!passwordMatches) {
+      const failedAttempts = credential.failed_login_attempts + 1
+      const lockedUntil =
+        failedAttempts >= MAX_FAILED_LOGIN_ATTEMPTS
+          ? new Date(now.getTime() + LOGIN_LOCK_DURATION_MS)
+          : null
+
+      await updateLocalCredentialAttempts(
+        credential.credential_id,
+        { failed_login_attempts: failedAttempts, locked_until: lockedUntil },
+        trx
+      )
+      await insertAuthenticationEvent(
+        {
+          ...eventContext,
+          outcome: 'failure',
+          failure_code: lockedUntil ? 'AUTH_CREDENTIAL_LOCKED' : 'AUTH_INVALID_CREDENTIALS',
+        },
+        trx
+      )
+      return lockedUntil
+        ? ({ ok: false, error: { type: 'AUTH_CREDENTIAL_LOCKED' } } as const)
+        : ({ ok: false, error: { type: 'AUTH_INVALID_CREDENTIALS' } } as const)
+    }
+
+    if (credential.user_status !== 'active') {
+      return { ok: false, error: { type: 'AUTH_USER_DISABLED' } } as const
+    }
+
+    if (credential.membership_status !== 'active' || !credential.membership_id) {
+      return { ok: false, error: { type: 'AUTH_MEMBERSHIP_NOT_ACTIVE' } } as const
+    }
+
+    let activeSession
+    let createdSessionToken: string | undefined
+
+    if (sessionToken) {
+      const sessionResult = await findValidSessionByToken(sessionToken, now, trx)
+      if (!sessionResult.ok) {
+        return { ok: false, error: sessionError(sessionResult.error) } as const
+      }
+      if (sessionResult.session.user_id !== credential.user_id) {
+        await insertAuthenticationEvent(
+          {
+            ...eventContext,
+            session_id: sessionResult.session.id,
+            outcome: 'failure',
+            failure_code: 'AUTH_IDENTITY_USER_MISMATCH',
+          },
+          trx
+        )
+        return { ok: false, error: { type: 'AUTH_IDENTITY_USER_MISMATCH' } } as const
+      }
+      activeSession = sessionResult.session
+    } else {
+      const created = await createSession(
+        { authMethod: 'password', userId: credential.user_id, now },
+        trx
+      )
+      activeSession = created.session
+      createdSessionToken = created.token
+    }
+
+    const authenticatedAt = now
+    const grantExpiresAt = new Date(
+      authenticatedAt.getTime() + policy.membership_grant_ttl_seconds * 1000
+    )
+    const grant = await upsertLocalMembershipGrant(
+      {
+        session_id: activeSession.id,
+        membership_id: credential.membership_id,
+        user_id: credential.user_id,
+        auth_method: 'local',
+        policy_version: policy.policy_version,
+        local_credential_id: credential.credential_id,
+        member_oidc_identity_id: null,
+        authenticated_at: authenticatedAt,
+        expires_at: grantExpiresAt,
+        revoked_at: null,
+      },
+      trx
+    )
+
+    await updateLocalCredentialAttempts(
+      credential.credential_id,
+      { failed_login_attempts: 0, locked_until: null },
+      trx
+    )
+    await insertAuthenticationEvent(
+      {
+        ...eventContext,
+        session_id: activeSession.id,
+        outcome: 'success',
+      },
+      trx
+    )
+
+    return {
+      ok: true,
+      value: {
+        sessionToken: createdSessionToken,
+        session: {
+          id: activeSession.id,
+          expires_at: activeSession.expires_at.toISOString(),
+        },
+        membership: {
+          id: credential.membership_id,
+          organization_id: credential.organization_id,
+          role: credential.membership_role as 'member' | 'manager' | 'owner',
+          status: 'active',
+        },
+        grant: {
+          auth_method: 'local',
+          authenticated_at: grant.authenticated_at.toISOString(),
+          expires_at: grant.expires_at.toISOString(),
+        },
+        return_to: payload.return_to,
+      },
+    }
+  })
+}

--- a/apps/kaede/src/usecases/organization-local-credentials/index.ts
+++ b/apps/kaede/src/usecases/organization-local-credentials/index.ts
@@ -1,0 +1,339 @@
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import type {
+  DisableOrganizationLocalCredentialRequest,
+  PutOrganizationLocalCredentialRequest,
+} from '../../schemas/organization-local-credentials.js'
+import { hashPassword, verifyPassword } from '../../services/auth/index.js'
+import type { Json } from '../../services/db/index.js'
+import { db } from '../../services/db/index.js'
+import type { DbExecutor } from '../../services/executor.js'
+import { normalizeLocalLoginEmail } from '../../services/organization-local-auth/index.js'
+import {
+  findEnabledLocalCredentialByNormalizedEmail,
+  findLocalCredentialByMembership,
+  findLocalCredentialMembershipContext,
+  findRecentCredentialManagementGrant,
+  findRecentUserSession,
+  hasUsableOidcLink,
+  insertLocalCredentialAuditEvent,
+  insertManagedLocalCredential,
+  revokeGrantsFromLocalCredential,
+  updateManagedLocalCredential,
+} from '../../services/organization-local-credentials/index.js'
+
+export type OrganizationLocalCredentialManagementError =
+  | { type: 'AUTH_UNAUTHENTICATED' }
+  | { type: 'AUTH_ORGANIZATION_FORBIDDEN' }
+  | { type: 'AUTH_METHOD_NOT_ALLOWED' }
+  | { type: 'AUTH_MEMBERSHIP_REAUTHENTICATION_REQUIRED' }
+  | { type: 'AUTH_INVALID_CREDENTIALS' }
+  | { type: 'LOCAL_CREDENTIAL_NOT_FOUND' }
+  | { type: 'LOCAL_CREDENTIAL_LAST_AUTH_METHOD' }
+  | { type: 'LOCAL_LOGIN_EMAIL_CONFLICT' }
+
+type Result<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: OrganizationLocalCredentialManagementError }
+
+export interface LocalCredentialManagementMetadata {
+  requestId?: string
+  userAgent?: string
+}
+
+type CredentialMetadata =
+  | {
+      organization_id: string
+      membership_id: string
+      configured: false
+    }
+  | {
+      organization_id: string
+      membership_id: string
+      configured: true
+      login_email: string
+      enabled: boolean
+      password_changed_at: string
+      updated_at: string
+    }
+
+const runInTransaction = async <T>(
+  executor: DbExecutor | undefined,
+  callback: (trx: DbExecutor) => Promise<T>
+) => {
+  const base = executor ?? db
+  return 'transaction' in base ? base.transaction().execute(callback) : callback(base)
+}
+
+const userIdFromActor = (actor: RequestActor) => (actor.type === 'user' ? actor.user_id : undefined)
+
+const toMetadata = (
+  organizationId: string,
+  membershipId: string,
+  credential: Awaited<ReturnType<typeof findLocalCredentialByMembership>>
+): CredentialMetadata =>
+  credential
+    ? {
+        organization_id: organizationId,
+        membership_id: membershipId,
+        configured: true,
+        login_email: credential.login_email,
+        enabled: credential.enabled,
+        password_changed_at: credential.password_changed_at.toISOString(),
+        updated_at: credential.updated_at.toISOString(),
+      }
+    : { organization_id: organizationId, membership_id: membershipId, configured: false }
+
+const authorizeSensitiveChange = async (
+  currentPassword: string | undefined,
+  credential: Awaited<ReturnType<typeof findLocalCredentialByMembership>>,
+  context: NonNullable<Awaited<ReturnType<typeof findLocalCredentialMembershipContext>>>,
+  sessionId: string,
+  now: Date,
+  executor: DbExecutor
+): Promise<Result<true>> => {
+  const recentAfter = new Date(now.getTime() - context.reauthentication_interval_seconds * 1000)
+  if (!credential) {
+    const recentSession = await findRecentUserSession(
+      sessionId,
+      context.user_id,
+      recentAfter,
+      now,
+      executor
+    )
+    return recentSession
+      ? { ok: true, value: true }
+      : { ok: false, error: { type: 'AUTH_MEMBERSHIP_REAUTHENTICATION_REQUIRED' } }
+  }
+
+  if (currentPassword !== undefined) {
+    if (!(await verifyPassword(credential.password_hash, currentPassword))) {
+      return { ok: false, error: { type: 'AUTH_INVALID_CREDENTIALS' } }
+    }
+    return { ok: true, value: true }
+  }
+
+  const grant = await findRecentCredentialManagementGrant(
+    sessionId,
+    context.membership_id,
+    context.user_id,
+    context.policy_version,
+    recentAfter,
+    now,
+    executor
+  )
+  return grant
+    ? { ok: true, value: true }
+    : { ok: false, error: { type: 'AUTH_MEMBERSHIP_REAUTHENTICATION_REQUIRED' } }
+}
+
+const isLocalLoginEmailConflict = (error: unknown) => {
+  if (!error || typeof error !== 'object') return false
+  const databaseError = error as { code?: string; constraint?: string }
+  return (
+    databaseError.code === '23505' &&
+    databaseError.constraint === 'organization_local_credentials_active_email_key'
+  )
+}
+
+export const getMyOrganizationLocalCredential = async (
+  actor: RequestActor,
+  organizationId: string,
+  executor: DbExecutor = db
+): Promise<Result<CredentialMetadata>> => {
+  const userId = userIdFromActor(actor)
+  if (!userId) return { ok: false, error: { type: 'AUTH_UNAUTHENTICATED' } }
+
+  const context = await findLocalCredentialMembershipContext(organizationId, userId, executor)
+  if (!context) return { ok: false, error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' } }
+  const credential = await findLocalCredentialByMembership(context.membership_id, executor)
+  return {
+    ok: true,
+    value: toMetadata(context.organization_id, context.membership_id, credential),
+  }
+}
+
+export const putMyOrganizationLocalCredential = async (
+  actor: RequestActor,
+  sessionId: string | undefined,
+  organizationId: string,
+  payload: PutOrganizationLocalCredentialRequest,
+  metadata: LocalCredentialManagementMetadata = {},
+  now = new Date(),
+  executor?: DbExecutor
+): Promise<Result<CredentialMetadata>> => {
+  const userId = userIdFromActor(actor)
+  if (!userId || !sessionId) return { ok: false, error: { type: 'AUTH_UNAUTHENTICATED' } }
+
+  const prechecked = await findLocalCredentialMembershipContext(
+    organizationId,
+    userId,
+    executor ?? db
+  )
+  if (!prechecked) return { ok: false, error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' } }
+  if (!prechecked.local_auth_enabled) {
+    return { ok: false, error: { type: 'AUTH_METHOD_NOT_ALLOWED' } }
+  }
+
+  const passwordHash = await hashPassword(payload.new_password)
+  const normalizedLoginEmail = normalizeLocalLoginEmail(payload.login_email)
+
+  try {
+    return await runInTransaction(executor, async (trx) => {
+      const context = await findLocalCredentialMembershipContext(organizationId, userId, trx, true)
+      if (!context) return { ok: false, error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' } }
+      if (!context.local_auth_enabled) {
+        return { ok: false, error: { type: 'AUTH_METHOD_NOT_ALLOWED' } }
+      }
+
+      const current = await findLocalCredentialByMembership(context.membership_id, trx, true)
+      const authorized = await authorizeSensitiveChange(
+        payload.current_password,
+        current,
+        context,
+        sessionId,
+        now,
+        trx
+      )
+      if (!authorized.ok) return authorized
+
+      if (
+        await findEnabledLocalCredentialByNormalizedEmail(
+          organizationId,
+          normalizedLoginEmail,
+          current?.id,
+          trx
+        )
+      ) {
+        return { ok: false, error: { type: 'LOCAL_LOGIN_EMAIL_CONFLICT' } }
+      }
+
+      const credential = current
+        ? await updateManagedLocalCredential(
+            current.id,
+            {
+              login_email: payload.login_email.trim(),
+              normalized_login_email: normalizedLoginEmail,
+              password_hash: passwordHash,
+              password_changed_at: now,
+              failed_login_attempts: 0,
+              locked_until: null,
+              enabled: true,
+            },
+            trx
+          )
+        : await insertManagedLocalCredential(
+            {
+              membership_id: context.membership_id,
+              organization_id: context.organization_id,
+              login_email: payload.login_email.trim(),
+              normalized_login_email: normalizedLoginEmail,
+              password_hash: passwordHash,
+              password_changed_at: now,
+              failed_login_attempts: 0,
+              locked_until: null,
+              enabled: true,
+            },
+            trx
+          )
+
+      if (current) await revokeGrantsFromLocalCredential(current.id, now, trx)
+      const changedFields = current
+        ? [
+            ...(current.login_email !== credential.login_email ? ['login_email'] : []),
+            'password',
+            ...(current.enabled ? [] : ['enabled']),
+          ]
+        : ['login_email', 'password', 'enabled']
+      await insertLocalCredentialAuditEvent(
+        {
+          actor_user_id: userId,
+          actor_membership_id: context.membership_id,
+          organization_id: organizationId,
+          target_type: 'organization_local_credential',
+          target_id: credential.id,
+          action: current ? 'update' : 'create',
+          changed_fields: changedFields,
+          before_values: current
+            ? ({ login_email: current.login_email, enabled: current.enabled } as Json)
+            : null,
+          after_values: {
+            login_email: credential.login_email,
+            enabled: credential.enabled,
+          } as Json,
+          request_id: metadata.requestId ?? null,
+        },
+        trx
+      )
+      return {
+        ok: true,
+        value: toMetadata(context.organization_id, context.membership_id, credential),
+      }
+    })
+  } catch (error) {
+    if (isLocalLoginEmailConflict(error)) {
+      return { ok: false, error: { type: 'LOCAL_LOGIN_EMAIL_CONFLICT' } }
+    }
+    throw error
+  }
+}
+
+export const disableMyOrganizationLocalCredential = async (
+  actor: RequestActor,
+  sessionId: string | undefined,
+  organizationId: string,
+  payload: DisableOrganizationLocalCredentialRequest,
+  metadata: LocalCredentialManagementMetadata = {},
+  now = new Date(),
+  executor?: DbExecutor
+): Promise<Result<CredentialMetadata>> => {
+  const userId = userIdFromActor(actor)
+  if (!userId || !sessionId) return { ok: false, error: { type: 'AUTH_UNAUTHENTICATED' } }
+
+  return runInTransaction(executor, async (trx) => {
+    const context = await findLocalCredentialMembershipContext(organizationId, userId, trx, true)
+    if (!context) return { ok: false, error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' } }
+    const current = await findLocalCredentialByMembership(context.membership_id, trx, true)
+    if (!current) return { ok: false, error: { type: 'LOCAL_CREDENTIAL_NOT_FOUND' } }
+
+    const authorized = await authorizeSensitiveChange(
+      payload.current_password,
+      current,
+      context,
+      sessionId,
+      now,
+      trx
+    )
+    if (!authorized.ok) return authorized
+    if (!current.enabled) {
+      return {
+        ok: true,
+        value: toMetadata(context.organization_id, context.membership_id, current),
+      }
+    }
+    if (!(await hasUsableOidcLink(context.membership_id, organizationId, trx))) {
+      return { ok: false, error: { type: 'LOCAL_CREDENTIAL_LAST_AUTH_METHOD' } }
+    }
+
+    const credential = await updateManagedLocalCredential(current.id, { enabled: false }, trx)
+    await revokeGrantsFromLocalCredential(current.id, now, trx)
+    await insertLocalCredentialAuditEvent(
+      {
+        actor_user_id: userId,
+        actor_membership_id: context.membership_id,
+        organization_id: organizationId,
+        target_type: 'organization_local_credential',
+        target_id: credential.id,
+        action: 'disable',
+        changed_fields: ['enabled'],
+        before_values: { login_email: current.login_email, enabled: true } as Json,
+        after_values: { login_email: credential.login_email, enabled: false } as Json,
+        request_id: metadata.requestId ?? null,
+      },
+      trx
+    )
+    return {
+      ok: true,
+      value: toMetadata(context.organization_id, context.membership_id, credential),
+    }
+  })
+}

--- a/apps/kaede/src/usecases/organization-oidc-auth/callback.ts
+++ b/apps/kaede/src/usecases/organization-oidc-auth/callback.ts
@@ -68,6 +68,12 @@ export type CompleteOrganizationOidcError =
   | { type: 'AUTH_MEMBERSHIP_NOT_ACTIVE' }
   | { type: 'AUTH_SESSION_REQUIRED' }
   | { type: 'AUTH_USER_DISABLED' }
+  | { type: 'AUTH_METHOD_NOT_ALLOWED' }
+  | { type: 'INVITE_INVALID' }
+  | { type: 'INVITE_EXPIRED' }
+  | { type: 'INVITE_ALREADY_REDEEMED' }
+  | { type: 'INVITE_ALREADY_MEMBER' }
+  | { type: 'INVITE_MEMBERSHIP_SUSPENDED' }
 
 export type CompleteOrganizationOidcResult =
   | {

--- a/apps/kaede/src/usecases/organization-oidc-auth/callback.ts
+++ b/apps/kaede/src/usecases/organization-oidc-auth/callback.ts
@@ -1,0 +1,400 @@
+import type { GoogleIdTokenClaims } from '../../services/auth/index.js'
+import { createSession, findValidSessionByToken } from '../../services/auth/index.js'
+import { db } from '../../services/db/index.js'
+import type { DbExecutor } from '../../services/executor.js'
+import {
+  canonicalizeOidcIssuer,
+  claimOidcLoginTransaction,
+  decryptPkceCodeVerifier,
+  findActiveMembershipByOrganizationAndUser,
+  findActiveOidcMembershipLink,
+  findOidcIdentity,
+  findOrganizationOidcProviderContextById,
+  findValidSessionById,
+  hashOidcState,
+  insertOidcAuthenticationEvent,
+  insertOidcIdentity,
+  isGoogleIssuer,
+  isHostedDomainAllowed,
+  oidcLoginTransactionStateExists,
+  updateOidcIdentityClaims,
+  upsertOidcMembershipGrant,
+  upsertOidcMembershipLink,
+} from '../../services/organization-oidc-auth/index.js'
+
+export const isOrganizationOidcTransactionState = (state: string, executor: DbExecutor = db) =>
+  oidcLoginTransactionStateExists(hashOidcState(state), executor)
+
+export interface OrganizationOidcCallbackClient {
+  exchangeCodeForIdToken(params: { code: string; codeVerifier: string }): Promise<string>
+  verifyIdToken(params: { idToken: string; nonce: string }): Promise<GoogleIdTokenClaims>
+}
+
+export interface OrganizationOidcInviteCompletionContext {
+  inviteId: string
+  organizationId: string
+  providerId: string
+  transactionSessionId: string | null
+  callbackSessionToken?: string
+  claims: GoogleIdTokenClaims
+  returnTo: string
+  now: Date
+  executor: DbExecutor
+}
+
+export type CompleteOrganizationOidcInvite = (
+  context: OrganizationOidcInviteCompletionContext
+) => Promise<CompleteOrganizationOidcResult>
+
+export interface CompleteOrganizationOidcOptions {
+  client: OrganizationOidcCallbackClient
+  configuredClientId: string
+  transactionSecret: string
+  sessionToken?: string
+  completeInvite?: CompleteOrganizationOidcInvite
+  now?: Date
+  executor?: DbExecutor
+}
+
+export type CompleteOrganizationOidcError =
+  | { type: 'OIDC_TRANSACTION_INVALID' }
+  | { type: 'OIDC_PROVIDER_ERROR' }
+  | { type: 'OIDC_PROVIDER_CONFIG_INVALID' }
+  | { type: 'OIDC_HOSTED_DOMAIN_NOT_ALLOWED' }
+  | { type: 'OIDC_EMAIL_UNVERIFIED' }
+  | { type: 'OIDC_IDENTITY_NOT_LINKED' }
+  | { type: 'OIDC_INVITE_COMPLETION_REQUIRED' }
+  | { type: 'AUTH_IDENTITY_USER_MISMATCH' }
+  | { type: 'AUTH_MEMBERSHIP_NOT_ACTIVE' }
+  | { type: 'AUTH_SESSION_REQUIRED' }
+  | { type: 'AUTH_USER_DISABLED' }
+
+export type CompleteOrganizationOidcResult =
+  | {
+      ok: true
+      value: {
+        return_to: string
+        sessionToken?: string
+      }
+    }
+  | {
+      ok: false
+      error: CompleteOrganizationOidcError
+      return_to?: string
+    }
+
+const runInTransaction = async <T>(
+  executor: DbExecutor | undefined,
+  callback: (trx: DbExecutor) => Promise<T>
+) => {
+  const base = executor ?? db
+  return 'transaction' in base ? base.transaction().execute(callback) : callback(base)
+}
+
+export const completeOrganizationOidc = async (
+  code: string | undefined,
+  state: string | undefined,
+  options: CompleteOrganizationOidcOptions
+): Promise<CompleteOrganizationOidcResult> => {
+  const now = options.now ?? new Date()
+  if (!state) {
+    return { ok: false, error: { type: 'OIDC_TRANSACTION_INVALID' } }
+  }
+
+  // stateをIdP通信より先に原子的に消費し、同じcallbackを二度処理しない。
+  const transaction = await claimOidcLoginTransaction(
+    hashOidcState(state),
+    now,
+    options.executor ?? db
+  )
+  if (!transaction) {
+    return { ok: false, error: { type: 'OIDC_TRANSACTION_INVALID' } }
+  }
+  if (!code) {
+    return {
+      ok: false,
+      error: { type: 'OIDC_PROVIDER_ERROR' },
+      return_to: transaction.return_to,
+    }
+  }
+
+  const provider = await findOrganizationOidcProviderContextById(
+    transaction.organization_oidc_provider_id,
+    options.executor ?? db
+  )
+  if (
+    provider?.organization_id !== transaction.organization_id ||
+    provider.organization_status !== 'active' ||
+    !provider.oidc_auth_enabled ||
+    !provider.provider_enabled
+  ) {
+    return {
+      ok: false,
+      error: { type: 'OIDC_PROVIDER_CONFIG_INVALID' },
+      return_to: transaction.return_to,
+    }
+  }
+  if (!isGoogleIssuer(provider.issuer) || provider.client_id !== options.configuredClientId) {
+    return {
+      ok: false,
+      error: { type: 'OIDC_PROVIDER_CONFIG_INVALID' },
+      return_to: transaction.return_to,
+    }
+  }
+
+  let claims: GoogleIdTokenClaims
+  try {
+    const codeVerifier = decryptPkceCodeVerifier(
+      transaction.pkce_code_verifier_ciphertext,
+      options.transactionSecret
+    )
+    const idToken = await options.client.exchangeCodeForIdToken({ code, codeVerifier })
+    claims = await options.client.verifyIdToken({ idToken, nonce: transaction.nonce })
+  } catch {
+    return {
+      ok: false,
+      error: { type: 'OIDC_PROVIDER_ERROR' },
+      return_to: transaction.return_to,
+    }
+  }
+
+  const issuer = canonicalizeOidcIssuer(claims.issuer)
+  if (issuer !== canonicalizeOidcIssuer(provider.issuer)) {
+    return {
+      ok: false,
+      error: { type: 'OIDC_PROVIDER_CONFIG_INVALID' },
+      return_to: transaction.return_to,
+    }
+  }
+  if (!claims.emailVerified) {
+    return {
+      ok: false,
+      error: { type: 'OIDC_EMAIL_UNVERIFIED' },
+      return_to: transaction.return_to,
+    }
+  }
+  if (!isHostedDomainAllowed(claims.hostedDomain, provider.allowed_hosted_domains)) {
+    return {
+      ok: false,
+      error: { type: 'OIDC_HOSTED_DOMAIN_NOT_ALLOWED' },
+      return_to: transaction.return_to,
+    }
+  }
+
+  if (transaction.intent === 'accept_invite') {
+    if (options.completeInvite && transaction.invite_id) {
+      return options.completeInvite({
+        inviteId: transaction.invite_id,
+        organizationId: provider.organization_id,
+        providerId: provider.provider_id,
+        transactionSessionId: transaction.session_id,
+        callbackSessionToken: options.sessionToken,
+        claims: { ...claims, issuer },
+        returnTo: transaction.return_to,
+        now,
+        executor: options.executor ?? db,
+      })
+    }
+    return {
+      ok: false,
+      error: { type: 'OIDC_INVITE_COMPLETION_REQUIRED' },
+      return_to: transaction.return_to,
+    }
+  }
+
+  return runInTransaction(options.executor, async (trx) => {
+    if (transaction.intent === 'link_identity') {
+      if (!transaction.session_id || !options.sessionToken) {
+        return {
+          ok: false,
+          error: { type: 'AUTH_SESSION_REQUIRED' },
+          return_to: transaction.return_to,
+        } as const
+      }
+      const session = await findValidSessionByToken(options.sessionToken, now, trx)
+      if (!session.ok || session.session.id !== transaction.session_id) {
+        return {
+          ok: false,
+          error: { type: 'AUTH_SESSION_REQUIRED' },
+          return_to: transaction.return_to,
+        } as const
+      }
+      const membership = await findActiveMembershipByOrganizationAndUser(
+        provider.organization_id,
+        session.session.user_id,
+        trx
+      )
+      if (!membership?.id) {
+        return {
+          ok: false,
+          error: { type: 'AUTH_MEMBERSHIP_NOT_ACTIVE' },
+          return_to: transaction.return_to,
+        } as const
+      }
+
+      const existingIdentity = await findOidcIdentity(issuer, claims.sub, trx)
+      if (existingIdentity && existingIdentity.user_id !== session.session.user_id) {
+        return {
+          ok: false,
+          error: { type: 'AUTH_IDENTITY_USER_MISMATCH' },
+          return_to: transaction.return_to,
+        } as const
+      }
+      const identity = existingIdentity
+        ? await updateOidcIdentityClaims(
+            existingIdentity.id,
+            {
+              last_claimed_email: claims.email,
+              last_claimed_email_verified: claims.emailVerified,
+            },
+            trx
+          )
+        : await insertOidcIdentity(
+            {
+              user_id: session.session.user_id,
+              issuer,
+              subject: claims.sub,
+              last_claimed_email: claims.email,
+              last_claimed_email_verified: claims.emailVerified,
+            },
+            trx
+          )
+      await upsertOidcMembershipLink(
+        {
+          membership_id: membership.id,
+          organization_id: provider.organization_id,
+          user_id: session.session.user_id,
+          organization_oidc_provider_id: provider.provider_id,
+          oidc_identity_id: identity.id,
+          revoked_at: null,
+        },
+        trx
+      )
+      await insertOidcAuthenticationEvent(
+        {
+          event_type: 'oidc_link_identity',
+          outcome: 'success',
+          user_id: session.session.user_id,
+          organization_id: provider.organization_id,
+          membership_id: membership.id,
+          session_id: session.session.id,
+          auth_method: 'oidc',
+          credential_reference_id: identity.id,
+        },
+        trx
+      )
+      return { ok: true, value: { return_to: transaction.return_to } } as const
+    }
+
+    const identity = await findOidcIdentity(issuer, claims.sub, trx)
+    if (!identity) {
+      return {
+        ok: false,
+        error: { type: 'OIDC_IDENTITY_NOT_LINKED' },
+        return_to: transaction.return_to,
+      } as const
+    }
+    const link = await findActiveOidcMembershipLink(provider.provider_id, identity.id, trx)
+    if (link?.membership_status !== 'active') {
+      return {
+        ok: false,
+        error: { type: 'AUTH_MEMBERSHIP_NOT_ACTIVE' },
+        return_to: transaction.return_to,
+      } as const
+    }
+    if (link.user_status !== 'active') {
+      return {
+        ok: false,
+        error: { type: 'AUTH_USER_DISABLED' },
+        return_to: transaction.return_to,
+      } as const
+    }
+
+    let session
+    let createdSessionToken: string | undefined
+    if (transaction.intent === 'reauthenticate') {
+      if (!transaction.session_id || !options.sessionToken) {
+        return {
+          ok: false,
+          error: { type: 'AUTH_SESSION_REQUIRED' },
+          return_to: transaction.return_to,
+        } as const
+      }
+      const cookieSession = await findValidSessionByToken(options.sessionToken, now, trx)
+      const transactionSession = await findValidSessionById(transaction.session_id, now, trx)
+      if (!cookieSession.ok || cookieSession.session.id !== transactionSession?.id) {
+        return {
+          ok: false,
+          error: { type: 'AUTH_SESSION_REQUIRED' },
+          return_to: transaction.return_to,
+        } as const
+      }
+      session = transactionSession
+    } else if (options.sessionToken) {
+      const existingSession = await findValidSessionByToken(options.sessionToken, now, trx)
+      if (existingSession.ok) session = existingSession.session
+    }
+
+    if (session && session.user_id !== identity.user_id) {
+      return {
+        ok: false,
+        error: { type: 'AUTH_IDENTITY_USER_MISMATCH' },
+        return_to: transaction.return_to,
+      } as const
+    }
+    if (!session) {
+      const created = await createSession(
+        { authMethod: 'oidc', userId: identity.user_id, now },
+        trx
+      )
+      session = created.session
+      createdSessionToken = created.token
+    }
+
+    const expiresAt = new Date(now.getTime() + provider.membership_grant_ttl_seconds * 1000)
+    await upsertOidcMembershipGrant(
+      {
+        session_id: session.id,
+        membership_id: link.membership_id,
+        user_id: identity.user_id,
+        auth_method: 'oidc',
+        policy_version: provider.policy_version,
+        local_credential_id: null,
+        member_oidc_identity_id: link.link_id,
+        authenticated_at: now,
+        expires_at: expiresAt,
+        revoked_at: null,
+      },
+      trx
+    )
+    await updateOidcIdentityClaims(
+      identity.id,
+      {
+        last_claimed_email: claims.email,
+        last_claimed_email_verified: claims.emailVerified,
+      },
+      trx
+    )
+    await insertOidcAuthenticationEvent(
+      {
+        event_type: transaction.intent === 'reauthenticate' ? 'oidc_reauthenticate' : 'oidc_login',
+        outcome: 'success',
+        user_id: identity.user_id,
+        organization_id: provider.organization_id,
+        membership_id: link.membership_id,
+        session_id: session.id,
+        auth_method: 'oidc',
+        credential_reference_id: identity.id,
+      },
+      trx
+    )
+
+    return {
+      ok: true,
+      value: {
+        return_to: transaction.return_to,
+        sessionToken: createdSessionToken,
+      },
+    } as const
+  })
+}

--- a/apps/kaede/src/usecases/organization-oidc-auth/index.ts
+++ b/apps/kaede/src/usecases/organization-oidc-auth/index.ts
@@ -1,0 +1,3 @@
+export * from './callback.js'
+export * from './providers.js'
+export * from './start.js'

--- a/apps/kaede/src/usecases/organization-oidc-auth/providers.ts
+++ b/apps/kaede/src/usecases/organization-oidc-auth/providers.ts
@@ -1,0 +1,217 @@
+import type {
+  CreateOrganizationOidcProviderRequest,
+  UpdateOrganizationOidcProviderRequest,
+} from '../../schemas/organization-oidc-auth.js'
+import { db } from '../../services/db/index.js'
+import type { DbExecutor } from '../../services/executor.js'
+import {
+  canonicalizeOidcIssuer,
+  findActiveOwnerMembershipForUpdate,
+  incrementOrganizationPolicyVersion,
+  insertOidcAuditEvent,
+  insertOidcProvider,
+  listOidcProviders,
+  normalizeHostedDomains,
+  updateOidcProvider,
+} from '../../services/organization-oidc-auth/index.js'
+
+export type OidcProviderManagementError =
+  | { type: 'AUTH_FORBIDDEN' }
+  | { type: 'OIDC_PROVIDER_NOT_FOUND' }
+  | { type: 'OIDC_PROVIDER_CONFIG_INVALID' }
+
+const runInTransaction = async <T>(
+  executor: DbExecutor | undefined,
+  callback: (trx: DbExecutor) => Promise<T>
+) => {
+  const base = executor ?? db
+  return 'transaction' in base ? base.transaction().execute(callback) : callback(base)
+}
+
+const toProviderResponse = (provider: {
+  id: string
+  organization_id: string
+  name: string
+  issuer: string
+  client_id: string
+  allowed_hosted_domains: string[] | null
+  enabled: boolean
+  created_at: Date
+  updated_at: Date
+}) => ({
+  id: provider.id,
+  organization_id: provider.organization_id,
+  display_name: provider.name,
+  issuer: provider.issuer,
+  client_id: provider.client_id,
+  allowed_hosted_domains: provider.allowed_hosted_domains,
+  enabled: provider.enabled,
+  created_at: provider.created_at.toISOString(),
+  updated_at: provider.updated_at.toISOString(),
+})
+
+const requireOwner = async (organizationId: string, userId: string, executor: DbExecutor) => {
+  const membership = await findActiveOwnerMembershipForUpdate(organizationId, userId, executor)
+  return membership?.id
+    ? { ok: true as const, membershipId: membership.id }
+    : { ok: false as const }
+}
+
+export const getOrganizationOidcProviders = async (
+  organizationId: string,
+  userId: string,
+  executor?: DbExecutor
+) =>
+  runInTransaction(executor, async (trx) => {
+    const owner = await requireOwner(organizationId, userId, trx)
+    if (!owner.ok) return { ok: false, error: { type: 'AUTH_FORBIDDEN' } } as const
+
+    const providers = await listOidcProviders(organizationId, trx)
+    return { ok: true, value: { providers: providers.map(toProviderResponse) } } as const
+  })
+
+export const createOrganizationOidcProvider = async (
+  organizationId: string,
+  userId: string,
+  payload: CreateOrganizationOidcProviderRequest,
+  configuredGoogleClientId: string,
+  executor?: DbExecutor
+) => {
+  if (payload.client_id !== configuredGoogleClientId) {
+    return { ok: false, error: { type: 'OIDC_PROVIDER_CONFIG_INVALID' } } as const
+  }
+
+  let allowedHostedDomains: string[] | null
+  try {
+    allowedHostedDomains = normalizeHostedDomains(payload.allowed_hosted_domains)
+  } catch {
+    return { ok: false, error: { type: 'OIDC_PROVIDER_CONFIG_INVALID' } } as const
+  }
+
+  return runInTransaction(executor, async (trx) => {
+    const owner = await requireOwner(organizationId, userId, trx)
+    if (!owner.ok) return { ok: false, error: { type: 'AUTH_FORBIDDEN' } } as const
+
+    const provider = await insertOidcProvider(
+      {
+        organization_id: organizationId,
+        name: payload.display_name,
+        issuer: canonicalizeOidcIssuer(payload.issuer),
+        client_id: payload.client_id,
+        client_secret_ref: null,
+        scopes: ['openid', 'email', 'profile'],
+        allowed_hosted_domains: allowedHostedDomains,
+        enabled: payload.enabled,
+      },
+      trx
+    )
+    if (provider.enabled) await incrementOrganizationPolicyVersion(organizationId, trx)
+    await insertOidcAuditEvent(
+      {
+        actor_user_id: userId,
+        actor_membership_id: owner.membershipId,
+        organization_id: organizationId,
+        target_type: 'organization_oidc_provider',
+        target_id: provider.id,
+        action: 'create',
+        changed_fields: ['provider'],
+        before_values: null,
+        after_values: { enabled: provider.enabled },
+      },
+      trx
+    )
+
+    return { ok: true, value: toProviderResponse(provider) } as const
+  })
+}
+
+export const patchOrganizationOidcProvider = async (
+  organizationId: string,
+  providerId: string,
+  userId: string,
+  payload: UpdateOrganizationOidcProviderRequest,
+  configuredGoogleClientId: string,
+  executor?: DbExecutor
+) => {
+  if (payload.client_id && payload.client_id !== configuredGoogleClientId) {
+    return { ok: false, error: { type: 'OIDC_PROVIDER_CONFIG_INVALID' } } as const
+  }
+
+  let allowedHostedDomains: string[] | null | undefined
+  try {
+    allowedHostedDomains =
+      payload.allowed_hosted_domains === undefined
+        ? undefined
+        : normalizeHostedDomains(payload.allowed_hosted_domains)
+  } catch {
+    return { ok: false, error: { type: 'OIDC_PROVIDER_CONFIG_INVALID' } } as const
+  }
+
+  return runInTransaction(executor, async (trx) => {
+    const owner = await requireOwner(organizationId, userId, trx)
+    if (!owner.ok) return { ok: false, error: { type: 'AUTH_FORBIDDEN' } } as const
+    const before = (await listOidcProviders(organizationId, trx)).find(
+      (provider) => provider.id === providerId
+    )
+    if (!before) {
+      return { ok: false, error: { type: 'OIDC_PROVIDER_NOT_FOUND' } } as const
+    }
+
+    const provider = await updateOidcProvider(
+      organizationId,
+      providerId,
+      {
+        ...(payload.display_name === undefined ? {} : { name: payload.display_name }),
+        ...(payload.issuer === undefined ? {} : { issuer: canonicalizeOidcIssuer(payload.issuer) }),
+        ...(payload.client_id === undefined ? {} : { client_id: payload.client_id }),
+        ...(allowedHostedDomains === undefined
+          ? {}
+          : { allowed_hosted_domains: allowedHostedDomains }),
+        ...(payload.enabled === undefined ? {} : { enabled: payload.enabled }),
+      },
+      trx
+    )
+    if (!provider) {
+      return { ok: false, error: { type: 'OIDC_PROVIDER_NOT_FOUND' } } as const
+    }
+
+    const policyChanged =
+      before.enabled !== provider.enabled ||
+      before.issuer !== provider.issuer ||
+      before.client_id !== provider.client_id ||
+      JSON.stringify(before.allowed_hosted_domains) !==
+        JSON.stringify(provider.allowed_hosted_domains)
+    if (policyChanged) await incrementOrganizationPolicyVersion(organizationId, trx)
+    await insertOidcAuditEvent(
+      {
+        actor_user_id: userId,
+        actor_membership_id: owner.membershipId,
+        organization_id: organizationId,
+        target_type: 'organization_oidc_provider',
+        target_id: provider.id,
+        action: 'update',
+        changed_fields: Object.keys(payload),
+        before_values: { enabled: before.enabled },
+        after_values: { enabled: provider.enabled },
+      },
+      trx
+    )
+
+    return { ok: true, value: toProviderResponse(provider) } as const
+  })
+}
+
+export const disableOrganizationOidcProvider = async (
+  organizationId: string,
+  providerId: string,
+  userId: string,
+  executor?: DbExecutor
+) =>
+  patchOrganizationOidcProvider(
+    organizationId,
+    providerId,
+    userId,
+    { enabled: false },
+    '',
+    executor
+  )

--- a/apps/kaede/src/usecases/organization-oidc-auth/start.ts
+++ b/apps/kaede/src/usecases/organization-oidc-auth/start.ts
@@ -1,0 +1,189 @@
+import type { OrganizationOidcStartRequest } from '../../schemas/organization-oidc-auth.js'
+import {
+  findValidSessionByToken,
+  generateOidcNonce,
+  generateOidcState,
+  generatePkceCodeVerifier,
+  hashActivationToken,
+} from '../../services/auth/index.js'
+import { db } from '../../services/db/index.js'
+import type { DbExecutor } from '../../services/executor.js'
+import {
+  encryptPkceCodeVerifier,
+  findActiveInviteIdByTokenHash,
+  findActiveMembershipByOrganizationAndUser,
+  findOrganizationOidcProviderContext,
+  findRecentMembershipGrant,
+  hashOidcState,
+  insertOidcLoginTransaction,
+  isGoogleIssuer,
+} from '../../services/organization-oidc-auth/index.js'
+
+const OIDC_TRANSACTION_TTL_MS = 10 * 60 * 1000
+
+export interface OrganizationOidcAuthorizationClient {
+  createAuthorizationUrl(params: { codeVerifier: string; nonce: string; state: string }): string
+}
+
+export interface StartOrganizationOidcOptions {
+  client: OrganizationOidcAuthorizationClient
+  configuredClientId: string
+  transactionSecret: string
+  now?: Date
+  executor?: DbExecutor
+}
+
+export type StartOrganizationOidcError =
+  | { type: 'AUTH_METHOD_NOT_ALLOWED' }
+  | { type: 'AUTH_SESSION_REQUIRED' }
+  | { type: 'AUTH_SESSION_EXPIRED' }
+  | { type: 'AUTH_SESSION_REVOKED' }
+  | { type: 'AUTH_MEMBERSHIP_NOT_ACTIVE' }
+  | { type: 'AUTH_MEMBERSHIP_REAUTHENTICATION_REQUIRED' }
+  | { type: 'OIDC_PROVIDER_NOT_FOUND' }
+  | { type: 'OIDC_PROVIDER_CONFIG_INVALID' }
+  | { type: 'INVITE_INVALID' }
+
+const runInTransaction = async <T>(
+  executor: DbExecutor | undefined,
+  callback: (trx: DbExecutor) => Promise<T>
+) => {
+  const base = executor ?? db
+  return 'transaction' in base ? base.transaction().execute(callback) : callback(base)
+}
+
+const mapSessionError = (
+  error: 'SESSION_NOT_FOUND' | 'SESSION_EXPIRED' | 'SESSION_REVOKED'
+): StartOrganizationOidcError => {
+  switch (error) {
+    case 'SESSION_EXPIRED':
+      return { type: 'AUTH_SESSION_EXPIRED' }
+    case 'SESSION_REVOKED':
+      return { type: 'AUTH_SESSION_REVOKED' }
+    case 'SESSION_NOT_FOUND':
+      return { type: 'AUTH_SESSION_REQUIRED' }
+  }
+}
+
+export const startOrganizationOidc = async (
+  organizationSlug: string,
+  providerId: string,
+  sessionToken: string | undefined,
+  payload: OrganizationOidcStartRequest,
+  options: StartOrganizationOidcOptions
+) => {
+  const now = options.now ?? new Date()
+
+  return runInTransaction(options.executor, async (trx) => {
+    const provider = await findOrganizationOidcProviderContext(organizationSlug, providerId, trx)
+    if (!provider) {
+      return { ok: false, error: { type: 'OIDC_PROVIDER_NOT_FOUND' } } as const
+    }
+    if (
+      provider.organization_status !== 'active' ||
+      !provider.oidc_auth_enabled ||
+      !provider.provider_enabled
+    ) {
+      return { ok: false, error: { type: 'AUTH_METHOD_NOT_ALLOWED' } } as const
+    }
+    if (!isGoogleIssuer(provider.issuer) || provider.client_id !== options.configuredClientId) {
+      return { ok: false, error: { type: 'OIDC_PROVIDER_CONFIG_INVALID' } } as const
+    }
+
+    let sessionId: string | null = null
+    let sessionUserId: string | null = null
+    if (sessionToken) {
+      const session = await findValidSessionByToken(sessionToken, now, trx)
+      if (!session.ok) return { ok: false, error: mapSessionError(session.error) } as const
+      sessionId = session.session.id
+      sessionUserId = session.session.user_id
+    }
+    if (payload.intent === 'reauthenticate' || payload.intent === 'link_identity') {
+      if (!sessionId || !sessionUserId) {
+        return { ok: false, error: { type: 'AUTH_SESSION_REQUIRED' } } as const
+      }
+      const membership = await findActiveMembershipByOrganizationAndUser(
+        provider.organization_id,
+        sessionUserId,
+        trx
+      )
+      if (!membership?.id) {
+        return { ok: false, error: { type: 'AUTH_MEMBERSHIP_NOT_ACTIVE' } } as const
+      }
+      if (payload.intent === 'link_identity') {
+        const recentAfter = new Date(
+          now.getTime() - provider.reauthentication_interval_seconds * 1000
+        )
+        const recentGrant = await findRecentMembershipGrant(
+          sessionId,
+          provider.organization_id,
+          sessionUserId,
+          provider.policy_version,
+          recentAfter,
+          now,
+          trx
+        )
+        if (!recentGrant) {
+          return {
+            ok: false,
+            error: { type: 'AUTH_MEMBERSHIP_REAUTHENTICATION_REQUIRED' },
+          } as const
+        }
+      }
+    }
+
+    let inviteId: string | null = null
+    if (payload.intent === 'accept_invite') {
+      if (!payload.invite_token) {
+        return { ok: false, error: { type: 'INVITE_INVALID' } } as const
+      }
+      const invite = await findActiveInviteIdByTokenHash(
+        provider.organization_id,
+        hashActivationToken(payload.invite_token),
+        now,
+        trx
+      )
+      if (!invite) return { ok: false, error: { type: 'INVITE_INVALID' } } as const
+      inviteId = invite.id
+    }
+
+    const state = generateOidcState()
+    const nonce = generateOidcNonce()
+    const codeVerifier = generatePkceCodeVerifier()
+    await insertOidcLoginTransaction(
+      {
+        state_hash: hashOidcState(state),
+        organization_id: provider.organization_id,
+        organization_oidc_provider_id: provider.provider_id,
+        session_id:
+          payload.intent === 'reauthenticate' ||
+          payload.intent === 'link_identity' ||
+          payload.intent === 'accept_invite'
+            ? sessionId
+            : null,
+        invite_id: inviteId,
+        intent: payload.intent,
+        nonce,
+        pkce_code_verifier_ciphertext: encryptPkceCodeVerifier(
+          codeVerifier,
+          options.transactionSecret
+        ),
+        return_to: payload.return_to,
+        expires_at: new Date(now.getTime() + OIDC_TRANSACTION_TTL_MS),
+        consumed_at: null,
+      },
+      trx
+    )
+
+    return {
+      ok: true,
+      value: {
+        authorization_url: options.client.createAuthorizationUrl({
+          codeVerifier,
+          nonce,
+          state,
+        }),
+      },
+    } as const
+  })
+}

--- a/apps/kaede/src/usecases/organization-oidc-links/index.test.ts
+++ b/apps/kaede/src/usecases/organization-oidc-links/index.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import type { DbExecutor } from '../../services/executor.js'
+
+const mocks = vi.hoisted(() => ({
+  countOtherUsableOidcLinks: vi.fn(),
+  findActiveMembership: vi.fn(),
+  findActiveMembershipForUpdate: vi.fn(),
+  findActiveOrganizationOidcLinkForUpdate: vi.fn(),
+  findOrganizationAuthSettingsForUpdate: vi.fn(),
+  hasEnabledLocalCredential: vi.fn(),
+  insertOidcLinkAuditEvent: vi.fn(),
+  insertOidcLinkAuthenticationEvent: vi.fn(),
+  listActiveOrganizationOidcLinks: vi.fn(),
+  revokeActiveGrantsForOidcLink: vi.fn(),
+  revokeOrganizationOidcLink: vi.fn(),
+}))
+
+vi.mock('../../services/organization-oidc-links/index.js', () => mocks)
+vi.mock('../../services/db/index.js', () => ({ db: {} }))
+
+import { getMyOrganizationOidcLinks, unlinkMyOrganizationOidcIdentity } from './index.js'
+
+const executor = {} as DbExecutor
+const organizationId = '11111111-1111-4111-8111-111111111111'
+const userId = '22222222-2222-4222-8222-222222222222'
+const membershipId = '33333333-3333-4333-8333-333333333333'
+const linkId = '44444444-4444-4444-8444-444444444444'
+const providerId = '55555555-5555-4555-8555-555555555555'
+const identityId = '66666666-6666-4666-8666-666666666666'
+const now = new Date('2026-08-11T12:00:00.000Z')
+
+const actor: RequestActor = {
+  type: 'user',
+  user_id: userId,
+  email: 'member@example.com',
+  global_role: 'none',
+  account_state: 'active',
+  memberships: [{ organization_id: organizationId, organization_name: 'Example', role: 'member' }],
+}
+
+const membership = { id: membershipId, organization_id: organizationId, user_id: userId }
+const link = {
+  id: linkId,
+  oidc_identity_id: identityId,
+  provider_id: providerId,
+  provider_enabled: true,
+}
+
+describe('organization OIDC link usecases', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.findActiveMembership.mockResolvedValue(membership)
+    mocks.findActiveMembershipForUpdate.mockResolvedValue(membership)
+    mocks.findOrganizationAuthSettingsForUpdate.mockResolvedValue({
+      local_auth_enabled: true,
+      oidc_auth_enabled: true,
+    })
+    mocks.findActiveOrganizationOidcLinkForUpdate.mockResolvedValue(link)
+    mocks.hasEnabledLocalCredential.mockResolvedValue(true)
+    mocks.countOtherUsableOidcLinks.mockResolvedValue(0)
+    mocks.revokeOrganizationOidcLink.mockResolvedValue({ id: linkId, revoked_at: now })
+    mocks.revokeActiveGrantsForOidcLink.mockResolvedValue(2)
+    mocks.listActiveOrganizationOidcLinks.mockResolvedValue([
+      {
+        id: linkId,
+        linked_at: new Date('2026-08-10T00:00:00.000Z'),
+        provider_id: providerId,
+        provider_name: 'Google',
+        provider_enabled: true,
+      },
+    ])
+  })
+
+  it('本人Membershipのactive LinkをProvider表示情報だけで返す', async () => {
+    await expect(getMyOrganizationOidcLinks(actor, organizationId, executor)).resolves.toEqual({
+      ok: true,
+      value: {
+        links: [
+          {
+            id: linkId,
+            provider: { id: providerId, display_name: 'Google', enabled: true },
+            linked_at: '2026-08-10T00:00:00.000Z',
+          },
+        ],
+      },
+    })
+  })
+
+  it('active MembershipがなければLink一覧を返さない', async () => {
+    mocks.findActiveMembership.mockResolvedValue(undefined)
+
+    await expect(getMyOrganizationOidcLinks(actor, organizationId, executor)).resolves.toEqual({
+      ok: false,
+      error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' },
+    })
+    expect(mocks.listActiveOrganizationOidcLinks).not.toHaveBeenCalled()
+  })
+
+  it('Local Credentialが残る場合はLinkとそのLink由来GrantだけをrevokeしてEventを残す', async () => {
+    const result = await unlinkMyOrganizationOidcIdentity(actor, organizationId, linkId, {
+      now,
+      executor,
+    })
+
+    expect(result).toEqual({ ok: true, value: { ok: true } })
+    expect(mocks.revokeOrganizationOidcLink).toHaveBeenCalledWith(linkId, now, executor)
+    expect(mocks.revokeActiveGrantsForOidcLink).toHaveBeenCalledWith(
+      membershipId,
+      linkId,
+      now,
+      executor
+    )
+    expect(mocks.insertOidcLinkAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actor_user_id: userId,
+        actor_membership_id: membershipId,
+        organization_id: organizationId,
+        target_type: 'organization_member_oidc_identity',
+        target_id: linkId,
+        action: 'unlink',
+        changed_fields: ['revoked_at'],
+      }),
+      executor
+    )
+    expect(mocks.insertOidcLinkAuthenticationEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_type: 'oidc_unlink_identity',
+        outcome: 'success',
+        credential_reference_id: identityId,
+      }),
+      executor
+    )
+  })
+
+  it('利用可能な最後の認証手段になるLinkはunlinkできない', async () => {
+    mocks.findOrganizationAuthSettingsForUpdate.mockResolvedValue({
+      local_auth_enabled: false,
+      oidc_auth_enabled: true,
+    })
+    mocks.hasEnabledLocalCredential.mockResolvedValue(false)
+    mocks.countOtherUsableOidcLinks.mockResolvedValue(0)
+
+    const result = await unlinkMyOrganizationOidcIdentity(actor, organizationId, linkId, {
+      now,
+      executor,
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      error: { type: 'OIDC_LINK_LAST_USABLE_AUTH_METHOD' },
+    })
+    expect(mocks.revokeOrganizationOidcLink).not.toHaveBeenCalled()
+    expect(mocks.revokeActiveGrantsForOidcLink).not.toHaveBeenCalled()
+    expect(mocks.insertOidcLinkAuditEvent).not.toHaveBeenCalled()
+  })
+
+  it('別のenabled OIDC Linkが残ればLocal Credentialなしでもunlinkできる', async () => {
+    mocks.findOrganizationAuthSettingsForUpdate.mockResolvedValue({
+      local_auth_enabled: false,
+      oidc_auth_enabled: true,
+    })
+    mocks.hasEnabledLocalCredential.mockResolvedValue(false)
+    mocks.countOtherUsableOidcLinks.mockResolvedValue(1)
+
+    await expect(
+      unlinkMyOrganizationOidcIdentity(actor, organizationId, linkId, { now, executor })
+    ).resolves.toEqual({ ok: true, value: { ok: true } })
+  })
+
+  it('対象Providerがdisabledなら現在の利用可能手段を減らさないためunlinkできる', async () => {
+    mocks.findActiveOrganizationOidcLinkForUpdate.mockResolvedValue({
+      ...link,
+      provider_enabled: false,
+    })
+    mocks.findOrganizationAuthSettingsForUpdate.mockResolvedValue({
+      local_auth_enabled: false,
+      oidc_auth_enabled: true,
+    })
+
+    await expect(
+      unlinkMyOrganizationOidcIdentity(actor, organizationId, linkId, { now, executor })
+    ).resolves.toEqual({ ok: true, value: { ok: true } })
+    expect(mocks.hasEnabledLocalCredential).not.toHaveBeenCalled()
+    expect(mocks.countOtherUsableOidcLinks).not.toHaveBeenCalled()
+  })
+
+  it('本人のactive Linkでなければ404用errorを返す', async () => {
+    mocks.findActiveOrganizationOidcLinkForUpdate.mockResolvedValue(undefined)
+
+    await expect(
+      unlinkMyOrganizationOidcIdentity(actor, organizationId, linkId, { now, executor })
+    ).resolves.toEqual({
+      ok: false,
+      error: { type: 'OIDC_MEMBERSHIP_LINK_NOT_FOUND' },
+    })
+  })
+})

--- a/apps/kaede/src/usecases/organization-oidc-links/index.ts
+++ b/apps/kaede/src/usecases/organization-oidc-links/index.ts
@@ -1,0 +1,149 @@
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import type { Json } from '../../services/db/index.js'
+import { db } from '../../services/db/index.js'
+import type { DbExecutor } from '../../services/executor.js'
+import {
+  countOtherUsableOidcLinks,
+  findActiveMembership,
+  findActiveMembershipForUpdate,
+  findActiveOrganizationOidcLinkForUpdate,
+  findOrganizationAuthSettingsForUpdate,
+  hasEnabledLocalCredential,
+  insertOidcLinkAuditEvent,
+  insertOidcLinkAuthenticationEvent,
+  listActiveOrganizationOidcLinks,
+  revokeActiveGrantsForOidcLink,
+  revokeOrganizationOidcLink,
+} from '../../services/organization-oidc-links/index.js'
+
+export type OrganizationOidcLinkError =
+  | { type: 'AUTH_ORGANIZATION_FORBIDDEN' }
+  | { type: 'OIDC_MEMBERSHIP_LINK_NOT_FOUND' }
+  | { type: 'OIDC_LINK_LAST_USABLE_AUTH_METHOD' }
+
+type Result<T> = { ok: true; value: T } | { ok: false; error: OrganizationOidcLinkError }
+
+const runInTransaction = async <T>(
+  executor: DbExecutor | undefined,
+  callback: (trx: DbExecutor) => Promise<T>
+): Promise<T> => {
+  const base = executor ?? db
+  return 'transaction' in base ? base.transaction().execute(callback) : callback(base)
+}
+
+const userIdFromActor = (actor: RequestActor) => (actor.type === 'user' ? actor.user_id : undefined)
+
+const toLinkResponse = (link: {
+  id: string
+  linked_at: Date
+  provider_id: string
+  provider_name: string
+  provider_enabled: boolean
+}) => ({
+  id: link.id,
+  provider: {
+    id: link.provider_id,
+    display_name: link.provider_name,
+    enabled: link.provider_enabled,
+  },
+  linked_at: link.linked_at.toISOString(),
+})
+
+export const getMyOrganizationOidcLinks = async (
+  actor: RequestActor,
+  organizationId: string,
+  executor: DbExecutor = db
+): Promise<Result<{ links: ReturnType<typeof toLinkResponse>[] }>> => {
+  const userId = userIdFromActor(actor)
+  if (!userId) return { ok: false, error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' } }
+  const membership = await findActiveMembership(organizationId, userId, executor)
+  if (!membership?.id) {
+    return { ok: false, error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' } }
+  }
+  const links = await listActiveOrganizationOidcLinks(membership.id, executor)
+  return { ok: true, value: { links: links.map(toLinkResponse) } }
+}
+
+export const unlinkMyOrganizationOidcIdentity = async (
+  actor: RequestActor,
+  organizationId: string,
+  linkId: string,
+  options: { now?: Date; executor?: DbExecutor } = {}
+): Promise<Result<{ ok: true }>> => {
+  const userId = userIdFromActor(actor)
+  if (!userId) return { ok: false, error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' } }
+  const now = options.now ?? new Date()
+
+  return runInTransaction(options.executor, async (trx) => {
+    // 本人のMembershipを先にlockし、退出・suspendとunlinkを直列化する。
+    const membership = await findActiveMembershipForUpdate(organizationId, userId, trx)
+    if (!membership?.id) {
+      return { ok: false, error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' } }
+    }
+    const policy = await findOrganizationAuthSettingsForUpdate(organizationId, trx)
+    if (!policy) return { ok: false, error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' } }
+    const link = await findActiveOrganizationOidcLinkForUpdate(
+      organizationId,
+      membership.id,
+      linkId,
+      trx
+    )
+    if (!link) {
+      return { ok: false, error: { type: 'OIDC_MEMBERSHIP_LINK_NOT_FOUND' } }
+    }
+
+    const targetIsUsable = policy.oidc_auth_enabled && link.provider_enabled
+    if (targetIsUsable) {
+      const localRemains =
+        policy.local_auth_enabled && (await hasEnabledLocalCredential(membership.id, trx))
+      const oidcRemains =
+        policy.oidc_auth_enabled &&
+        (await countOtherUsableOidcLinks(membership.id, link.id, trx)) > 0
+      if (!localRemains && !oidcRemains) {
+        return { ok: false, error: { type: 'OIDC_LINK_LAST_USABLE_AUTH_METHOD' } }
+      }
+    }
+
+    const revoked = await revokeOrganizationOidcLink(link.id, now, trx)
+    if (!revoked) {
+      return { ok: false, error: { type: 'OIDC_MEMBERSHIP_LINK_NOT_FOUND' } }
+    }
+    const revokedGrantCount = await revokeActiveGrantsForOidcLink(membership.id, link.id, now, trx)
+    await insertOidcLinkAuditEvent(
+      {
+        actor_user_id: userId,
+        actor_membership_id: membership.id,
+        organization_id: organizationId,
+        target_type: 'organization_member_oidc_identity',
+        target_id: link.id,
+        action: 'unlink',
+        changed_fields: ['revoked_at'],
+        before_values: {
+          revoked_at: null,
+          provider_id: link.provider_id,
+          revoked_grant_count: 0,
+        } as Json,
+        after_values: {
+          revoked_at: now.toISOString(),
+          provider_id: link.provider_id,
+          revoked_grant_count: revokedGrantCount,
+        } as Json,
+      },
+      trx
+    )
+    await insertOidcLinkAuthenticationEvent(
+      {
+        event_type: 'oidc_unlink_identity',
+        outcome: 'success',
+        user_id: userId,
+        organization_id: organizationId,
+        membership_id: membership.id,
+        auth_method: 'oidc',
+        credential_reference_id: link.oidc_identity_id,
+      },
+      trx
+    )
+
+    return { ok: true, value: { ok: true } }
+  })
+}

--- a/apps/kaede/src/usecases/organization-session-auth/index.ts
+++ b/apps/kaede/src/usecases/organization-session-auth/index.ts
@@ -1,0 +1,2 @@
+export { logoutFromOrganization } from './logout.js'
+export type { OrganizationSessionLogoutResult } from './logout.js'

--- a/apps/kaede/src/usecases/organization-session-auth/logout.ts
+++ b/apps/kaede/src/usecases/organization-session-auth/logout.ts
@@ -1,0 +1,86 @@
+import { findValidSessionByToken } from '../../services/auth/index.js'
+import { db } from '../../services/db/index.js'
+import type { DbExecutor } from '../../services/executor.js'
+import {
+  findCurrentMembershipForSessionLogout,
+  insertOrganizationSessionAuthenticationEvent,
+  revokeCurrentSessionMembershipGrant,
+} from '../../services/organization-session-auth/index.js'
+
+export type OrganizationSessionLogoutResult =
+  | {
+      ok: true
+      value: { organization_id: string; membership_id: string; revoked: boolean }
+    }
+  | {
+      ok: false
+      error: { type: 'AUTH_UNAUTHENTICATED' | 'AUTH_SESSION_EXPIRED' | 'AUTH_SESSION_REVOKED' }
+    }
+  | { ok: false; error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' } }
+
+const mapSessionError = (
+  error: 'SESSION_NOT_FOUND' | 'SESSION_EXPIRED' | 'SESSION_REVOKED'
+): 'AUTH_UNAUTHENTICATED' | 'AUTH_SESSION_EXPIRED' | 'AUTH_SESSION_REVOKED' => {
+  if (error === 'SESSION_EXPIRED') return 'AUTH_SESSION_EXPIRED'
+  if (error === 'SESSION_REVOKED') return 'AUTH_SESSION_REVOKED'
+  return 'AUTH_UNAUTHENTICATED'
+}
+
+export const logoutFromOrganization = async (
+  organizationId: string,
+  sessionToken: string | undefined,
+  options: { now?: Date; requestId?: string; userAgent?: string } = {},
+  executor?: DbExecutor
+): Promise<OrganizationSessionLogoutResult> => {
+  if (!sessionToken) return { ok: false, error: { type: 'AUTH_UNAUTHENTICATED' } }
+
+  const base = executor ?? db
+  const run = async (trx: DbExecutor) => {
+    const now = options.now ?? new Date()
+    const sessionResult = await findValidSessionByToken(sessionToken, now, trx)
+    if (!sessionResult.ok) {
+      return { ok: false, error: { type: mapSessionError(sessionResult.error) } } as const
+    }
+
+    const membership = await findCurrentMembershipForSessionLogout(
+      organizationId,
+      sessionResult.session.user_id,
+      trx
+    )
+    if (!membership) {
+      return { ok: false, error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' } } as const
+    }
+
+    const revoked = await revokeCurrentSessionMembershipGrant(
+      sessionResult.session.id,
+      membership.id,
+      sessionResult.session.user_id,
+      now,
+      trx
+    )
+    await insertOrganizationSessionAuthenticationEvent(
+      {
+        event_type: 'organization_logout',
+        outcome: 'success',
+        user_id: sessionResult.session.user_id,
+        organization_id: organizationId,
+        membership_id: membership.id,
+        session_id: sessionResult.session.id,
+        request_id: options.requestId,
+        user_agent: options.userAgent,
+      },
+      trx
+    )
+
+    return {
+      ok: true,
+      value: {
+        organization_id: organizationId,
+        membership_id: membership.id,
+        revoked,
+      },
+    } as const
+  }
+
+  return 'transaction' in base ? base.transaction().execute(run) : run(base)
+}

--- a/apps/kaede/src/usecases/organizations/index.ts
+++ b/apps/kaede/src/usecases/organizations/index.ts
@@ -144,6 +144,7 @@ const requirePedestrianOrganizationId = (
 }
 
 const toOrganizationUserResponse = (row: OrganizationUserRow): OrganizationUserResponse => ({
+  membership_id: row.membership_id,
   user_id: row.user_id,
   email: row.email,
   display_name: row.display_name,

--- a/apps/kaede/src/usecases/organizations/index.ts
+++ b/apps/kaede/src/usecases/organizations/index.ts
@@ -36,6 +36,7 @@ import {
   findOrganizationCreationRequestByIdForUpdate,
   findPendingOrganizationCreationRequestByRequester,
   findOrganizationById,
+  insertDefaultOrganizationAuthSettings,
   insertOrganization,
   insertOrganizationCreationRequest,
   listOrganizationCreationRequests,
@@ -581,12 +582,16 @@ export const createOrganizationForSession = async (
     return admin
   }
 
-  const organization = await insertOrganization(
-    {
-      name: payload.name.trim(),
-    },
-    executor
-  )
+  const organization = await runInTransaction(executor, async (trx) => {
+    const created = await insertOrganization(
+      {
+        name: payload.name.trim(),
+      },
+      trx
+    )
+    await insertDefaultOrganizationAuthSettings(created.id, trx)
+    return created
+  })
 
   return {
     ok: true,
@@ -786,6 +791,8 @@ export const approveOrganizationCreationRequestForAdminSession = async (
       },
       trx
     )
+
+    await insertDefaultOrganizationAuthSettings(organization.id, trx)
 
     await insertOrganizationMembership(
       {

--- a/apps/kaede/src/usecases/profiles/index.test.ts
+++ b/apps/kaede/src/usecases/profiles/index.test.ts
@@ -1,0 +1,264 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import type { DbExecutor } from '../../services/executor.js'
+
+const mocks = vi.hoisted(() => ({
+  findMemberProfileContextById: vi.fn(),
+  findMemberProfileContextByUser: vi.fn(),
+  findUserProfileContext: vi.fn(),
+  insertAuditEvent: vi.fn(),
+  upsertOrganizationMemberProfile: vi.fn(),
+  upsertUserProfile: vi.fn(),
+}))
+
+vi.mock('../../services/profiles/index.js', () => mocks)
+vi.mock('../../services/db/index.js', () => ({ db: {} }))
+
+import {
+  getMyOrganizationMemberProfile,
+  getMyUserProfile,
+  updateMyOrganizationMemberProfile,
+  updateOrganizationMemberProfile,
+} from './index.js'
+
+const executor = {} as DbExecutor
+const organizationId = '11111111-1111-4111-8111-111111111111'
+const actorMembershipId = '22222222-2222-4222-8222-222222222222'
+const targetMembershipId = '33333333-3333-4333-8333-333333333333'
+const actorUserId = '44444444-4444-4444-8444-444444444444'
+const targetUserId = '55555555-5555-4555-8555-555555555555'
+
+const userActor = (
+  role: 'member' | 'manager' | 'owner' = 'member',
+  globalRole: 'none' | 'admin' = 'none'
+): RequestActor => ({
+  type: 'user',
+  user_id: actorUserId,
+  email: 'actor@example.com',
+  global_role: globalRole,
+  account_state: 'active',
+  memberships: [
+    {
+      organization_id: organizationId,
+      organization_name: 'Example',
+      role,
+    },
+  ],
+})
+
+const memberContext = ({
+  membershipId = targetMembershipId,
+  userId = targetUserId,
+  role = 'member',
+  status = 'active',
+  overrideDisplayName = null,
+}: {
+  membershipId?: string | null
+  userId?: string
+  role?: string
+  status?: string | null
+  overrideDisplayName?: string | null
+} = {}) => ({
+  membership_id: membershipId,
+  organization_id: organizationId,
+  membership_user_id: userId,
+  role,
+  status,
+  user_id: userId,
+  legacy_display_name: 'Legacy Name',
+  display_name: 'Global Name',
+  locale: 'ja-JP',
+  timezone: 'Asia/Tokyo',
+  profile_updated_at: new Date('2026-08-11T00:00:00.000Z'),
+  override_display_name: overrideDisplayName,
+  height_meters: '1.705',
+  stride_length_meters: '0.720',
+  member_profile_updated_at: new Date('2026-08-11T00:00:00.000Z'),
+})
+
+describe('profile usecases', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('User Profile未作成時はlegacy display nameとdefault preferenceへfallbackする', async () => {
+    mocks.findUserProfileContext.mockResolvedValue({
+      user_id: actorUserId,
+      legacy_display_name: 'Legacy Name',
+      legacy_updated_at: new Date('2026-08-10T00:00:00.000Z'),
+      display_name: null,
+      locale: null,
+      timezone: null,
+      profile_updated_at: null,
+    })
+
+    await expect(getMyUserProfile(userActor(), executor)).resolves.toEqual({
+      ok: true,
+      value: {
+        user_id: actorUserId,
+        display_name: 'Legacy Name',
+        locale: 'ja-JP',
+        timezone: 'Asia/Tokyo',
+        updated_at: '2026-08-10T00:00:00.000Z',
+      },
+    })
+  })
+
+  it('Organization overrideがNULLなら共通display nameを実効値にする', async () => {
+    mocks.findMemberProfileContextByUser.mockResolvedValue(
+      memberContext({ membershipId: actorMembershipId, userId: actorUserId })
+    )
+
+    const result = await getMyOrganizationMemberProfile(userActor(), organizationId, executor)
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        global: { display_name: 'Global Name' },
+        override: { display_name: null, height_meters: 1.705, stride_length_meters: 0.72 },
+        effective: { display_name: 'Global Name', display_name_source: 'global' },
+      },
+    })
+  })
+
+  it('本人更新はoverrideを解除でき、Audit Eventを作成しない', async () => {
+    const current = memberContext({
+      membershipId: actorMembershipId,
+      userId: actorUserId,
+      overrideDisplayName: 'Override Name',
+    })
+    mocks.findMemberProfileContextByUser.mockResolvedValue(current)
+    mocks.findMemberProfileContextById.mockResolvedValue({
+      ...current,
+      override_display_name: null,
+    })
+    mocks.upsertOrganizationMemberProfile.mockResolvedValue({})
+
+    const result = await updateMyOrganizationMemberProfile(
+      userActor(),
+      organizationId,
+      { display_name: null },
+      executor
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        effective: { display_name: 'Global Name', display_name_source: 'global' },
+        update_context: { kind: 'self' },
+      },
+    })
+    expect(mocks.insertAuditEvent).not.toHaveBeenCalled()
+  })
+
+  it('active managerは同じOrganizationのmember Profileを変更しAuditへ記録する', async () => {
+    const target = memberContext()
+    const actorMembership = memberContext({
+      membershipId: actorMembershipId,
+      userId: actorUserId,
+      role: 'manager',
+    })
+    mocks.findMemberProfileContextById
+      .mockResolvedValueOnce(target)
+      .mockResolvedValueOnce({ ...target, override_display_name: 'Managed Name' })
+    mocks.findMemberProfileContextByUser.mockResolvedValue(actorMembership)
+    mocks.upsertOrganizationMemberProfile.mockResolvedValue({})
+
+    const result = await updateOrganizationMemberProfile(
+      userActor('manager'),
+      organizationId,
+      targetMembershipId,
+      { display_name: 'Managed Name' },
+      executor
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: { update_context: { kind: 'forced', actor_role: 'manager' } },
+    })
+    expect(mocks.insertAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actor_user_id: actorUserId,
+        actor_membership_id: actorMembershipId,
+        organization_id: organizationId,
+        target_type: 'member_profile',
+        target_id: targetMembershipId,
+        changed_fields: ['display_name'],
+      }),
+      executor
+    )
+  })
+
+  it('managerはmanager/owner Profileを変更できない', async () => {
+    mocks.findMemberProfileContextById.mockResolvedValue(memberContext({ role: 'manager' }))
+    mocks.findMemberProfileContextByUser.mockResolvedValue(
+      memberContext({
+        membershipId: actorMembershipId,
+        userId: actorUserId,
+        role: 'manager',
+      })
+    )
+
+    await expect(
+      updateOrganizationMemberProfile(
+        userActor('manager'),
+        organizationId,
+        targetMembershipId,
+        { display_name: 'Denied' },
+        executor
+      )
+    ).resolves.toEqual({ ok: false, error: { type: 'AUTH_DASHBOARD_FORBIDDEN' } })
+    expect(mocks.upsertOrganizationMemberProfile).not.toHaveBeenCalled()
+    expect(mocks.insertAuditEvent).not.toHaveBeenCalled()
+  })
+
+  it('inactive actor Membershipでは第三者Profileを変更できない', async () => {
+    mocks.findMemberProfileContextById.mockResolvedValue(memberContext())
+    mocks.findMemberProfileContextByUser.mockResolvedValue(
+      memberContext({
+        membershipId: actorMembershipId,
+        userId: actorUserId,
+        role: 'owner',
+        status: 'suspended',
+      })
+    )
+
+    const result = await updateOrganizationMemberProfile(
+      userActor('owner'),
+      organizationId,
+      targetMembershipId,
+      { height_meters: 1.8 },
+      executor
+    )
+
+    expect(result).toEqual({ ok: false, error: { type: 'AUTH_DASHBOARD_FORBIDDEN' } })
+  })
+
+  it('ownerはowner Profileを変更できる', async () => {
+    const target = memberContext({ role: 'owner' })
+    mocks.findMemberProfileContextById
+      .mockResolvedValueOnce(target)
+      .mockResolvedValueOnce({ ...target, height_meters: '1.800' })
+    mocks.findMemberProfileContextByUser.mockResolvedValue(
+      memberContext({
+        membershipId: actorMembershipId,
+        userId: actorUserId,
+        role: 'owner',
+      })
+    )
+    mocks.upsertOrganizationMemberProfile.mockResolvedValue({})
+
+    const result = await updateOrganizationMemberProfile(
+      userActor('owner'),
+      organizationId,
+      targetMembershipId,
+      { height_meters: 1.8 },
+      executor
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: { update_context: { kind: 'forced', actor_role: 'owner' } },
+    })
+  })
+})

--- a/apps/kaede/src/usecases/profiles/index.test.ts
+++ b/apps/kaede/src/usecases/profiles/index.test.ts
@@ -65,7 +65,6 @@ const memberContext = ({
   role,
   status,
   user_id: userId,
-  legacy_display_name: 'Legacy Name',
   display_name: 'Global Name',
   locale: 'ja-JP',
   timezone: 'Asia/Tokyo',
@@ -81,25 +80,23 @@ describe('profile usecases', () => {
     vi.clearAllMocks()
   })
 
-  it('User Profile未作成時はlegacy display nameとdefault preferenceへfallbackする', async () => {
+  it('移行済みUser Profileを返す', async () => {
     mocks.findUserProfileContext.mockResolvedValue({
       user_id: actorUserId,
-      legacy_display_name: 'Legacy Name',
-      legacy_updated_at: new Date('2026-08-10T00:00:00.000Z'),
-      display_name: null,
-      locale: null,
-      timezone: null,
-      profile_updated_at: null,
+      display_name: 'Global Name',
+      locale: 'ja-JP',
+      timezone: 'Asia/Tokyo',
+      profile_updated_at: new Date('2026-08-11T00:00:00.000Z'),
     })
 
     await expect(getMyUserProfile(userActor(), executor)).resolves.toEqual({
       ok: true,
       value: {
         user_id: actorUserId,
-        display_name: 'Legacy Name',
+        display_name: 'Global Name',
         locale: 'ja-JP',
         timezone: 'Asia/Tokyo',
-        updated_at: '2026-08-10T00:00:00.000Z',
+        updated_at: '2026-08-11T00:00:00.000Z',
       },
     })
   })

--- a/apps/kaede/src/usecases/profiles/index.ts
+++ b/apps/kaede/src/usecases/profiles/index.ts
@@ -1,0 +1,333 @@
+import type { Kysely } from 'kysely'
+import type { RequestActor } from '../../middleware/request-actor-context.js'
+import type {
+  OrganizationMemberProfileResponse,
+  OrganizationMemberProfileUpdateResponse,
+  UpdateOrganizationMemberProfileRequest,
+  UpdateUserProfileRequest,
+  UserProfileResponse,
+} from '../../schemas/profiles.js'
+import { db } from '../../services/db/index.js'
+import type { DB, Json } from '../../services/db/index.js'
+import type { DbExecutor } from '../../services/executor.js'
+import {
+  findMemberProfileContextById,
+  findMemberProfileContextByUser,
+  findUserProfileContext,
+  insertAuditEvent,
+  upsertOrganizationMemberProfile,
+  upsertUserProfile,
+} from '../../services/profiles/index.js'
+import type { MemberProfileContext, UserProfileContext } from '../../services/profiles/index.js'
+import type { AuthorizationError } from '../authorization.js'
+
+const defaultLocale = 'ja-JP'
+const defaultTimezone = 'Asia/Tokyo'
+
+export type ProfileError =
+  | AuthorizationError
+  | { type: 'USER_NOT_FOUND' }
+  | { type: 'MEMBERSHIP_NOT_FOUND' }
+  | { type: 'MEMBERSHIP_NOT_ACTIVE' }
+  | { type: 'MEMBERSHIP_PROFILE_UNAVAILABLE' }
+
+type ProfileResult<T> = { ok: true; value: T } | { ok: false; error: ProfileError }
+
+const runInTransaction = async <T>(
+  executor: DbExecutor | undefined,
+  callback: (trx: DbExecutor) => Promise<T>
+): Promise<T> => {
+  const baseExecutor = executor ?? db
+
+  if ('transaction' in baseExecutor) {
+    return (baseExecutor as Kysely<DB>).transaction().execute((trx) => callback(trx))
+  }
+
+  return callback(baseExecutor)
+}
+
+const requireUserActor = (
+  actor: RequestActor
+):
+  | { ok: true; actor: Extract<RequestActor, { type: 'user' }> }
+  | { ok: false; error: ProfileError } => {
+  if (actor.type === 'service_client') {
+    return { ok: false, error: { type: 'AUTH_DASHBOARD_FORBIDDEN' } }
+  }
+
+  return { ok: true, actor }
+}
+
+const toUserProfileResponse = (context: UserProfileContext): UserProfileResponse => ({
+  user_id: context.user_id,
+  display_name: context.display_name ?? context.legacy_display_name,
+  locale: context.locale ?? defaultLocale,
+  timezone: context.timezone ?? defaultTimezone,
+  updated_at: (context.profile_updated_at ?? context.legacy_updated_at).toISOString(),
+})
+
+const toMemberProfileResponse = (
+  context: MemberProfileContext
+): OrganizationMemberProfileResponse => {
+  if (!context.membership_id) {
+    throw new Error('membership id is not available')
+  }
+
+  const globalDisplayName = context.display_name ?? context.legacy_display_name
+
+  return {
+    organization_id: context.organization_id,
+    membership_id: context.membership_id,
+    global: {
+      display_name: globalDisplayName,
+    },
+    override: {
+      display_name: context.override_display_name,
+      height_meters: context.height_meters === null ? null : Number(context.height_meters),
+      stride_length_meters:
+        context.stride_length_meters === null ? null : Number(context.stride_length_meters),
+    },
+    effective: {
+      display_name: context.override_display_name ?? globalDisplayName,
+      display_name_source:
+        context.override_display_name === null ? 'global' : 'organization_override',
+    },
+    updated_at: context.member_profile_updated_at?.toISOString() ?? null,
+  }
+}
+
+const checkActiveMembership = (
+  membership: MemberProfileContext | undefined
+):
+  | { ok: true; membership: MemberProfileContext & { membership_id: string } }
+  | {
+      ok: false
+      error: ProfileError
+    } => {
+  if (!membership) {
+    return { ok: false, error: { type: 'MEMBERSHIP_NOT_FOUND' } }
+  }
+
+  if (membership.status !== 'active') {
+    return { ok: false, error: { type: 'MEMBERSHIP_NOT_ACTIVE' } }
+  }
+
+  if (!membership.membership_id) {
+    return { ok: false, error: { type: 'MEMBERSHIP_PROFILE_UNAVAILABLE' } }
+  }
+
+  return {
+    ok: true,
+    membership: membership as MemberProfileContext & { membership_id: string },
+  }
+}
+
+export const getMyUserProfile = async (
+  actor: RequestActor,
+  executor?: DbExecutor
+): Promise<ProfileResult<UserProfileResponse>> => {
+  const authenticated = requireUserActor(actor)
+  if (!authenticated.ok) return authenticated
+
+  const profile = await findUserProfileContext(authenticated.actor.user_id, executor)
+
+  if (!profile) {
+    return { ok: false, error: { type: 'USER_NOT_FOUND' } }
+  }
+
+  return { ok: true, value: toUserProfileResponse(profile) }
+}
+
+export const updateMyUserProfile = async (
+  actor: RequestActor,
+  payload: UpdateUserProfileRequest,
+  executor?: DbExecutor
+): Promise<ProfileResult<UserProfileResponse>> => {
+  const authenticated = requireUserActor(actor)
+  if (!authenticated.ok) return authenticated
+
+  return runInTransaction(executor, async (trx) => {
+    const current = await findUserProfileContext(authenticated.actor.user_id, trx)
+    if (!current) return { ok: false, error: { type: 'USER_NOT_FOUND' } }
+
+    const next = {
+      display_name: payload.display_name ?? current.display_name ?? current.legacy_display_name,
+      locale: payload.locale ?? current.locale ?? defaultLocale,
+      timezone: payload.timezone ?? current.timezone ?? defaultTimezone,
+    }
+
+    const profile = await upsertUserProfile(
+      { user_id: authenticated.actor.user_id, ...next },
+      next,
+      trx
+    )
+
+    return {
+      ok: true,
+      value: {
+        user_id: profile.user_id,
+        display_name: profile.display_name,
+        locale: profile.locale,
+        timezone: profile.timezone,
+        updated_at: profile.updated_at.toISOString(),
+      },
+    }
+  })
+}
+
+export const getMyOrganizationMemberProfile = async (
+  actor: RequestActor,
+  organizationId: string,
+  executor?: DbExecutor
+): Promise<ProfileResult<OrganizationMemberProfileResponse>> => {
+  const authenticated = requireUserActor(actor)
+  if (!authenticated.ok) return authenticated
+
+  const membership = checkActiveMembership(
+    await findMemberProfileContextByUser(organizationId, authenticated.actor.user_id, executor)
+  )
+  if (!membership.ok) return membership
+
+  return { ok: true, value: toMemberProfileResponse(membership.membership) }
+}
+
+const updateMemberProfile = async (
+  current: MemberProfileContext & { membership_id: string },
+  payload: UpdateOrganizationMemberProfileRequest,
+  executor: DbExecutor
+) => {
+  const next = {
+    display_name:
+      payload.display_name === undefined ? current.override_display_name : payload.display_name,
+    height_meters:
+      payload.height_meters === undefined ? current.height_meters : payload.height_meters,
+    stride_length_meters:
+      payload.stride_length_meters === undefined
+        ? current.stride_length_meters
+        : payload.stride_length_meters,
+  }
+
+  await upsertOrganizationMemberProfile(
+    { membership_id: current.membership_id, ...next },
+    next,
+    executor
+  )
+
+  const refreshed = await findMemberProfileContextById(
+    current.organization_id,
+    current.membership_id,
+    executor
+  )
+
+  if (!refreshed) throw new Error('updated membership profile was not found')
+  return { next, refreshed }
+}
+
+export const updateMyOrganizationMemberProfile = async (
+  actor: RequestActor,
+  organizationId: string,
+  payload: UpdateOrganizationMemberProfileRequest,
+  executor?: DbExecutor
+): Promise<ProfileResult<OrganizationMemberProfileUpdateResponse>> => {
+  const authenticated = requireUserActor(actor)
+  if (!authenticated.ok) return authenticated
+
+  return runInTransaction(executor, async (trx) => {
+    const membership = checkActiveMembership(
+      await findMemberProfileContextByUser(organizationId, authenticated.actor.user_id, trx)
+    )
+    if (!membership.ok) return membership
+
+    const { refreshed } = await updateMemberProfile(membership.membership, payload, trx)
+    return {
+      ok: true,
+      value: { ...toMemberProfileResponse(refreshed), update_context: { kind: 'self' } },
+    }
+  })
+}
+
+const thirdPartyActorRole = (
+  actor: Extract<RequestActor, { type: 'user' }>,
+  actorMembership: MemberProfileContext | undefined,
+  target: MemberProfileContext
+): 'manager' | 'owner' | 'global_admin' | undefined => {
+  if (actor.global_role === 'admin') return 'global_admin'
+  if (actorMembership?.status !== 'active' || !actorMembership.membership_id) return undefined
+  if (actorMembership.role === 'owner') return 'owner'
+  if (actorMembership.role === 'manager' && target.role === 'member') return 'manager'
+  return undefined
+}
+
+export const updateOrganizationMemberProfile = async (
+  actor: RequestActor,
+  organizationId: string,
+  membershipId: string,
+  payload: UpdateOrganizationMemberProfileRequest,
+  executor?: DbExecutor
+): Promise<ProfileResult<OrganizationMemberProfileUpdateResponse>> => {
+  const authenticated = requireUserActor(actor)
+  if (!authenticated.ok) return authenticated
+
+  return runInTransaction(executor, async (trx) => {
+    const target = checkActiveMembership(
+      await findMemberProfileContextById(organizationId, membershipId, trx)
+    )
+    if (!target.ok) return target
+
+    const actorMembership = await findMemberProfileContextByUser(
+      organizationId,
+      authenticated.actor.user_id,
+      trx
+    )
+    const actorRole = thirdPartyActorRole(authenticated.actor, actorMembership, target.membership)
+
+    if (!actorRole) {
+      return { ok: false, error: { type: 'AUTH_DASHBOARD_FORBIDDEN' } }
+    }
+
+    const before = {
+      display_name: target.membership.override_display_name,
+      height_meters:
+        target.membership.height_meters === null ? null : Number(target.membership.height_meters),
+      stride_length_meters:
+        target.membership.stride_length_meters === null
+          ? null
+          : Number(target.membership.stride_length_meters),
+    }
+    const { next, refreshed } = await updateMemberProfile(target.membership, payload, trx)
+    const after = {
+      display_name: next.display_name,
+      height_meters: next.height_meters === null ? null : Number(next.height_meters),
+      stride_length_meters:
+        next.stride_length_meters === null ? null : Number(next.stride_length_meters),
+    }
+    const changedFields = (Object.keys(after) as (keyof typeof after)[]).filter(
+      (field) => before[field] !== after[field]
+    )
+
+    if (changedFields.length > 0) {
+      await insertAuditEvent(
+        {
+          actor_user_id: authenticated.actor.user_id,
+          actor_membership_id: actorMembership?.membership_id ?? null,
+          organization_id: organizationId,
+          target_type: 'member_profile',
+          target_id: membershipId,
+          action: 'update',
+          changed_fields: changedFields,
+          before_values: before as Json,
+          after_values: { ...after, actor_role: actorRole } as Json,
+        },
+        trx
+      )
+    }
+
+    return {
+      ok: true,
+      value: {
+        ...toMemberProfileResponse(refreshed),
+        update_context: { kind: 'forced', actor_role: actorRole },
+      },
+    }
+  })
+}

--- a/apps/kaede/src/usecases/profiles/index.ts
+++ b/apps/kaede/src/usecases/profiles/index.ts
@@ -21,9 +21,6 @@ import {
 import type { MemberProfileContext, UserProfileContext } from '../../services/profiles/index.js'
 import type { AuthorizationError } from '../authorization.js'
 
-const defaultLocale = 'ja-JP'
-const defaultTimezone = 'Asia/Tokyo'
-
 export type ProfileError =
   | AuthorizationError
   | { type: 'USER_NOT_FOUND' }
@@ -60,10 +57,10 @@ const requireUserActor = (
 
 const toUserProfileResponse = (context: UserProfileContext): UserProfileResponse => ({
   user_id: context.user_id,
-  display_name: context.display_name ?? context.legacy_display_name,
-  locale: context.locale ?? defaultLocale,
-  timezone: context.timezone ?? defaultTimezone,
-  updated_at: (context.profile_updated_at ?? context.legacy_updated_at).toISOString(),
+  display_name: context.display_name,
+  locale: context.locale,
+  timezone: context.timezone,
+  updated_at: context.profile_updated_at.toISOString(),
 })
 
 const toMemberProfileResponse = (
@@ -73,7 +70,7 @@ const toMemberProfileResponse = (
     throw new Error('membership id is not available')
   }
 
-  const globalDisplayName = context.display_name ?? context.legacy_display_name
+  const globalDisplayName = context.display_name
 
   return {
     organization_id: context.organization_id,
@@ -151,9 +148,9 @@ export const updateMyUserProfile = async (
     if (!current) return { ok: false, error: { type: 'USER_NOT_FOUND' } }
 
     const next = {
-      display_name: payload.display_name ?? current.display_name ?? current.legacy_display_name,
-      locale: payload.locale ?? current.locale ?? defaultLocale,
-      timezone: payload.timezone ?? current.timezone ?? defaultTimezone,
+      display_name: payload.display_name ?? current.display_name,
+      locale: payload.locale ?? current.locale,
+      timezone: payload.timezone ?? current.timezone,
     }
 
     const profile = await upsertUserProfile(

--- a/apps/kaede/tests/db/helpers.ts
+++ b/apps/kaede/tests/db/helpers.ts
@@ -5,6 +5,17 @@ import type { DB } from '../../src/services/db/generated.js'
 export const resetDatabase = async (db: Kysely<DB>) => {
   await sql`
     TRUNCATE TABLE
+      audit_events,
+      authentication_events,
+      oidc_login_transactions,
+      session_membership_authentications,
+      organization_member_oidc_identities,
+      oidc_identities,
+      organization_local_credentials,
+      organization_oidc_providers,
+      organization_auth_settings,
+      organization_member_profiles,
+      user_profiles,
       sessions,
       organization_invite_redemptions,
       organization_invites,

--- a/apps/kaede/tests/db/helpers.ts
+++ b/apps/kaede/tests/db/helpers.ts
@@ -5,6 +5,7 @@ import type { DB } from '../../src/services/db/generated.js'
 export const resetDatabase = async (db: Kysely<DB>) => {
   await sql`
     TRUNCATE TABLE
+      application_data_migrations,
       audit_events,
       authentication_events,
       oidc_login_transactions,

--- a/apps/kaede/tests/services/auth/auth-usecase.test.ts
+++ b/apps/kaede/tests/services/auth/auth-usecase.test.ts
@@ -1042,10 +1042,11 @@ describe('auth usecase', () => {
       .values({ name: 'Missing Grant Organization' })
       .returningAll()
       .executeTakeFirstOrThrow()
-    await db
+    const secondMembership = await db
       .insertInto('organization_memberships')
       .values({ organization_id: secondOrganization.id, user_id: user.id, role: 'manager' })
-      .execute()
+      .returningAll()
+      .executeTakeFirstOrThrow()
     await db
       .insertInto('organization_auth_settings')
       .values({
@@ -1056,35 +1057,121 @@ describe('auth usecase', () => {
         reauthentication_interval_seconds: 3600,
       })
       .execute()
+    const missingSettingsOrganization = await db
+      .insertInto('organizations')
+      .values({ name: 'Missing Settings Organization' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const missingSettingsMembership = await db
+      .insertInto('organization_memberships')
+      .values({
+        organization_id: missingSettingsOrganization.id,
+        user_id: user.id,
+        role: 'member',
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const suspendedOrganization = await db
+      .insertInto('organizations')
+      .values({ name: 'Suspended Membership Organization' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const suspendedMembership = await db
+      .insertInto('organization_memberships')
+      .values({
+        organization_id: suspendedOrganization.id,
+        user_id: user.id,
+        role: 'member',
+        status: 'suspended',
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    await db
+      .insertInto('organization_auth_settings')
+      .values({
+        organization_id: suspendedOrganization.id,
+        local_auth_enabled: true,
+        oidc_auth_enabled: false,
+        membership_grant_ttl_seconds: 7200,
+        reauthentication_interval_seconds: 3600,
+      })
+      .execute()
 
     const result = await getMe(token, new Date('2026-08-11T11:30:00.000Z'), db)
 
-    expect(result).toMatchObject({
-      ok: true,
-      value: {
-        user: {
-          memberships: [
-            {
-              organization_id: organization.id,
-              grant_state: {
-                status: 'granted',
-                auth_method: 'local',
-                authenticated_at: '2026-08-11T11:00:00.000Z',
-                expires_at: '2026-08-11T13:00:00.000Z',
-              },
-            },
-            {
-              organization_id: secondOrganization.id,
-              grant_state: {
-                status: 'reauthentication_required',
-                reason: 'grant_missing',
-                allowed_auth_methods: ['local'],
-              },
-            },
-          ],
-        },
-      },
-    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.value.user.memberships).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          membership_id: membership.id,
+          organization_id: organization.id,
+          organization_name: organization.name,
+          organization_slug: organization.slug,
+          role: 'member',
+          status: 'active',
+          allowed_auth_methods: ['local'],
+          grant_state: {
+            status: 'granted',
+            reason: null,
+            auth_method: 'local',
+            authenticated_at: '2026-08-11T11:00:00.000Z',
+            reauthentication_required_at: '2026-08-11T12:00:00.000Z',
+            expires_at: '2026-08-11T13:00:00.000Z',
+            effective_expires_at: '2026-08-11T12:00:00.000Z',
+          },
+        }),
+        expect.objectContaining({
+          membership_id: secondMembership.id,
+          organization_id: secondOrganization.id,
+          organization_slug: secondOrganization.slug,
+          role: 'manager',
+          status: 'active',
+          allowed_auth_methods: ['local'],
+          grant_state: {
+            status: 'reauthentication_required',
+            reason: 'grant_missing',
+            auth_method: null,
+            authenticated_at: null,
+            reauthentication_required_at: null,
+            expires_at: null,
+            effective_expires_at: null,
+          },
+        }),
+        expect.objectContaining({
+          membership_id: missingSettingsMembership.id,
+          organization_id: missingSettingsOrganization.id,
+          organization_slug: missingSettingsOrganization.slug,
+          status: 'active',
+          allowed_auth_methods: [],
+          grant_state: {
+            status: 'forbidden',
+            reason: 'auth_settings_unavailable',
+            auth_method: null,
+            authenticated_at: null,
+            reauthentication_required_at: null,
+            expires_at: null,
+            effective_expires_at: null,
+          },
+        }),
+        expect.objectContaining({
+          membership_id: suspendedMembership.id,
+          organization_id: suspendedOrganization.id,
+          organization_slug: suspendedOrganization.slug,
+          status: 'suspended',
+          allowed_auth_methods: [],
+          grant_state: {
+            status: 'forbidden',
+            reason: 'membership_suspended',
+            auth_method: null,
+            authenticated_at: null,
+            reauthentication_required_at: null,
+            expires_at: null,
+            effective_expires_at: null,
+          },
+        }),
+      ])
+    )
   })
 
   it('verifyActivationToken は valid token の表示情報を返し token を consume しない', async () => {

--- a/apps/kaede/tests/services/auth/auth-usecase.test.ts
+++ b/apps/kaede/tests/services/auth/auth-usecase.test.ts
@@ -985,6 +985,108 @@ describe('auth usecase', () => {
     expect(result.value.user.status).toBe('active')
   })
 
+  it('getMe はMembershipごとのgrant stateを返す', async () => {
+    const user = await insertUser()
+    const organization = await db
+      .insertInto('organizations')
+      .values({ name: 'Grant Organization' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const membership = await db
+      .insertInto('organization_memberships')
+      .values({ organization_id: organization.id, user_id: user.id, role: 'member' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    if (!membership.id) throw new Error('membership id is required')
+    await db
+      .insertInto('organization_auth_settings')
+      .values({
+        organization_id: organization.id,
+        local_auth_enabled: true,
+        oidc_auth_enabled: false,
+        policy_version: 2,
+        membership_grant_ttl_seconds: 7200,
+        reauthentication_interval_seconds: 3600,
+      })
+      .execute()
+    const credential = await db
+      .insertInto('organization_local_credentials')
+      .values({
+        membership_id: membership.id,
+        organization_id: organization.id,
+        login_email: 'grant-user@example.com',
+        normalized_login_email: 'grant-user@example.com',
+        password_hash: await hashPassword('organization-password'),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const { session, token } = await createSession(
+      { userId: user.id, now: new Date('2026-08-11T10:00:00.000Z') },
+      db
+    )
+    await db
+      .insertInto('session_membership_authentications')
+      .values({
+        session_id: session.id,
+        membership_id: membership.id,
+        user_id: user.id,
+        auth_method: 'local',
+        policy_version: 2,
+        local_credential_id: credential.id,
+        authenticated_at: new Date('2026-08-11T11:00:00.000Z'),
+        expires_at: new Date('2026-08-11T13:00:00.000Z'),
+      })
+      .execute()
+    const secondOrganization = await db
+      .insertInto('organizations')
+      .values({ name: 'Missing Grant Organization' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    await db
+      .insertInto('organization_memberships')
+      .values({ organization_id: secondOrganization.id, user_id: user.id, role: 'manager' })
+      .execute()
+    await db
+      .insertInto('organization_auth_settings')
+      .values({
+        organization_id: secondOrganization.id,
+        local_auth_enabled: true,
+        oidc_auth_enabled: false,
+        membership_grant_ttl_seconds: 7200,
+        reauthentication_interval_seconds: 3600,
+      })
+      .execute()
+
+    const result = await getMe(token, new Date('2026-08-11T11:30:00.000Z'), db)
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        user: {
+          memberships: [
+            {
+              organization_id: organization.id,
+              grant_state: {
+                status: 'granted',
+                auth_method: 'local',
+                authenticated_at: '2026-08-11T11:00:00.000Z',
+                expires_at: '2026-08-11T13:00:00.000Z',
+              },
+            },
+            {
+              organization_id: secondOrganization.id,
+              grant_state: {
+                status: 'reauthentication_required',
+                reason: 'grant_missing',
+                allowed_auth_methods: ['local'],
+              },
+            },
+          ],
+        },
+      },
+    })
+  })
+
   it('verifyActivationToken は valid token の表示情報を返し token を consume しない', async () => {
     const { activationToken, organization, token, user } = await insertActivationToken()
 

--- a/apps/kaede/tests/services/auth/organization-local-auth.test.ts
+++ b/apps/kaede/tests/services/auth/organization-local-auth.test.ts
@@ -1,0 +1,366 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { hashPassword } from '../../../src/services/auth/password.js'
+import { createSession } from '../../../src/services/auth/session-repository.js'
+import { createDb } from '../../../src/services/db/client.js'
+import { loginToOrganizationWithLocalCredential } from '../../../src/usecases/organization-local-auth/login.js'
+import { resetDatabase } from '../../db/helpers.js'
+
+const db = createDb()
+const now = new Date('2026-08-11T10:00:00.000Z')
+
+const createLocalMembership = async ({
+  organizationName,
+  organizationSlug,
+  legacyEmail,
+  loginEmail,
+  password,
+  contactEmail = null,
+}: {
+  organizationName: string
+  organizationSlug: string
+  legacyEmail: string
+  loginEmail: string
+  password: string
+  contactEmail?: string | null
+}) => {
+  const user = await db
+    .insertInto('users')
+    .values({
+      email: legacyEmail,
+      contact_email: contactEmail,
+      normalized_contact_email: contactEmail,
+      display_name: legacyEmail,
+      password_hash: null,
+      global_role: 'none',
+      status: 'active',
+      password_changed_at: null,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const organization = await db
+    .insertInto('organizations')
+    .values({ name: organizationName, slug: organizationSlug })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  await db
+    .insertInto('organization_auth_settings')
+    .values({
+      organization_id: organization.id,
+      local_auth_enabled: true,
+      oidc_auth_enabled: false,
+      membership_grant_ttl_seconds: 28_800,
+      reauthentication_interval_seconds: 14_400,
+    })
+    .execute()
+  const membership = await db
+    .insertInto('organization_memberships')
+    .values({ organization_id: organization.id, user_id: user.id, role: 'member' })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  if (!membership.id) throw new Error('membership id is required')
+  const credential = await db
+    .insertInto('organization_local_credentials')
+    .values({
+      membership_id: membership.id,
+      organization_id: organization.id,
+      login_email: loginEmail,
+      normalized_login_email: loginEmail.trim().toLowerCase(),
+      password_hash: await hashPassword(password),
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+  return { credential, membership: { ...membership, id: membership.id }, organization, user }
+}
+
+describe('organization local authentication', () => {
+  beforeEach(async () => {
+    await resetDatabase(db)
+  })
+
+  afterAll(async () => {
+    await db.destroy()
+  })
+
+  it('Organizationと正規化emailでCredentialを検索し、Sessionと対象Grantを作る', async () => {
+    const fixture = await createLocalMembership({
+      organizationName: 'Organization A',
+      organizationSlug: 'organization-a',
+      legacyEmail: 'legacy@example.test',
+      contactEmail: 'LOCAL@EXAMPLE.TEST',
+      loginEmail: 'local@example.test',
+      password: 'organization-a-password',
+    })
+
+    const result = await loginToOrganizationWithLocalCredential(
+      'organization-a',
+      undefined,
+      {
+        login_email: '  LOCAL@example.test  ',
+        password: 'organization-a-password',
+        return_to: '/orgs/organization-a/dashboard',
+      },
+      {},
+      now,
+      db
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.value.sessionToken).toBeDefined()
+    expect(result.value.membership.id).toBe(fixture.membership.id)
+    expect(result.value.grant).toEqual({
+      auth_method: 'local',
+      authenticated_at: now.toISOString(),
+      expires_at: '2026-08-11T18:00:00.000Z',
+    })
+
+    const grant = await db
+      .selectFrom('session_membership_authentications')
+      .selectAll()
+      .where('membership_id', '=', fixture.membership.id)
+      .executeTakeFirstOrThrow()
+    expect(grant.user_id).toBe(fixture.user.id)
+    expect(grant.local_credential_id).toBe(fixture.credential.id)
+    expect(grant.policy_version).toBe('1')
+    await expect(
+      db.selectFrom('authentication_events').selectAll().execute()
+    ).resolves.toMatchObject([{ outcome: 'success', event_type: 'local_login' }])
+  })
+
+  it('同じlogin emailでもOrganizationごとのpasswordを分離する', async () => {
+    await createLocalMembership({
+      organizationName: 'Organization A',
+      organizationSlug: 'organization-a',
+      legacyEmail: 'a@example.test',
+      loginEmail: 'shared@example.test',
+      password: 'organization-a-password',
+    })
+    const organizationB = await createLocalMembership({
+      organizationName: 'Organization B',
+      organizationSlug: 'organization-b',
+      legacyEmail: 'b@example.test',
+      loginEmail: 'shared@example.test',
+      password: 'organization-b-password',
+    })
+
+    const result = await loginToOrganizationWithLocalCredential(
+      'organization-b',
+      undefined,
+      {
+        login_email: 'shared@example.test',
+        password: 'organization-a-password',
+        return_to: '/orgs/organization-b',
+      },
+      {},
+      now,
+      db
+    )
+
+    expect(result).toEqual({ ok: false, error: { type: 'AUTH_INVALID_CREDENTIALS' } })
+    const credential = await db
+      .selectFrom('organization_local_credentials')
+      .selectAll()
+      .where('id', '=', organizationB.credential.id)
+      .executeTakeFirstOrThrow()
+    expect(credential.failed_login_attempts).toBe(1)
+  })
+
+  it('User contact_emailをLocal認証の検索キーにしない', async () => {
+    await createLocalMembership({
+      organizationName: 'Contact Organization',
+      organizationSlug: 'contact-organization',
+      legacyEmail: 'legacy-contact@example.test',
+      contactEmail: 'contact@example.test',
+      loginEmail: 'local-login@example.test',
+      password: 'local-password',
+    })
+
+    const result = await loginToOrganizationWithLocalCredential(
+      'contact-organization',
+      undefined,
+      {
+        login_email: 'contact@example.test',
+        password: 'local-password',
+        return_to: '/orgs/contact-organization',
+      },
+      {},
+      now,
+      db
+    )
+
+    expect(result).toEqual({ ok: false, error: { type: 'AUTH_INVALID_CREDENTIALS' } })
+  })
+
+  it('既存SessionのUserが一致すればSessionを維持し対象Membership Grantだけ追加する', async () => {
+    const organizationA = await createLocalMembership({
+      organizationName: 'Organization A',
+      organizationSlug: 'organization-a',
+      legacyEmail: 'same-user@example.test',
+      loginEmail: 'a-login@example.test',
+      password: 'password-a',
+    })
+    const organizationB = await db
+      .insertInto('organizations')
+      .values({ name: 'Organization B', slug: 'organization-b' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    await db
+      .insertInto('organization_auth_settings')
+      .values({
+        organization_id: organizationB.id,
+        local_auth_enabled: true,
+        oidc_auth_enabled: false,
+        membership_grant_ttl_seconds: 28_800,
+        reauthentication_interval_seconds: 14_400,
+      })
+      .execute()
+    const membershipB = await db
+      .insertInto('organization_memberships')
+      .values({ organization_id: organizationB.id, user_id: organizationA.user.id, role: 'member' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    if (!membershipB.id) throw new Error('membership id is required')
+    await db
+      .insertInto('organization_local_credentials')
+      .values({
+        membership_id: membershipB.id,
+        organization_id: organizationB.id,
+        login_email: 'b-login@example.test',
+        normalized_login_email: 'b-login@example.test',
+        password_hash: await hashPassword('password-b'),
+      })
+      .execute()
+    const existingSession = await createSession({ userId: organizationA.user.id, now }, db)
+
+    const result = await loginToOrganizationWithLocalCredential(
+      'organization-b',
+      existingSession.token,
+      {
+        login_email: 'b-login@example.test',
+        password: 'password-b',
+        return_to: '/orgs/organization-b',
+      },
+      {},
+      now,
+      db
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.value.sessionToken).toBeUndefined()
+    expect(result.value.session.id).toBe(existingSession.session.id)
+    const grants = await db
+      .selectFrom('session_membership_authentications')
+      .select(['membership_id'])
+      .where('session_id', '=', existingSession.session.id)
+      .execute()
+    expect(grants).toEqual([{ membership_id: membershipB.id }])
+  })
+
+  it('既存SessionとCredentialのUserが異なる場合は拒否してGrantを作らない', async () => {
+    const sessionOwner = await createLocalMembership({
+      organizationName: 'Session Organization',
+      organizationSlug: 'session-organization',
+      legacyEmail: 'session-owner@example.test',
+      loginEmail: 'session-login@example.test',
+      password: 'session-password',
+    })
+    await createLocalMembership({
+      organizationName: 'Target Organization',
+      organizationSlug: 'target-organization',
+      legacyEmail: 'target-owner@example.test',
+      loginEmail: 'target-login@example.test',
+      password: 'target-password',
+    })
+    const session = await createSession({ userId: sessionOwner.user.id, now }, db)
+
+    const result = await loginToOrganizationWithLocalCredential(
+      'target-organization',
+      session.token,
+      {
+        login_email: 'target-login@example.test',
+        password: 'target-password',
+        return_to: '/orgs/target-organization',
+      },
+      {},
+      now,
+      db
+    )
+
+    expect(result).toEqual({
+      ok: false,
+      error: { type: 'AUTH_IDENTITY_USER_MISMATCH' },
+    })
+    await expect(
+      db.selectFrom('session_membership_authentications').selectAll().execute()
+    ).resolves.toEqual([])
+  })
+
+  it('失敗回数とlockoutはCredential単位で更新する', async () => {
+    const fixture = await createLocalMembership({
+      organizationName: 'Lock Organization',
+      organizationSlug: 'lock-organization',
+      legacyEmail: 'lock@example.test',
+      loginEmail: 'lock-login@example.test',
+      password: 'correct-password',
+    })
+    await db
+      .updateTable('organization_local_credentials')
+      .set({ failed_login_attempts: 4 })
+      .where('id', '=', fixture.credential.id)
+      .execute()
+
+    const result = await loginToOrganizationWithLocalCredential(
+      'lock-organization',
+      undefined,
+      {
+        login_email: 'lock-login@example.test',
+        password: 'wrong-password',
+        return_to: '/orgs/lock-organization',
+      },
+      {},
+      now,
+      db
+    )
+
+    expect(result).toEqual({ ok: false, error: { type: 'AUTH_CREDENTIAL_LOCKED' } })
+    const credential = await db
+      .selectFrom('organization_local_credentials')
+      .selectAll()
+      .where('id', '=', fixture.credential.id)
+      .executeTakeFirstOrThrow()
+    expect(credential.failed_login_attempts).toBe(5)
+    expect(credential.locked_until).toEqual(new Date('2026-08-11T10:15:00.000Z'))
+  })
+
+  it('Organization policyでLocal認証が無効ならCredentialを使用しない', async () => {
+    const fixture = await createLocalMembership({
+      organizationName: 'OIDC Organization',
+      organizationSlug: 'oidc-organization',
+      legacyEmail: 'oidc@example.test',
+      loginEmail: 'oidc-login@example.test',
+      password: 'local-password',
+    })
+    await db
+      .updateTable('organization_auth_settings')
+      .set({ local_auth_enabled: false, oidc_auth_enabled: true })
+      .where('organization_id', '=', fixture.organization.id)
+      .execute()
+
+    const result = await loginToOrganizationWithLocalCredential(
+      'oidc-organization',
+      undefined,
+      {
+        login_email: 'oidc-login@example.test',
+        password: 'local-password',
+        return_to: '/orgs/oidc-organization',
+      },
+      {},
+      now,
+      db
+    )
+
+    expect(result).toEqual({ ok: false, error: { type: 'AUTH_METHOD_NOT_ALLOWED' } })
+  })
+})

--- a/apps/kaede/tests/services/auth/organization-local-credential-management.test.ts
+++ b/apps/kaede/tests/services/auth/organization-local-credential-management.test.ts
@@ -1,0 +1,211 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import type { RequestActor } from '../../../src/middleware/request-actor-context.js'
+import { createSession, hashPassword } from '../../../src/services/auth/index.js'
+import { createDb } from '../../../src/services/db/client.js'
+import {
+  disableMyOrganizationLocalCredential,
+  getMyOrganizationLocalCredential,
+  putMyOrganizationLocalCredential,
+} from '../../../src/usecases/organization-local-credentials/index.js'
+import { resetDatabase } from '../../db/helpers.js'
+
+const db = createDb()
+const now = new Date('2026-08-11T12:00:00.000Z')
+
+const createFixture = async () => {
+  const user = await db
+    .insertInto('users')
+    .values({
+      email: 'global@example.test',
+      display_name: 'Local Credential User',
+      global_role: 'none',
+      status: 'active',
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const organization = await db
+    .insertInto('organizations')
+    .values({ name: 'Credential Organization', slug: 'credential-organization' })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  await db
+    .insertInto('organization_auth_settings')
+    .values({
+      organization_id: organization.id,
+      local_auth_enabled: true,
+      oidc_auth_enabled: false,
+      membership_grant_ttl_seconds: 28_800,
+      reauthentication_interval_seconds: 14_400,
+    })
+    .execute()
+  const membership = await db
+    .insertInto('organization_memberships')
+    .values({ organization_id: organization.id, user_id: user.id, role: 'member' })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const { session } = await createSession({ userId: user.id, now }, db)
+  const actor = {
+    type: 'user',
+    user_id: user.id,
+    email: user.email,
+    global_role: 'none',
+    account_state: 'active',
+    memberships: [
+      { organization_id: organization.id, organization_name: organization.name, role: 'member' },
+    ],
+  } satisfies RequestActor
+  return { actor, membership, organization, session, user }
+}
+
+describe('organization local credential management', () => {
+  beforeEach(async () => resetDatabase(db))
+  afterAll(async () => db.destroy())
+
+  it('recentなUser Sessionで初回Credentialを設定し、secretを返さない', async () => {
+    const fixture = await createFixture()
+    const result = await putMyOrganizationLocalCredential(
+      fixture.actor,
+      fixture.session.id,
+      fixture.organization.id,
+      { login_email: ' Login@Example.Test ', new_password: 'new-password' },
+      {},
+      now,
+      db
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        configured: true,
+        login_email: 'Login@Example.Test',
+        enabled: true,
+      },
+    })
+    if (!result.ok) return
+    expect(result.value).not.toHaveProperty('password_hash')
+    expect(JSON.stringify(result.value)).not.toContain('new-password')
+    const stored = await db
+      .selectFrom('organization_local_credentials')
+      .select(['normalized_login_email', 'password_hash'])
+      .where('membership_id', '=', fixture.membership.id)
+      .executeTakeFirstOrThrow()
+    expect(stored.normalized_login_email).toBe('login@example.test')
+    expect(stored.password_hash).not.toBe('new-password')
+    await expect(
+      getMyOrganizationLocalCredential(fixture.actor, fixture.organization.id, db)
+    ).resolves.toMatchObject({ ok: true, value: { configured: true } })
+  })
+
+  it('現在passwordで変更し、そのCredential由来Grantだけをrevokeする', async () => {
+    const fixture = await createFixture()
+    const credential = await db
+      .insertInto('organization_local_credentials')
+      .values({
+        membership_id: fixture.membership.id,
+        organization_id: fixture.organization.id,
+        login_email: 'old@example.test',
+        normalized_login_email: 'old@example.test',
+        password_hash: await hashPassword('current-password'),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    await db
+      .insertInto('session_membership_authentications')
+      .values({
+        session_id: fixture.session.id,
+        membership_id: fixture.membership.id,
+        user_id: fixture.user.id,
+        auth_method: 'local',
+        policy_version: 1,
+        local_credential_id: credential.id,
+        authenticated_at: now,
+        expires_at: new Date(now.getTime() + 3_600_000),
+      })
+      .execute()
+
+    const result = await putMyOrganizationLocalCredential(
+      fixture.actor,
+      fixture.session.id,
+      fixture.organization.id,
+      {
+        login_email: 'changed@example.test',
+        current_password: 'current-password',
+        new_password: 'changed-password',
+      },
+      {},
+      now,
+      db
+    )
+
+    expect(result).toMatchObject({ ok: true, value: { login_email: 'changed@example.test' } })
+    await expect(
+      db
+        .selectFrom('session_membership_authentications')
+        .select('revoked_at')
+        .where('local_credential_id', '=', credential.id)
+        .executeTakeFirstOrThrow()
+    ).resolves.toEqual({ revoked_at: now })
+  })
+
+  it('Organization内のnormalized login email重複を拒否する', async () => {
+    const fixture = await createFixture()
+    const otherUser = await db
+      .insertInto('users')
+      .values({ email: 'other@example.test', display_name: 'Other', status: 'active' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const otherMembership = await db
+      .insertInto('organization_memberships')
+      .values({ organization_id: fixture.organization.id, user_id: otherUser.id, role: 'member' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    await db
+      .insertInto('organization_local_credentials')
+      .values({
+        membership_id: otherMembership.id,
+        organization_id: fixture.organization.id,
+        login_email: 'used@example.test',
+        normalized_login_email: 'used@example.test',
+        password_hash: await hashPassword('other-password'),
+      })
+      .execute()
+
+    await expect(
+      putMyOrganizationLocalCredential(
+        fixture.actor,
+        fixture.session.id,
+        fixture.organization.id,
+        { login_email: ' USED@example.test ', new_password: 'new-password' },
+        {},
+        now,
+        db
+      )
+    ).resolves.toEqual({ ok: false, error: { type: 'LOCAL_LOGIN_EMAIL_CONFLICT' } })
+  })
+
+  it('利用可能なOIDC Linkがない場合は最後の認証方式を無効化しない', async () => {
+    const fixture = await createFixture()
+    await db
+      .insertInto('organization_local_credentials')
+      .values({
+        membership_id: fixture.membership.id,
+        organization_id: fixture.organization.id,
+        login_email: 'only@example.test',
+        normalized_login_email: 'only@example.test',
+        password_hash: await hashPassword('current-password'),
+      })
+      .execute()
+
+    await expect(
+      disableMyOrganizationLocalCredential(
+        fixture.actor,
+        fixture.session.id,
+        fixture.organization.id,
+        { current_password: 'current-password' },
+        {},
+        now,
+        db
+      )
+    ).resolves.toEqual({ ok: false, error: { type: 'LOCAL_CREDENTIAL_LAST_AUTH_METHOD' } })
+  })
+})

--- a/apps/kaede/tests/services/auth/organization-oidc-auth.test.ts
+++ b/apps/kaede/tests/services/auth/organization-oidc-auth.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { hashActivationToken } from '../../../src/services/auth/activation-token.js'
 import { createSession } from '../../../src/services/auth/session-repository.js'
 import { createDb } from '../../../src/services/db/client.js'
+import { acceptOrganizationInviteWithOidc } from '../../../src/usecases/organization-invites/index.js'
 import {
   completeOrganizationOidc,
   isOrganizationOidcTransactionState,
@@ -135,10 +136,14 @@ const startLogin = async (
 }
 
 const callbackClient = ({
+  email = 'oidc-user@example.test',
   hostedDomain = null,
+  name = 'OIDC User',
   subject = 'google-subject',
 }: {
+  email?: string
   hostedDomain?: string | null
+  name?: string
   subject?: string
 } = {}) => ({
   exchangeCodeForIdToken: () => Promise.resolve('id-token'),
@@ -146,12 +151,75 @@ const callbackClient = ({
     Promise.resolve({
       issuer: 'accounts.google.com',
       sub: subject,
-      email: 'oidc-user@example.test',
+      email,
       emailVerified: true,
-      name: 'OIDC User',
+      name,
       hostedDomain,
     }),
 })
+
+const createInvite = async (
+  fixture: Awaited<ReturnType<typeof createFixture>>,
+  token = 'single-use-invite-token'
+) => {
+  const invite = await db
+    .insertInto('organization_invites')
+    .values({
+      organization_id: fixture.organization.id,
+      created_by_user_id: fixture.user.id,
+      created_by_membership_id: fixture.membership.id,
+      email: 'legacy-unused@example.test',
+      token_hash: hashActivationToken(token),
+      role: 'member',
+      expires_at: new Date('2026-08-12T10:00:00.000Z'),
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  return { invite, token }
+}
+
+const startInvite = async (
+  fixture: Awaited<ReturnType<typeof createFixture>>,
+  token: string,
+  sessionToken?: string
+) => {
+  const result = await startOrganizationOidc(
+    fixture.organization.slug,
+    fixture.provider.id,
+    sessionToken,
+    { intent: 'accept_invite', invite_token: token, return_to: '/invites/complete' },
+    {
+      client: {
+        createAuthorizationUrl: ({ state }) =>
+          `https://accounts.google.com/o/oauth2/v2/auth?state=${encodeURIComponent(state)}`,
+      },
+      configuredClientId,
+      transactionSecret,
+      now,
+      executor: db,
+    }
+  )
+  expect(result.ok).toBe(true)
+  if (!result.ok) throw new Error(result.error.type)
+  const state = new URL(result.value.authorization_url).searchParams.get('state')
+  if (!state) throw new Error('state is required')
+  return state
+}
+
+const completeInvite = (
+  state: string,
+  client: ReturnType<typeof callbackClient>,
+  sessionToken?: string
+) =>
+  completeOrganizationOidc('authorization-code', state, {
+    client,
+    configuredClientId,
+    transactionSecret,
+    completeInvite: acceptOrganizationInviteWithOidc,
+    sessionToken,
+    now,
+    executor: db,
+  })
 
 describe('organization OIDC authentication', () => {
   beforeEach(async () => {
@@ -407,5 +475,220 @@ describe('organization OIDC authentication', () => {
       error: { type: 'OIDC_TRANSACTION_INVALID' },
     })
     expect(completeInvite).toHaveBeenCalledTimes(1)
+  })
+
+  it('OIDC Invite成功後にUserからGrantまでを一括作成してInviteを消費する', async () => {
+    const fixture = await createFixture()
+    const { invite, token } = await createInvite(fixture)
+    const state = await startInvite(fixture, token)
+
+    const result = await completeInvite(
+      state,
+      callbackClient({
+        subject: 'new-invite-subject',
+        email: 'new-invite-user@example.test',
+        name: 'New Invite User',
+      })
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: { return_to: '/invites/complete', sessionToken: expect.any(String) },
+    })
+    const identity = await db
+      .selectFrom('oidc_identities')
+      .selectAll()
+      .where('subject', '=', 'new-invite-subject')
+      .executeTakeFirstOrThrow()
+    expect(identity.issuer).toBe('https://accounts.google.com')
+    const invitedUser = await db
+      .selectFrom('users')
+      .selectAll()
+      .where('id', '=', identity.user_id)
+      .executeTakeFirstOrThrow()
+    expect(invitedUser).toMatchObject({
+      contact_email: 'new-invite-user@example.test',
+      normalized_contact_email: 'new-invite-user@example.test',
+      status: 'active',
+    })
+    expect(invitedUser.contact_email_verified_at).toEqual(now)
+    const membership = await db
+      .selectFrom('organization_memberships')
+      .selectAll()
+      .where('organization_id', '=', fixture.organization.id)
+      .where('user_id', '=', identity.user_id)
+      .where('status', '=', 'active')
+      .executeTakeFirstOrThrow()
+    const redeemedInvite = await db
+      .selectFrom('organization_invites')
+      .selectAll()
+      .where('id', '=', invite.id)
+      .executeTakeFirstOrThrow()
+    expect(redeemedInvite).toMatchObject({ redeemed_membership_id: membership.id })
+    expect(redeemedInvite.redeemed_at).toEqual(now)
+    await expect(
+      db
+        .selectFrom('organization_member_profiles')
+        .selectAll()
+        .where('membership_id', '=', membership.id)
+        .executeTakeFirst()
+    ).resolves.toBeDefined()
+    await expect(
+      db
+        .selectFrom('session_membership_authentications')
+        .selectAll()
+        .where('membership_id', '=', membership.id)
+        .where('auth_method', '=', 'oidc')
+        .executeTakeFirst()
+    ).resolves.toMatchObject({ user_id: identity.user_id })
+
+    await expect(
+      completeInvite(
+        state,
+        callbackClient({ subject: 'new-invite-subject', email: 'new-invite-user@example.test' })
+      )
+    ).resolves.toEqual({ ok: false, error: { type: 'OIDC_TRANSACTION_INVALID' } })
+  })
+
+  it.each([
+    ['active', 'INVITE_ALREADY_MEMBER'],
+    ['suspended', 'INVITE_MEMBERSHIP_SUSPENDED'],
+  ] as const)(
+    '%s MembershipはInviteを消費せず拒否する',
+    async (membershipStatus, expectedError) => {
+      const fixture = await createFixture()
+      const { identity } = await linkIdentity(fixture)
+      if (membershipStatus === 'suspended') {
+        await db
+          .updateTable('organization_memberships')
+          .set({ status: 'suspended' })
+          .where('id', '=', fixture.membership.id)
+          .execute()
+      }
+      const { invite, token } = await createInvite(fixture)
+      const state = await startInvite(fixture, token)
+
+      await expect(completeInvite(state, callbackClient())).resolves.toEqual({
+        ok: false,
+        error: { type: expectedError },
+        return_to: '/invites/complete',
+      })
+      const untouchedInvite = await db
+        .selectFrom('organization_invites')
+        .selectAll()
+        .where('id', '=', invite.id)
+        .executeTakeFirstOrThrow()
+      expect(untouchedInvite.redeemed_at).toBeNull()
+      expect(untouchedInvite.redeemed_membership_id).toBeNull()
+      await expect(
+        db
+          .selectFrom('organization_memberships')
+          .select(({ fn }) => fn.countAll<string>().as('count'))
+          .where('organization_id', '=', fixture.organization.id)
+          .where('user_id', '=', identity.user_id)
+          .executeTakeFirstOrThrow()
+      ).resolves.toMatchObject({ count: '1' })
+    }
+  )
+
+  it('left Membershipは新しいMembershipを作りOIDC Linkを付け替える', async () => {
+    const fixture = await createFixture()
+    const { identity, link: oldLink } = await linkIdentity(fixture)
+    await db
+      .updateTable('organization_memberships')
+      .set({ status: 'left', left_at: new Date('2026-08-10T10:00:00.000Z') })
+      .where('id', '=', fixture.membership.id)
+      .execute()
+    const { token } = await createInvite(fixture)
+    const state = await startInvite(fixture, token)
+
+    await expect(completeInvite(state, callbackClient())).resolves.toMatchObject({ ok: true })
+    const memberships = await db
+      .selectFrom('organization_memberships')
+      .selectAll()
+      .where('organization_id', '=', fixture.organization.id)
+      .where('user_id', '=', fixture.user.id)
+      .orderBy('joined_at')
+      .execute()
+    expect(memberships).toHaveLength(2)
+    expect(memberships).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: fixture.membership.id, status: 'left' }),
+        expect.objectContaining({ status: 'active', left_at: null }),
+      ])
+    )
+    const links = await db
+      .selectFrom('organization_member_oidc_identities')
+      .selectAll()
+      .where('oidc_identity_id', '=', identity.id)
+      .orderBy('created_at')
+      .execute()
+    expect(links).toHaveLength(2)
+    expect(links.find((link) => link.id === oldLink.id)?.revoked_at).toEqual(now)
+    expect(links.find((link) => link.id !== oldLink.id)).toMatchObject({
+      membership_id: memberships.find((membership) => membership.status === 'active')?.id,
+      revoked_at: null,
+    })
+  })
+
+  it('Session UserとOIDC Identity Userが違う場合は自動統合せずInviteを消費しない', async () => {
+    const fixture = await createFixture()
+    await linkIdentity(fixture)
+    const otherUser = await createUser('invite-session-user@example.test')
+    const session = await createSession({ userId: otherUser.id, now }, db)
+    const { invite, token } = await createInvite(fixture)
+    const state = await startInvite(fixture, token, session.token)
+
+    await expect(completeInvite(state, callbackClient(), session.token)).resolves.toEqual({
+      ok: false,
+      error: { type: 'AUTH_IDENTITY_USER_MISMATCH' },
+      return_to: '/invites/complete',
+    })
+    const untouchedInvite = await db
+      .selectFrom('organization_invites')
+      .selectAll()
+      .where('id', '=', invite.id)
+      .executeTakeFirstOrThrow()
+    expect(untouchedInvite.redeemed_at).toBeNull()
+    await expect(
+      db
+        .selectFrom('organization_memberships')
+        .selectAll()
+        .where('organization_id', '=', fixture.organization.id)
+        .where('user_id', '=', otherUser.id)
+        .execute()
+    ).resolves.toEqual([])
+  })
+
+  it('OIDC開始後に取消されたInviteはcallbackで再検証して書き込まない', async () => {
+    const fixture = await createFixture()
+    const { invite, token } = await createInvite(fixture)
+    const state = await startInvite(fixture, token)
+    await db
+      .updateTable('organization_invites')
+      .set({ revoked_at: now })
+      .where('id', '=', invite.id)
+      .execute()
+
+    await expect(
+      completeInvite(
+        state,
+        callbackClient({
+          subject: 'revoked-invite-subject',
+          email: 'revoked-invite@example.test',
+        })
+      )
+    ).resolves.toEqual({
+      ok: false,
+      error: { type: 'INVITE_INVALID' },
+      return_to: '/invites/complete',
+    })
+    await expect(
+      db
+        .selectFrom('oidc_identities')
+        .selectAll()
+        .where('subject', '=', 'revoked-invite-subject')
+        .execute()
+    ).resolves.toEqual([])
   })
 })

--- a/apps/kaede/tests/services/auth/organization-oidc-auth.test.ts
+++ b/apps/kaede/tests/services/auth/organization-oidc-auth.test.ts
@@ -1,0 +1,411 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { hashActivationToken } from '../../../src/services/auth/activation-token.js'
+import { createSession } from '../../../src/services/auth/session-repository.js'
+import { createDb } from '../../../src/services/db/client.js'
+import {
+  completeOrganizationOidc,
+  isOrganizationOidcTransactionState,
+} from '../../../src/usecases/organization-oidc-auth/callback.js'
+import {
+  createOrganizationOidcProvider,
+  getOrganizationOidcProviders,
+} from '../../../src/usecases/organization-oidc-auth/providers.js'
+import { startOrganizationOidc } from '../../../src/usecases/organization-oidc-auth/start.js'
+import { resetDatabase } from '../../db/helpers.js'
+
+const db = createDb()
+const now = new Date('2026-08-11T10:00:00.000Z')
+const configuredClientId = 'google-client-id'
+const transactionSecret = 'test-oidc-transaction-secret'
+
+const createUser = async (email: string) =>
+  db
+    .insertInto('users')
+    .values({
+      email,
+      contact_email: email,
+      normalized_contact_email: email.toLowerCase(),
+      display_name: email,
+      password_hash: null,
+      global_role: 'none',
+      status: 'active',
+      password_changed_at: null,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+const createFixture = async ({
+  allowedHostedDomains = null,
+}: { allowedHostedDomains?: string[] | null } = {}) => {
+  const user = await createUser('oidc-user@example.test')
+  const organization = await db
+    .insertInto('organizations')
+    .values({ name: 'OIDC Organization', slug: 'oidc-organization' })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  await db
+    .insertInto('organization_auth_settings')
+    .values({
+      organization_id: organization.id,
+      local_auth_enabled: false,
+      oidc_auth_enabled: true,
+      membership_grant_ttl_seconds: 28_800,
+      reauthentication_interval_seconds: 14_400,
+    })
+    .execute()
+  const membership = await db
+    .insertInto('organization_memberships')
+    .values({ organization_id: organization.id, user_id: user.id, role: 'member' })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  if (!membership.id) throw new Error('membership id is required')
+  const provider = await db
+    .insertInto('organization_oidc_providers')
+    .values({
+      organization_id: organization.id,
+      name: 'Google',
+      issuer: 'https://accounts.google.com',
+      client_id: configuredClientId,
+      client_secret_ref: null,
+      scopes: ['openid', 'email', 'profile'],
+      allowed_hosted_domains: allowedHostedDomains,
+      enabled: true,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+  return { membership: { ...membership, id: membership.id }, organization, provider, user }
+}
+
+const linkIdentity = async (
+  fixture: Awaited<ReturnType<typeof createFixture>>,
+  subject = 'google-subject'
+) => {
+  const identity = await db
+    .insertInto('oidc_identities')
+    .values({
+      user_id: fixture.user.id,
+      issuer: 'https://accounts.google.com',
+      subject,
+      last_claimed_email: fixture.user.email,
+      last_claimed_email_verified: true,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const link = await db
+    .insertInto('organization_member_oidc_identities')
+    .values({
+      membership_id: fixture.membership.id,
+      organization_id: fixture.organization.id,
+      user_id: fixture.user.id,
+      organization_oidc_provider_id: fixture.provider.id,
+      oidc_identity_id: identity.id,
+      revoked_at: null,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  return { identity, link }
+}
+
+const startLogin = async (
+  fixture: Awaited<ReturnType<typeof createFixture>>,
+  sessionToken?: string
+) => {
+  const result = await startOrganizationOidc(
+    fixture.organization.slug,
+    fixture.provider.id,
+    sessionToken,
+    { intent: 'login', return_to: '/orgs/oidc-organization' },
+    {
+      client: {
+        createAuthorizationUrl: ({ state }) =>
+          `https://accounts.google.com/o/oauth2/v2/auth?state=${encodeURIComponent(state)}`,
+      },
+      configuredClientId,
+      transactionSecret,
+      now,
+      executor: db,
+    }
+  )
+  expect(result.ok).toBe(true)
+  if (!result.ok) throw new Error(result.error.type)
+  const state = new URL(result.value.authorization_url).searchParams.get('state')
+  if (!state) throw new Error('state is required')
+  return state
+}
+
+const callbackClient = ({
+  hostedDomain = null,
+  subject = 'google-subject',
+}: {
+  hostedDomain?: string | null
+  subject?: string
+} = {}) => ({
+  exchangeCodeForIdToken: () => Promise.resolve('id-token'),
+  verifyIdToken: () =>
+    Promise.resolve({
+      issuer: 'accounts.google.com',
+      sub: subject,
+      email: 'oidc-user@example.test',
+      emailVerified: true,
+      name: 'OIDC User',
+      hostedDomain,
+    }),
+})
+
+describe('organization OIDC authentication', () => {
+  beforeEach(async () => {
+    await resetDatabase(db)
+  })
+
+  afterAll(async () => {
+    await db.destroy()
+  })
+
+  it('canonical issuerのIdentity LinkからSessionと対象Membership Grantを作る', async () => {
+    const fixture = await createFixture()
+    const { link } = await linkIdentity(fixture)
+    const state = await startLogin(fixture)
+
+    const result = await completeOrganizationOidc('authorization-code', state, {
+      client: callbackClient(),
+      configuredClientId,
+      transactionSecret,
+      now,
+      executor: db,
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.value.sessionToken).toBeDefined()
+    const grant = await db
+      .selectFrom('session_membership_authentications')
+      .selectAll()
+      .where('membership_id', '=', fixture.membership.id)
+      .executeTakeFirstOrThrow()
+    expect(grant).toMatchObject({
+      auth_method: 'oidc',
+      member_oidc_identity_id: link.id,
+      policy_version: '1',
+      user_id: fixture.user.id,
+    })
+    expect(grant.expires_at).toEqual(new Date('2026-08-11T18:00:00.000Z'))
+  })
+
+  it('state transactionを先に原子的に消費しcallbackの再利用を拒否する', async () => {
+    const fixture = await createFixture()
+    await linkIdentity(fixture)
+    const state = await startLogin(fixture)
+    const options = {
+      client: callbackClient(),
+      configuredClientId,
+      transactionSecret,
+      now,
+      executor: db,
+    }
+
+    await expect(
+      completeOrganizationOidc('authorization-code', state, options)
+    ).resolves.toMatchObject({ ok: true })
+    await expect(completeOrganizationOidc('authorization-code', state, options)).resolves.toEqual({
+      ok: false,
+      error: { type: 'OIDC_TRANSACTION_INVALID' },
+    })
+    await expect(isOrganizationOidcTransactionState(state, db)).resolves.toBe(true)
+  })
+
+  it('IdP error callbackでもstate transactionを消費する', async () => {
+    const fixture = await createFixture()
+    await linkIdentity(fixture)
+    const state = await startLogin(fixture)
+    const options = {
+      client: callbackClient(),
+      configuredClientId,
+      transactionSecret,
+      now,
+      executor: db,
+    }
+
+    await expect(completeOrganizationOidc(undefined, state, options)).resolves.toEqual({
+      ok: false,
+      error: { type: 'OIDC_PROVIDER_ERROR' },
+      return_to: '/orgs/oidc-organization',
+    })
+    await expect(completeOrganizationOidc('authorization-code', state, options)).resolves.toEqual({
+      ok: false,
+      error: { type: 'OIDC_TRANSACTION_INVALID' },
+    })
+  })
+
+  it('既存Session UserとOIDC Identity Userが異なる場合はGrantを作らない', async () => {
+    const fixture = await createFixture()
+    await linkIdentity(fixture)
+    const otherUser = await createUser('other-user@example.test')
+    const session = await createSession({ userId: otherUser.id, now }, db)
+    const state = await startLogin(fixture, session.token)
+
+    const result = await completeOrganizationOidc('authorization-code', state, {
+      client: callbackClient(),
+      configuredClientId,
+      transactionSecret,
+      sessionToken: session.token,
+      now,
+      executor: db,
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      error: { type: 'AUTH_IDENTITY_USER_MISMATCH' },
+      return_to: '/orgs/oidc-organization',
+    })
+    await expect(
+      db.selectFrom('session_membership_authentications').selectAll().execute()
+    ).resolves.toEqual([])
+  })
+
+  it('allowed_hosted_domains設定時はID tokenのhd一致を要求する', async () => {
+    const fixture = await createFixture({ allowedHostedDomains: ['company-a.example'] })
+    await linkIdentity(fixture)
+    const state = await startLogin(fixture)
+
+    const result = await completeOrganizationOidc('authorization-code', state, {
+      client: callbackClient({ hostedDomain: null }),
+      configuredClientId,
+      transactionSecret,
+      now,
+      executor: db,
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      error: { type: 'OIDC_HOSTED_DOMAIN_NOT_ALLOWED' },
+      return_to: '/orgs/oidc-organization',
+    })
+  })
+
+  it('active ownerだけがProviderを作成できissuer/domainを正規化してpolicyを更新する', async () => {
+    const fixture = await createFixture()
+    await db
+      .deleteFrom('organization_oidc_providers')
+      .where('id', '=', fixture.provider.id)
+      .execute()
+
+    const forbidden = await getOrganizationOidcProviders(
+      fixture.organization.id,
+      fixture.user.id,
+      db
+    )
+    expect(forbidden).toEqual({ ok: false, error: { type: 'AUTH_FORBIDDEN' } })
+
+    await db
+      .updateTable('organization_memberships')
+      .set({ role: 'owner' })
+      .where('id', '=', fixture.membership.id)
+      .execute()
+    const result = await createOrganizationOidcProvider(
+      fixture.organization.id,
+      fixture.user.id,
+      {
+        display_name: 'Google Workspace',
+        issuer: 'accounts.google.com',
+        client_id: configuredClientId,
+        allowed_hosted_domains: [' Company-A.Example ', 'company-a.example'],
+        enabled: true,
+      },
+      configuredClientId,
+      db
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.value).toMatchObject({
+      issuer: 'https://accounts.google.com',
+      allowed_hosted_domains: ['company-a.example'],
+      enabled: true,
+    })
+    const settings = await db
+      .selectFrom('organization_auth_settings')
+      .select('policy_version')
+      .where('organization_id', '=', fixture.organization.id)
+      .executeTakeFirstOrThrow()
+    expect(settings.policy_version).toBe('2')
+  })
+
+  it('accept_inviteはverified claimsを注入されたcompletionへ渡しstateを再利用させない', async () => {
+    const fixture = await createFixture()
+    const inviteToken = 'single-use-invite-token'
+    const invite = await db
+      .insertInto('organization_invites')
+      .values({
+        organization_id: fixture.organization.id,
+        created_by_user_id: fixture.user.id,
+        created_by_membership_id: fixture.membership.id,
+        email: 'legacy-unused@example.test',
+        token_hash: hashActivationToken(inviteToken),
+        role: 'member',
+        expires_at: new Date('2026-08-12T10:00:00.000Z'),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    let state = ''
+    const start = await startOrganizationOidc(
+      fixture.organization.slug,
+      fixture.provider.id,
+      undefined,
+      {
+        intent: 'accept_invite',
+        invite_token: inviteToken,
+        return_to: '/invites/complete',
+      },
+      {
+        client: {
+          createAuthorizationUrl: (params) => {
+            state = params.state
+            return `https://accounts.google.com/o/oauth2/v2/auth?state=${params.state}`
+          },
+        },
+        configuredClientId,
+        transactionSecret,
+        now,
+        executor: db,
+      }
+    )
+    expect(start.ok).toBe(true)
+    const completeInvite = vi.fn().mockResolvedValue({
+      ok: true,
+      value: { return_to: '/invites/complete' },
+    })
+    const options = {
+      client: callbackClient({ hostedDomain: 'company-a.example' }),
+      configuredClientId,
+      transactionSecret,
+      completeInvite,
+      now,
+      executor: db,
+    }
+
+    await expect(completeOrganizationOidc('authorization-code', state, options)).resolves.toEqual({
+      ok: true,
+      value: { return_to: '/invites/complete' },
+    })
+    expect(completeInvite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        inviteId: invite.id,
+        organizationId: fixture.organization.id,
+        providerId: fixture.provider.id,
+        transactionSessionId: null,
+        claims: expect.objectContaining({
+          issuer: 'https://accounts.google.com',
+          sub: 'google-subject',
+          hostedDomain: 'company-a.example',
+        }),
+      })
+    )
+
+    await expect(completeOrganizationOidc('authorization-code', state, options)).resolves.toEqual({
+      ok: false,
+      error: { type: 'OIDC_TRANSACTION_INVALID' },
+    })
+    expect(completeInvite).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/kaede/tests/services/auth/organization-oidc-link-management.test.ts
+++ b/apps/kaede/tests/services/auth/organization-oidc-link-management.test.ts
@@ -1,0 +1,204 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import type { RequestActor } from '../../../src/middleware/request-actor-context.js'
+import { createSession } from '../../../src/services/auth/index.js'
+import { createDb } from '../../../src/services/db/client.js'
+import {
+  getMyOrganizationOidcLinks,
+  unlinkMyOrganizationOidcIdentity,
+} from '../../../src/usecases/organization-oidc-links/index.js'
+import { resetDatabase } from '../../db/helpers.js'
+
+const db = createDb()
+const now = new Date('2026-08-11T12:00:00.000Z')
+
+const createFixture = async (withLocalCredential: boolean) => {
+  const user = await db
+    .insertInto('users')
+    .values({ email: 'oidc-link@example.test', display_name: 'OIDC Link', status: 'active' })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const organization = await db
+    .insertInto('organizations')
+    .values({ name: 'OIDC Link Organization', slug: 'oidc-link-organization' })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  await db
+    .insertInto('organization_auth_settings')
+    .values({
+      organization_id: organization.id,
+      local_auth_enabled: true,
+      oidc_auth_enabled: true,
+      membership_grant_ttl_seconds: 28_800,
+      reauthentication_interval_seconds: 14_400,
+    })
+    .execute()
+  const membership = await db
+    .insertInto('organization_memberships')
+    .values({ organization_id: organization.id, user_id: user.id, role: 'member' })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const provider = await db
+    .insertInto('organization_oidc_providers')
+    .values({
+      organization_id: organization.id,
+      name: 'Google',
+      issuer: 'https://accounts.google.com',
+      client_id: 'client-id-not-returned',
+      client_secret_ref: 'secret-ref-not-returned',
+      scopes: ['openid'],
+      allowed_hosted_domains: null,
+      enabled: true,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const identity = await db
+    .insertInto('oidc_identities')
+    .values({
+      user_id: user.id,
+      issuer: 'https://accounts.google.com',
+      subject: 'subject-not-returned',
+      last_claimed_email: user.email,
+      last_claimed_email_verified: true,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const link = await db
+    .insertInto('organization_member_oidc_identities')
+    .values({
+      membership_id: membership.id,
+      organization_id: organization.id,
+      user_id: user.id,
+      organization_oidc_provider_id: provider.id,
+      oidc_identity_id: identity.id,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const localCredential = withLocalCredential
+    ? await db
+        .insertInto('organization_local_credentials')
+        .values({
+          membership_id: membership.id,
+          organization_id: organization.id,
+          login_email: 'local@example.test',
+          normalized_login_email: 'local@example.test',
+          password_hash: 'hash-not-returned',
+        })
+        .returningAll()
+        .executeTakeFirstOrThrow()
+    : undefined
+  const actor = {
+    type: 'user',
+    user_id: user.id,
+    email: user.email,
+    global_role: 'none',
+    account_state: 'active',
+    memberships: [
+      { organization_id: organization.id, organization_name: organization.name, role: 'member' },
+    ],
+  } satisfies RequestActor
+  return { actor, identity, link, localCredential, membership, organization, provider, user }
+}
+
+describe('organization OIDC link management', () => {
+  beforeEach(async () => resetDatabase(db))
+  afterAll(async () => db.destroy())
+
+  it('本人のactive LinkをProvider表示情報だけで返す', async () => {
+    const fixture = await createFixture(false)
+    const result = await getMyOrganizationOidcLinks(fixture.actor, fixture.organization.id, db)
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        links: [
+          {
+            id: fixture.link.id,
+            provider: { id: fixture.provider.id, display_name: 'Google', enabled: true },
+            linked_at: fixture.link.created_at.toISOString(),
+          },
+        ],
+      },
+    })
+    expect(JSON.stringify(result)).not.toContain('client-id-not-returned')
+    expect(JSON.stringify(result)).not.toContain('subject-not-returned')
+  })
+
+  it('Linkを論理失効し、対象Link由来GrantだけをrevokeしてIdentityは残す', async () => {
+    const fixture = await createFixture(true)
+    const oidcSession = await createSession(
+      { userId: fixture.user.id, authMethod: 'oidc', now },
+      db
+    )
+    const localSession = await createSession({ userId: fixture.user.id, now }, db)
+    await db
+      .insertInto('session_membership_authentications')
+      .values([
+        {
+          session_id: oidcSession.session.id,
+          membership_id: fixture.membership.id,
+          user_id: fixture.user.id,
+          auth_method: 'oidc',
+          policy_version: 1,
+          member_oidc_identity_id: fixture.link.id,
+          authenticated_at: now,
+          expires_at: new Date(now.getTime() + 3_600_000),
+        },
+        {
+          session_id: localSession.session.id,
+          membership_id: fixture.membership.id,
+          user_id: fixture.user.id,
+          auth_method: 'local',
+          policy_version: 1,
+          local_credential_id: fixture.localCredential?.id,
+          authenticated_at: now,
+          expires_at: new Date(now.getTime() + 3_600_000),
+        },
+      ])
+      .execute()
+
+    await expect(
+      unlinkMyOrganizationOidcIdentity(fixture.actor, fixture.organization.id, fixture.link.id, {
+        now,
+        executor: db,
+      })
+    ).resolves.toEqual({ ok: true, value: { ok: true } })
+
+    const grants = await db
+      .selectFrom('session_membership_authentications')
+      .select(['auth_method', 'revoked_at'])
+      .orderBy('auth_method')
+      .execute()
+    expect(grants).toEqual([
+      { auth_method: 'local', revoked_at: null },
+      { auth_method: 'oidc', revoked_at: now },
+    ])
+    await expect(
+      db
+        .selectFrom('oidc_identities')
+        .select('id')
+        .where('id', '=', fixture.identity.id)
+        .executeTakeFirst()
+    ).resolves.toEqual({ id: fixture.identity.id })
+  })
+
+  it('最後の利用可能な認証方式になるLinkはunlinkしない', async () => {
+    const fixture = await createFixture(false)
+
+    await expect(
+      unlinkMyOrganizationOidcIdentity(fixture.actor, fixture.organization.id, fixture.link.id, {
+        now,
+        executor: db,
+      })
+    ).resolves.toEqual({
+      ok: false,
+      error: { type: 'OIDC_LINK_LAST_USABLE_AUTH_METHOD' },
+    })
+    await expect(
+      db
+        .selectFrom('organization_member_oidc_identities')
+        .select('revoked_at')
+        .where('id', '=', fixture.link.id)
+        .executeTakeFirstOrThrow()
+    ).resolves.toEqual({ revoked_at: null })
+  })
+})

--- a/apps/kaede/tests/services/auth/organization-session-logout.test.ts
+++ b/apps/kaede/tests/services/auth/organization-session-logout.test.ts
@@ -1,0 +1,148 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { createSession } from '../../../src/services/auth/index.js'
+import { createDb } from '../../../src/services/db/client.js'
+import { logoutFromOrganization } from '../../../src/usecases/organization-session-auth/index.js'
+import { resetDatabase } from '../../db/helpers.js'
+
+const db = createDb()
+const now = new Date('2026-08-11T12:00:00.000Z')
+
+const createGrantFixture = async () => {
+  const user = await db
+    .insertInto('users')
+    .values({
+      email: 'organization-logout@example.test',
+      display_name: 'Organization Logout',
+      global_role: 'none',
+      status: 'active',
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const organizations = await db
+    .insertInto('organizations')
+    .values([{ name: 'Organization A' }, { name: 'Organization B' }])
+    .returningAll()
+    .execute()
+  const memberships = await Promise.all(
+    organizations.map((organization) =>
+      db
+        .insertInto('organization_memberships')
+        .values({ organization_id: organization.id, user_id: user.id, role: 'member' })
+        .returningAll()
+        .executeTakeFirstOrThrow()
+    )
+  )
+  const credentials = await Promise.all(
+    memberships.map((membership, index) =>
+      db
+        .insertInto('organization_local_credentials')
+        .values({
+          membership_id: membership.id,
+          organization_id: membership.organization_id,
+          login_email: `logout-${index}@example.test`,
+          normalized_login_email: `logout-${index}@example.test`,
+          password_hash: 'test-password-hash',
+        })
+        .returningAll()
+        .executeTakeFirstOrThrow()
+    )
+  )
+  const { session, token } = await createSession({ userId: user.id, now }, db)
+  await db
+    .insertInto('session_membership_authentications')
+    .values(
+      memberships.map((membership, index) => ({
+        session_id: session.id,
+        membership_id: membership.id,
+        user_id: user.id,
+        auth_method: 'local',
+        policy_version: 1,
+        local_credential_id: credentials[index].id,
+        authenticated_at: now,
+        expires_at: new Date(now.getTime() + 3_600_000),
+      }))
+    )
+    .execute()
+
+  return { memberships, organizations, session, token }
+}
+
+describe('organization session logout', () => {
+  beforeEach(async () => resetDatabase(db))
+  afterAll(async () => db.destroy())
+
+  it('対象OrganizationのGrantだけをrevokeし、Sessionと他Organization Grantを維持する', async () => {
+    const fixture = await createGrantFixture()
+    const targetOrganization = fixture.organizations[0]
+    const targetMembership = fixture.memberships[0]
+
+    const result = await logoutFromOrganization(
+      targetOrganization.id,
+      fixture.token,
+      { now, requestId: 'request-id', userAgent: 'test-agent' },
+      db
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        organization_id: targetOrganization.id,
+        membership_id: targetMembership.id,
+        revoked: true,
+      },
+    })
+    const grants = await db
+      .selectFrom('session_membership_authentications')
+      .select(['membership_id', 'revoked_at'])
+      .where('session_id', '=', fixture.session.id)
+      .orderBy('membership_id')
+      .execute()
+    expect(grants.find((grant) => grant.membership_id === targetMembership.id)?.revoked_at).toEqual(
+      now
+    )
+    expect(
+      grants.find((grant) => grant.membership_id !== targetMembership.id)?.revoked_at
+    ).toBeNull()
+    await expect(
+      db
+        .selectFrom('sessions')
+        .select('revoked_at')
+        .where('id', '=', fixture.session.id)
+        .executeTakeFirst()
+    ).resolves.toEqual({ revoked_at: null })
+  })
+
+  it('既にrevoke済みまたはGrantなしでもidempotentに成功する', async () => {
+    const fixture = await createGrantFixture()
+    const targetOrganization = fixture.organizations[0]
+
+    await logoutFromOrganization(targetOrganization.id, fixture.token, { now }, db)
+    const second = await logoutFromOrganization(
+      targetOrganization.id,
+      fixture.token,
+      { now: new Date(now.getTime() + 1000) },
+      db
+    )
+
+    expect(second).toMatchObject({ ok: true, value: { revoked: false } })
+  })
+
+  it('current MembershipがないOrganizationは拒否してGrantを変更しない', async () => {
+    const fixture = await createGrantFixture()
+    const unrelated = await db
+      .insertInto('organizations')
+      .values({ name: 'Unrelated Organization' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    const result = await logoutFromOrganization(unrelated.id, fixture.token, { now }, db)
+
+    expect(result).toEqual({ ok: false, error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' } })
+    const revokedCount = await db
+      .selectFrom('session_membership_authentications')
+      .select(({ fn }) => fn.countAll<number>().as('count'))
+      .where('revoked_at', 'is not', null)
+      .executeTakeFirstOrThrow()
+    expect(revokedCount.count.toString()).toBe('0')
+  })
+})

--- a/apps/kaede/tests/services/db/membership-lifecycle.test.ts
+++ b/apps/kaede/tests/services/db/membership-lifecycle.test.ts
@@ -1,0 +1,131 @@
+import { sql } from 'kysely'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { createDb } from '../../../src/services/db/client.js'
+import {
+  findOrganizationMembership,
+  upsertOrganizationMembership,
+} from '../../../src/services/users/index.js'
+import { resetDatabase } from '../../db/helpers.js'
+
+const db = createDb()
+
+const createUserAndOrganization = async () => {
+  const user = await db
+    .insertInto('users')
+    .values({
+      email: 'membership-lifecycle@example.test',
+      display_name: 'Membership Lifecycle',
+      global_role: 'none',
+      status: 'active',
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const organization = await db
+    .insertInto('organizations')
+    .values({ name: 'Membership Lifecycle Organization' })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+  return { organization, user }
+}
+
+describe('membership lifecycle', () => {
+  beforeEach(async () => {
+    await resetDatabase(db)
+  })
+
+  afterAll(async () => {
+    await db.destroy()
+  })
+
+  it('UUIDをprimary keyとし、current MembershipだけをUserとOrganizationごとに一意にする', async () => {
+    const primaryKeyColumns = await sql<{ column_name: string }>`
+      SELECT attribute.attname AS column_name
+      FROM pg_constraint AS con
+      JOIN pg_class AS relation ON relation.oid = con.conrelid
+      JOIN unnest(con.conkey) WITH ORDINALITY AS key(attnum, position) ON true
+      JOIN pg_attribute AS attribute
+        ON attribute.attrelid = relation.oid
+       AND attribute.attnum = key.attnum
+      WHERE relation.relname = 'organization_memberships'
+        AND con.contype = 'p'
+      ORDER BY key.position
+    `.execute(db)
+
+    expect(primaryKeyColumns.rows.map((row) => row.column_name)).toEqual(['id'])
+
+    const index = await sql<{ predicate: string | null }>`
+      SELECT pg_get_expr(idx.indpred, idx.indrelid) AS predicate
+      FROM pg_index AS idx
+      JOIN pg_class AS relation ON relation.oid = idx.indexrelid
+      WHERE relation.relname = 'organization_memberships_current_user_org_key'
+    `.execute(db)
+
+    expect(index.rows[0]?.predicate).toContain('status = ANY')
+  })
+
+  it('left後の再参加では新しいMembershipを作成する', async () => {
+    const { organization, user } = await createUserAndOrganization()
+    const leftMembership = await db
+      .insertInto('organization_memberships')
+      .values({
+        organization_id: organization.id,
+        user_id: user.id,
+        role: 'member',
+        status: 'left',
+        left_at: new Date('2026-08-10T00:00:00.000Z'),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    const currentMembership = await upsertOrganizationMembership(
+      {
+        organization_id: organization.id,
+        user_id: user.id,
+        role: 'manager',
+        status: 'active',
+      },
+      db
+    )
+
+    expect(currentMembership.id).not.toBe(leftMembership.id)
+    await expect(findOrganizationMembership(organization.id, user.id, db)).resolves.toMatchObject({
+      id: currentMembership.id,
+      role: 'manager',
+      status: 'active',
+    })
+    await expect(
+      db
+        .selectFrom('organization_memberships')
+        .selectAll()
+        .where('organization_id', '=', organization.id)
+        .where('user_id', '=', user.id)
+        .execute()
+    ).resolves.toHaveLength(2)
+  })
+
+  it('current Membershipがある場合は新規行を作らずroleを更新する', async () => {
+    const { organization, user } = await createUserAndOrganization()
+    const original = await upsertOrganizationMembership(
+      {
+        organization_id: organization.id,
+        user_id: user.id,
+        role: 'member',
+        status: 'active',
+      },
+      db
+    )
+    const updated = await upsertOrganizationMembership(
+      {
+        organization_id: organization.id,
+        user_id: user.id,
+        role: 'manager',
+        status: 'active',
+      },
+      db
+    )
+
+    expect(updated.id).toBe(original.id)
+    expect(updated.role).toBe('manager')
+  })
+})

--- a/apps/kaede/tests/services/db/multi-org-auth-backfill.test.ts
+++ b/apps/kaede/tests/services/db/multi-org-auth-backfill.test.ts
@@ -1,0 +1,335 @@
+import { sql } from 'kysely'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { createDb } from '../../../src/services/db/client.js'
+import {
+  backfillMultiOrgAuthCore,
+  backfillMultiOrgAuthCredentials,
+  canonicalGoogleIssuer,
+  getMultiOrgAuthPreflightReport,
+  validateMultiOrgAuthExpandConstraints,
+  verifyMultiOrgAuthCoreBackfill,
+} from '../../../src/services/migrations/multi-org-auth-backfill.js'
+import { resetDatabase } from '../../db/helpers.js'
+
+const db = createDb()
+const passwordHash = '$argon2id$v=19$m=65536,t=3,p=4$ZHVtbXk$legacy-password-hash'
+
+const createLegacyUserAndMembership = async (suffix: string) => {
+  const user = await db
+    .insertInto('users')
+    .values({
+      display_name: `User ${suffix}`,
+      email: `${suffix}@example.com`,
+      global_role: 'none',
+      password_hash: passwordHash,
+      status: 'active',
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const organization = await db
+    .insertInto('organizations')
+    .values({ name: `Organization ${suffix}` })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const membership = await db
+    .insertInto('organization_memberships')
+    .values({ organization_id: organization.id, role: 'owner', user_id: user.id })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+  await sql`
+    UPDATE organization_memberships
+    SET id = NULL, status = NULL, joined_at = NULL
+    WHERE organization_id = ${organization.id} AND user_id = ${user.id}
+  `.execute(db)
+  await sql`UPDATE organizations SET status = NULL WHERE id = ${organization.id}`.execute(db)
+
+  return { membership, organization, user }
+}
+
+describe('multi organization auth backfill', () => {
+  beforeEach(async () => {
+    await resetDatabase(db)
+  })
+
+  afterAll(async () => {
+    await db.destroy()
+  })
+
+  it('backfills the safe core fields in batches and is idempotent', async () => {
+    const { organization, user } = await createLegacyUserAndMembership('core')
+    const pedestrian = await db
+      .insertInto('pedestrians')
+      .values({
+        display_name: 'Organization Persona',
+        organization_id: organization.id,
+        user_id: user.id,
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    await db
+      .insertInto('organization_invites')
+      .values({
+        created_by_user_id: user.id,
+        email: 'invitee@example.com',
+        expires_at: new Date('2026-08-20T00:00:00.000Z'),
+        organization_id: organization.id,
+        role: 'member',
+        token_hash: 'legacy-token',
+      })
+      .execute()
+
+    const first = await backfillMultiOrgAuthCore(1, db)
+    const second = await backfillMultiOrgAuthCore(1, db)
+    const verification = await verifyMultiOrgAuthCoreBackfill(db)
+
+    expect(first).toMatchObject({
+      contact_emails: 1,
+      invite_creators: 1,
+      memberships: 1,
+      member_profiles: 1,
+      organizations: 1,
+      pedestrian_memberships: 1,
+      user_profiles: 1,
+    })
+    expect(Object.values(second).every((count) => count === 0)).toBe(true)
+    expect(Object.values(verification).every((count) => count === 0)).toBe(true)
+
+    const migratedPedestrian = await db
+      .selectFrom('pedestrians')
+      .select('membership_id')
+      .where('id', '=', pedestrian.id)
+      .executeTakeFirstOrThrow()
+    if (!migratedPedestrian.membership_id) throw new Error('membership was not backfilled')
+    const memberProfile = await db
+      .selectFrom('organization_member_profiles')
+      .selectAll()
+      .where('membership_id', '=', migratedPedestrian.membership_id)
+      .executeTakeFirstOrThrow()
+    expect(memberProfile.display_name).toBe('Organization Persona')
+    expect(memberProfile.height_meters).toBeNull()
+    expect(memberProfile.stride_length_meters).toBeNull()
+  })
+
+  it('normalizes meter and centimeter measurements and reports their classifications', async () => {
+    const { organization, user } = await createLegacyUserAndMembership('measurements')
+    await db
+      .insertInto('pedestrians')
+      .values({
+        display_name: 'Measured User',
+        height: 170,
+        organization_id: organization.id,
+        stride_length: 0.7,
+        user_id: user.id,
+      })
+      .execute()
+
+    const report = await getMultiOrgAuthPreflightReport(db)
+    expect(report.measurements).toEqual({ already_m: 1, converted_cm: 1, invalid: 0 })
+
+    const result = await backfillMultiOrgAuthCore(10, db)
+    const profile = await db
+      .selectFrom('organization_member_profiles')
+      .select(['height_meters', 'stride_length_meters'])
+      .executeTakeFirstOrThrow()
+    expect(profile).toEqual({ height_meters: '1.700', stride_length_meters: '0.700' })
+    expect(result.measurement_values_already_m).toBe(1)
+    expect(result.measurement_values_converted_cm).toBe(1)
+  })
+
+  it('blocks values that cannot be represented safely after normalization', async () => {
+    const { organization, user } = await createLegacyUserAndMembership('invalid-measurement')
+    await db
+      .insertInto('pedestrians')
+      .values({
+        display_name: 'Invalid Measurement',
+        height: 0.0001,
+        organization_id: organization.id,
+        stride_length: 301,
+        user_id: user.id,
+      })
+      .execute()
+
+    const report = await getMultiOrgAuthPreflightReport(db)
+    expect(report.measurements.invalid).toBe(2)
+    await expect(backfillMultiOrgAuthCore(10, db)).rejects.toThrow(
+      'PEDESTRIAN_MEASUREMENT_OUT_OF_RANGE'
+    )
+  })
+
+  it('returns an exact issue count with at most twenty samples', async () => {
+    const { organization } = await createLegacyUserAndMembership('bounded-samples')
+    await db
+      .insertInto('pedestrians')
+      .values(
+        Array.from({ length: 25 }, (_, index) => ({
+          display_name: `Invalid ${index}`,
+          height: 301,
+          organization_id: organization.id,
+        }))
+      )
+      .execute()
+
+    const report = await getMultiOrgAuthPreflightReport(db)
+    const issue = report.issues.find(
+      (candidate) => candidate.code === 'PEDESTRIAN_MEASUREMENT_OUT_OF_RANGE'
+    )
+    expect(issue?.count).toBe(25)
+    expect(issue?.samples).toHaveLength(20)
+  })
+
+  it('stops core backfill before writing when a blocking legacy issue exists', async () => {
+    const { organization, user } = await createLegacyUserAndMembership('legacy-blocker')
+    await db
+      .insertInto('organization_invites')
+      .values({
+        created_by_user_id: user.id,
+        email: 'legacy-multi-use@example.com',
+        expires_at: new Date('2026-08-20T00:00:00.000Z'),
+        max_uses: 2,
+        organization_id: organization.id,
+        role: 'member',
+        token_hash: 'legacy-multi-use-token',
+      })
+      .execute()
+
+    await expect(backfillMultiOrgAuthCore(10, db)).rejects.toThrow('LEGACY_MULTI_USE_INVITE')
+    const unchanged = await db
+      .selectFrom('organization_memberships')
+      .select(['id', 'joined_at', 'status'])
+      .where('organization_id', '=', organization.id)
+      .where('user_id', '=', user.id)
+      .executeTakeFirstOrThrow()
+    expect(unchanged).toEqual({ id: null, joined_at: null, status: null })
+  })
+
+  it('stops auth backfill on normalized login email collision', async () => {
+    const first = await createLegacyUserAndMembership('collision-first')
+    const secondUser = await db
+      .insertInto('users')
+      .values({
+        display_name: 'Collision Second',
+        email: 'COLLISION-FIRST@example.com',
+        global_role: 'none',
+        password_hash: passwordHash,
+        status: 'active',
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    await db
+      .insertInto('organization_memberships')
+      .values({
+        organization_id: first.organization.id,
+        role: 'member',
+        user_id: secondUser.id,
+      })
+      .execute()
+    await db
+      .insertInto('organization_auth_settings')
+      .values({
+        local_auth_enabled: true,
+        membership_grant_ttl_seconds: 3600,
+        oidc_auth_enabled: false,
+        organization_id: first.organization.id,
+        reauthentication_interval_seconds: 1800,
+      })
+      .execute()
+    await backfillMultiOrgAuthCore(10, db)
+
+    await expect(backfillMultiOrgAuthCredentials(10, db)).rejects.toThrow(
+      'LOCAL_LOGIN_EMAIL_COLLISION'
+    )
+    expect(await db.selectFrom('organization_local_credentials').selectAll().execute()).toEqual([])
+  })
+
+  it('backfills local credentials and canonical Google identities only after explicit policy/provider setup', async () => {
+    const { organization, user } = await createLegacyUserAndMembership('auth')
+    await backfillMultiOrgAuthCore(10, db)
+    await db
+      .insertInto('organization_auth_settings')
+      .values({
+        local_auth_enabled: true,
+        membership_grant_ttl_seconds: 3600,
+        oidc_auth_enabled: true,
+        organization_id: organization.id,
+        reauthentication_interval_seconds: 1800,
+      })
+      .execute()
+    await db
+      .insertInto('organization_oidc_providers')
+      .values({
+        client_id: 'legacy-google-client',
+        issuer: canonicalGoogleIssuer,
+        name: 'Google',
+        organization_id: organization.id,
+        scopes: ['openid'],
+      })
+      .execute()
+    await db
+      .insertInto('auth_identities')
+      .values({
+        email: user.email,
+        email_verified: true,
+        provider: 'google',
+        provider_subject: 'legacy-google-subject',
+        user_id: user.id,
+      })
+      .execute()
+
+    const first = await backfillMultiOrgAuthCredentials(1, db)
+    const second = await backfillMultiOrgAuthCredentials(1, db)
+
+    expect(first).toMatchObject({
+      auth_settings_unchanged: 1,
+      local_credentials: 1,
+      oidc_identities: 1,
+      oidc_links: 1,
+    })
+    expect(second).toMatchObject({
+      auth_settings_unchanged: 1,
+      local_credentials: 0,
+      oidc_identities: 0,
+      oidc_links: 0,
+    })
+    await expect(
+      db
+        .selectFrom('oidc_identities')
+        .select(['issuer', 'subject', 'user_id'])
+        .executeTakeFirstOrThrow()
+    ).resolves.toEqual({
+      issuer: canonicalGoogleIssuer,
+      subject: 'legacy-google-subject',
+      user_id: user.id,
+    })
+  })
+
+  it('validates expand constraints and promotes required columns only after core verification', async () => {
+    await db
+      .transaction()
+      .execute(async (trx) => {
+        await createLegacyUserAndMembership('validate')
+        await backfillMultiOrgAuthCore(10, trx)
+        await validateMultiOrgAuthExpandConstraints(trx)
+
+        const columns = await sql<{ attname: string; attnotnull: boolean }>`
+          SELECT attribute.attname, attribute.attnotnull
+          FROM pg_attribute AS attribute
+          WHERE attribute.attrelid = 'organization_memberships'::regclass
+            AND attribute.attname IN ('id', 'status', 'joined_at')
+          ORDER BY attribute.attname
+        `.execute(trx)
+        expect(columns.rows).toEqual([
+          { attname: 'id', attnotnull: true },
+          { attname: 'joined_at', attnotnull: true },
+          { attname: 'status', attnotnull: true },
+        ])
+
+        throw new Error('rollback constraint promotion test')
+      })
+      .catch((error: unknown) => {
+        if (!(error instanceof Error) || error.message !== 'rollback constraint promotion test') {
+          throw error
+        }
+      })
+  })
+})

--- a/apps/kaede/tests/services/db/multi-org-auth-backfill.test.ts
+++ b/apps/kaede/tests/services/db/multi-org-auth-backfill.test.ts
@@ -5,6 +5,7 @@ import {
   backfillMultiOrgAuthCore,
   backfillMultiOrgAuthCredentials,
   canonicalGoogleIssuer,
+  executeOneShotMultiOrgAuthCutover,
   getMultiOrgAuthPreflightReport,
   validateMultiOrgAuthExpandConstraints,
   verifyMultiOrgAuthCoreBackfill,
@@ -399,5 +400,42 @@ describe('multi organization auth backfill', () => {
           throw error
         }
       })
+  })
+
+  it('migrates all rows and revokes legacy sessions in one cutover transaction', async () => {
+    const { organization, user } = await createLegacyUserAndMembership('one-shot')
+    await db
+      .insertInto('organization_auth_settings')
+      .values({
+        local_auth_enabled: true,
+        membership_grant_ttl_seconds: 3600,
+        oidc_auth_enabled: false,
+        organization_id: organization.id,
+        reauthentication_interval_seconds: 1800,
+      })
+      .execute()
+    await db
+      .insertInto('sessions')
+      .values({
+        expires_at: new Date('2026-08-20T00:00:00.000Z'),
+        session_hash: 'legacy-session-hash',
+        user_id: user.id,
+      })
+      .execute()
+
+    const result = await executeOneShotMultiOrgAuthCutover(1, db)
+
+    expect(result).toMatchObject({
+      auth: { local_credentials: 1 },
+      core: { memberships: 1, user_profiles: 1 },
+      revoked_sessions: 1,
+      validated: true,
+    })
+    await expect(
+      db.selectFrom('sessions').select('revoked_at').executeTakeFirstOrThrow()
+    ).resolves.toEqual({ revoked_at: expect.any(Date) })
+    await expect(
+      db.selectFrom('organization_local_credentials').select('id').executeTakeFirstOrThrow()
+    ).resolves.toEqual({ id: expect.any(String) })
   })
 })

--- a/apps/kaede/tests/services/db/multi-org-auth-backfill.test.ts
+++ b/apps/kaede/tests/services/db/multi-org-auth-backfill.test.ts
@@ -403,17 +403,7 @@ describe('multi organization auth backfill', () => {
   })
 
   it('migrates all rows and revokes legacy sessions in one cutover transaction', async () => {
-    const { organization, user } = await createLegacyUserAndMembership('one-shot')
-    await db
-      .insertInto('organization_auth_settings')
-      .values({
-        local_auth_enabled: true,
-        membership_grant_ttl_seconds: 3600,
-        oidc_auth_enabled: false,
-        organization_id: organization.id,
-        reauthentication_interval_seconds: 1800,
-      })
-      .execute()
+    const { user } = await createLegacyUserAndMembership('one-shot')
     await db
       .insertInto('sessions')
       .values({
@@ -423,10 +413,16 @@ describe('multi organization auth backfill', () => {
       })
       .execute()
 
-    const result = await executeOneShotMultiOrgAuthCutover(1, db)
+    const result = await executeOneShotMultiOrgAuthCutover(1, db, {
+      google_client_id: '',
+      local_auth_enabled: true,
+      oidc_auth_enabled: false,
+    })
 
     expect(result).toMatchObject({
+      already_completed: false,
       auth: { local_credentials: 1 },
+      bootstrapped_auth_settings: 1,
       core: { memberships: 1, user_profiles: 1 },
       revoked_sessions: 1,
       validated: true,
@@ -437,5 +433,27 @@ describe('multi organization auth backfill', () => {
     await expect(
       db.selectFrom('organization_local_credentials').select('id').executeTakeFirstOrThrow()
     ).resolves.toEqual({ id: expect.any(String) })
+
+    await db
+      .insertInto('sessions')
+      .values({
+        expires_at: new Date('2026-08-20T00:00:00.000Z'),
+        session_hash: 'post-cutover-session-hash',
+        user_id: user.id,
+      })
+      .execute()
+    const repeated = await executeOneShotMultiOrgAuthCutover(1, db, {
+      google_client_id: '',
+      local_auth_enabled: true,
+      oidc_auth_enabled: false,
+    })
+    expect(repeated).toMatchObject({ already_completed: true, revoked_sessions: 0 })
+    await expect(
+      db
+        .selectFrom('sessions')
+        .select('revoked_at')
+        .where('session_hash', '=', 'post-cutover-session-hash')
+        .executeTakeFirstOrThrow()
+    ).resolves.toEqual({ revoked_at: null })
   })
 })

--- a/apps/kaede/tests/services/db/multi-org-auth-backfill.test.ts
+++ b/apps/kaede/tests/services/db/multi-org-auth-backfill.test.ts
@@ -1,5 +1,5 @@
 import { sql } from 'kysely'
-import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { createDb } from '../../../src/services/db/client.js'
 import {
   backfillMultiOrgAuthCore,
@@ -13,6 +13,45 @@ import { resetDatabase } from '../../db/helpers.js'
 
 const db = createDb()
 const passwordHash = '$argon2id$v=19$m=65536,t=3,p=4$ZHVtbXk$legacy-password-hash'
+
+const usePrePromotionMembershipSchema = async () => {
+  await sql`
+    ALTER TABLE organization_member_profiles
+      DROP CONSTRAINT organization_member_profiles_membership_id_fkey;
+    ALTER TABLE organization_memberships
+      DROP CONSTRAINT organization_memberships_pkey;
+    ALTER TABLE organization_memberships
+      ADD CONSTRAINT organization_memberships_pkey PRIMARY KEY (organization_id, user_id);
+    CREATE UNIQUE INDEX organization_memberships_id_key
+      ON organization_memberships (id);
+    ALTER TABLE organization_member_profiles
+      ADD CONSTRAINT organization_member_profiles_membership_id_fkey
+      FOREIGN KEY (membership_id)
+      REFERENCES organization_memberships(id) ON DELETE RESTRICT;
+    ALTER TABLE organization_memberships ALTER COLUMN id DROP NOT NULL;
+    ALTER TABLE organization_memberships ALTER COLUMN status DROP NOT NULL;
+    ALTER TABLE organization_memberships ALTER COLUMN joined_at DROP NOT NULL;
+  `.execute(db)
+}
+
+const restorePromotedMembershipSchema = async () => {
+  await sql`
+    ALTER TABLE organization_memberships ALTER COLUMN id SET NOT NULL;
+    ALTER TABLE organization_memberships ALTER COLUMN status SET NOT NULL;
+    ALTER TABLE organization_memberships ALTER COLUMN joined_at SET NOT NULL;
+    ALTER TABLE organization_member_profiles
+      DROP CONSTRAINT organization_member_profiles_membership_id_fkey;
+    ALTER TABLE organization_memberships
+      DROP CONSTRAINT organization_memberships_pkey;
+    ALTER TABLE organization_memberships
+      ADD CONSTRAINT organization_memberships_pkey
+      PRIMARY KEY USING INDEX organization_memberships_id_key;
+    ALTER TABLE organization_member_profiles
+      ADD CONSTRAINT organization_member_profiles_membership_id_fkey
+      FOREIGN KEY (membership_id)
+      REFERENCES organization_memberships(id) ON DELETE RESTRICT;
+  `.execute(db)
+}
 
 const withLegacyMeasurementConstraintsDisabled = async (insertRows: () => Promise<void>) => {
   await sql`
@@ -67,11 +106,18 @@ const createLegacyUserAndMembership = async (suffix: string) => {
 }
 
 describe('multi organization auth backfill', () => {
+  beforeAll(async () => {
+    await resetDatabase(db)
+    await usePrePromotionMembershipSchema()
+  })
+
   beforeEach(async () => {
     await resetDatabase(db)
   })
 
   afterAll(async () => {
+    await resetDatabase(db)
+    await restorePromotedMembershipSchema()
     await db.destroy()
   })
 

--- a/apps/kaede/tests/services/db/multi-org-auth-backfill.test.ts
+++ b/apps/kaede/tests/services/db/multi-org-auth-backfill.test.ts
@@ -14,6 +14,25 @@ import { resetDatabase } from '../../db/helpers.js'
 const db = createDb()
 const passwordHash = '$argon2id$v=19$m=65536,t=3,p=4$ZHVtbXk$legacy-password-hash'
 
+const withLegacyMeasurementConstraintsDisabled = async (insertRows: () => Promise<void>) => {
+  await sql`
+    ALTER TABLE pedestrians
+      DROP CONSTRAINT pedestrians_height_meter_bounds_chk,
+      DROP CONSTRAINT pedestrians_stride_meter_bounds_chk
+  `.execute(db)
+  try {
+    await insertRows()
+  } finally {
+    await sql`
+      ALTER TABLE pedestrians
+        ADD CONSTRAINT pedestrians_height_meter_bounds_chk
+          CHECK (height IS NULL OR (height > 0 AND height <= 3)) NOT VALID,
+        ADD CONSTRAINT pedestrians_stride_meter_bounds_chk
+          CHECK (stride_length IS NULL OR (stride_length > 0 AND stride_length <= 3)) NOT VALID
+    `.execute(db)
+  }
+}
+
 const createLegacyUserAndMembership = async (suffix: string) => {
   const user = await db
     .insertInto('users')
@@ -111,13 +130,13 @@ describe('multi organization auth backfill', () => {
     expect(memberProfile.stride_length_meters).toBeNull()
   })
 
-  it('normalizes meter and centimeter measurements and reports their classifications', async () => {
+  it('copies meter measurements without guessing another unit', async () => {
     const { organization, user } = await createLegacyUserAndMembership('measurements')
     await db
       .insertInto('pedestrians')
       .values({
         display_name: 'Measured User',
-        height: 170,
+        height: 1.7,
         organization_id: organization.id,
         stride_length: 0.7,
         user_id: user.id,
@@ -125,7 +144,7 @@ describe('multi organization auth backfill', () => {
       .execute()
 
     const report = await getMultiOrgAuthPreflightReport(db)
-    expect(report.measurements).toEqual({ already_m: 1, converted_cm: 1, invalid: 0 })
+    expect(report.measurements).toEqual({ valid_meters: 2, invalid: 0 })
 
     const result = await backfillMultiOrgAuthCore(10, db)
     const profile = await db
@@ -133,22 +152,23 @@ describe('multi organization auth backfill', () => {
       .select(['height_meters', 'stride_length_meters'])
       .executeTakeFirstOrThrow()
     expect(profile).toEqual({ height_meters: '1.700', stride_length_meters: '0.700' })
-    expect(result.measurement_values_already_m).toBe(1)
-    expect(result.measurement_values_converted_cm).toBe(1)
+    expect(result.measurement_values_copied_meters).toBe(2)
   })
 
   it('blocks values that cannot be represented safely after normalization', async () => {
     const { organization, user } = await createLegacyUserAndMembership('invalid-measurement')
-    await db
-      .insertInto('pedestrians')
-      .values({
-        display_name: 'Invalid Measurement',
-        height: 0.0001,
-        organization_id: organization.id,
-        stride_length: 301,
-        user_id: user.id,
-      })
-      .execute()
+    await withLegacyMeasurementConstraintsDisabled(async () => {
+      await db
+        .insertInto('pedestrians')
+        .values({
+          display_name: 'Invalid Measurement',
+          height: 170,
+          organization_id: organization.id,
+          stride_length: 70,
+          user_id: user.id,
+        })
+        .execute()
+    })
 
     const report = await getMultiOrgAuthPreflightReport(db)
     expect(report.measurements.invalid).toBe(2)
@@ -159,16 +179,18 @@ describe('multi organization auth backfill', () => {
 
   it('returns an exact issue count with at most twenty samples', async () => {
     const { organization } = await createLegacyUserAndMembership('bounded-samples')
-    await db
-      .insertInto('pedestrians')
-      .values(
-        Array.from({ length: 25 }, (_, index) => ({
-          display_name: `Invalid ${index}`,
-          height: 301,
-          organization_id: organization.id,
-        }))
-      )
-      .execute()
+    await withLegacyMeasurementConstraintsDisabled(async () => {
+      await db
+        .insertInto('pedestrians')
+        .values(
+          Array.from({ length: 25 }, (_, index) => ({
+            display_name: `Invalid ${index}`,
+            height: 301,
+            organization_id: organization.id,
+          }))
+        )
+        .execute()
+    })
 
     const report = await getMultiOrgAuthPreflightReport(db)
     const issue = report.issues.find(

--- a/apps/kaede/tests/services/db/multi-organization-auth-expand-migration.test.ts
+++ b/apps/kaede/tests/services/db/multi-organization-auth-expand-migration.test.ts
@@ -1,0 +1,193 @@
+import { sql } from 'kysely'
+import { afterAll, describe, expect, it } from 'vitest'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createDb } from '../../../src/services/db/client.js'
+
+const db = createDb()
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const loadExpandUpSql = async () => {
+  const migrationPath = path.resolve(
+    __dirname,
+    '../../../../../db/migrations/20260811010000_add_multi_org_membership_columns.sql'
+  )
+  const migration = await readFile(migrationPath, 'utf8')
+  const upSql = migration.split('-- migrate:down')[0]?.replace('-- migrate:up', '').trim()
+
+  if (!upSql) {
+    throw new Error('multi-organization expand migration up SQL was not found')
+  }
+
+  return upSql
+}
+
+const loadInviteExpandDownSql = async () => {
+  const migrationPath = path.resolve(
+    __dirname,
+    '../../../../../db/migrations/20260811010500_expand_organization_invites.sql'
+  )
+  const migration = await readFile(migrationPath, 'utf8')
+  const downSql = migration.split('-- migrate:down')[1]?.trim()
+
+  if (!downSql) {
+    throw new Error('organization invite expand migration down SQL was not found')
+  }
+
+  return downSql
+}
+
+describe('multi-organization auth expand migration', () => {
+  afterAll(async () => {
+    await db.destroy()
+  })
+
+  it('既存Membershipをbackfillせず、新規insertにだけdefaultを適用する', async () => {
+    const upSql = await loadExpandUpSql()
+
+    await db
+      .transaction()
+      .execute(async (trx) => {
+        await sql.raw('CREATE SCHEMA multi_org_expand_compat').execute(trx)
+        await sql.raw('SET LOCAL search_path TO multi_org_expand_compat, public').execute(trx)
+        await sql
+          .raw(
+            `
+          CREATE TABLE users (
+            id uuid PRIMARY KEY,
+            email text NOT NULL,
+            display_name text NOT NULL
+          );
+          CREATE TABLE organizations (
+            id uuid PRIMARY KEY,
+            name text NOT NULL
+          );
+          CREATE TABLE organization_memberships (
+            organization_id uuid NOT NULL,
+            user_id uuid NOT NULL,
+            role text NOT NULL,
+            PRIMARY KEY (organization_id, user_id)
+          );
+          CREATE TABLE sessions (
+            id uuid PRIMARY KEY,
+            user_id uuid NOT NULL,
+            session_hash text NOT NULL,
+            expires_at timestamptz NOT NULL,
+            revoked_at timestamptz
+          );
+          INSERT INTO users (id, email, display_name)
+          VALUES
+            ('20000000-0000-0000-0000-000000000001', 'existing@example.com', 'Existing'),
+            ('20000000-0000-0000-0000-000000000002', 'new@example.com', 'New');
+          INSERT INTO organizations (id, name)
+          VALUES ('10000000-0000-0000-0000-000000000001', 'Existing Organization');
+          INSERT INTO organization_memberships (organization_id, user_id, role)
+          VALUES (
+            '10000000-0000-0000-0000-000000000001',
+            '20000000-0000-0000-0000-000000000001',
+            'member'
+          );
+        `
+          )
+          .execute(trx)
+
+        await sql.raw(upSql).execute(trx)
+
+        await sql
+          .raw(
+            `
+          INSERT INTO organization_memberships (organization_id, user_id, role)
+          VALUES (
+            '10000000-0000-0000-0000-000000000001',
+            '20000000-0000-0000-0000-000000000002',
+            'member'
+          );
+        `
+          )
+          .execute(trx)
+
+        const rows = await sql<{
+          user_id: string
+          id_is_null: boolean
+          status: string | null
+          joined_at_is_null: boolean
+        }>`
+          SELECT
+            user_id,
+            id IS NULL AS id_is_null,
+            status,
+            joined_at IS NULL AS joined_at_is_null
+          FROM organization_memberships
+          ORDER BY user_id
+        `.execute(trx)
+
+        expect(rows.rows).toEqual([
+          {
+            user_id: '20000000-0000-0000-0000-000000000001',
+            id_is_null: true,
+            status: null,
+            joined_at_is_null: true,
+          },
+          {
+            user_id: '20000000-0000-0000-0000-000000000002',
+            id_is_null: false,
+            status: 'active',
+            joined_at_is_null: false,
+          },
+        ])
+
+        throw new Error('rollback multi-organization expand compatibility test')
+      })
+      .catch((error: unknown) => {
+        if (
+          !(error instanceof Error) ||
+          error.message !== 'rollback multi-organization expand compatibility test'
+        ) {
+          throw error
+        }
+      })
+  })
+
+  it('manager Inviteが存在する場合はrole制約をmemberへ戻さず安全に停止する', async () => {
+    const downSql = await loadInviteExpandDownSql()
+
+    await expect(
+      db.transaction().execute(async (trx) => {
+        const user = await trx
+          .insertInto('users')
+          .values({
+            email: 'invite-down@example.com',
+            display_name: 'Invite Down',
+            password_hash: 'hash',
+            global_role: 'none',
+            status: 'active',
+          })
+          .returning('id')
+          .executeTakeFirstOrThrow()
+        const organization = await trx
+          .insertInto('organizations')
+          .values({ name: 'Invite Down Organization' })
+          .returning('id')
+          .executeTakeFirstOrThrow()
+
+        await trx
+          .insertInto('organization_invites')
+          .values({
+            organization_id: organization.id,
+            token_hash: 'invite-down-manager-token',
+            email: 'invitee@example.com',
+            role: 'manager',
+            expires_at: new Date('2026-08-18T00:00:00.000Z'),
+            created_by_user_id: user.id,
+          })
+          .execute()
+
+        await sql.raw(downSql).execute(trx)
+      })
+    ).rejects.toThrow(
+      'cannot rollback organization invite role expansion while non-member invites exist'
+    )
+  })
+})

--- a/apps/kaede/tests/services/db/multi-organization-auth-schema.test.ts
+++ b/apps/kaede/tests/services/db/multi-organization-auth-schema.test.ts
@@ -1,0 +1,565 @@
+import { sql } from 'kysely'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { createDb } from '../../../src/services/db/client.js'
+import { resetDatabase } from '../../db/helpers.js'
+
+const db = createDb()
+const passwordHash =
+  '$argon2id$v=19$m=65536,t=3,p=4$ZHVtbXk$zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'
+
+const createUser = async (suffix: string) =>
+  db
+    .insertInto('users')
+    .values({
+      email: `${suffix}@example.com`,
+      contact_email: 'shared-contact@example.com',
+      normalized_contact_email: 'shared-contact@example.com',
+      display_name: suffix,
+      password_hash: passwordHash,
+      global_role: 'none',
+      status: 'active',
+      password_changed_at: new Date('2026-08-11T00:00:00.000Z'),
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+const createOrganization = async (suffix: string) =>
+  db
+    .insertInto('organizations')
+    .values({ name: `Organization ${suffix}` })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+const createMembership = async (
+  organizationId: string,
+  userId: string,
+  role: 'member' | 'manager' | 'owner' = 'member'
+) => {
+  const membership = await db
+    .insertInto('organization_memberships')
+    .values({ organization_id: organizationId, user_id: userId, role })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+  if (!membership.id) {
+    throw new Error('new membership must receive an id from the expand-schema default')
+  }
+
+  return { ...membership, id: membership.id }
+}
+
+describe('multi-organization auth expand schema', () => {
+  beforeEach(async () => {
+    await resetDatabase(db)
+  })
+
+  afterAll(async () => {
+    await db.destroy()
+  })
+
+  it('既存Kaedeと同じinsert payloadを維持し、新規Membershipだけにdefaultを設定する', async () => {
+    const user = await db
+      .insertInto('users')
+      .values({
+        email: 'legacy@example.com',
+        display_name: 'Legacy User',
+        password_hash: passwordHash,
+        global_role: 'none',
+        status: 'active',
+        password_changed_at: new Date('2026-08-11T00:00:00.000Z'),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const organization = await db
+      .insertInto('organizations')
+      .values({ name: 'Legacy Organization' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const membership = await db
+      .insertInto('organization_memberships')
+      .values({ organization_id: organization.id, user_id: user.id, role: 'member' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    await expect(
+      db
+        .insertInto('sessions')
+        .values({
+          user_id: user.id,
+          session_hash: 'legacy-session',
+          expires_at: new Date('2026-08-12T00:00:00.000Z'),
+          auth_method: 'password',
+        })
+        .execute()
+    ).resolves.toBeDefined()
+
+    await expect(
+      db
+        .insertInto('organization_invites')
+        .values({
+          organization_id: organization.id,
+          token_hash: 'legacy-invite-token',
+          email: 'legacy-invitee@example.com',
+          role: 'member',
+          max_uses: 1,
+          used_count: 0,
+          expires_at: new Date('2026-08-18T00:00:00.000Z'),
+          created_by_user_id: user.id,
+        })
+        .execute()
+    ).resolves.toBeDefined()
+
+    expect(user.contact_email).toBeNull()
+    expect(organization.status).toBe('active')
+    expect(membership.id).not.toBeNull()
+    expect(membership.status).toBe('active')
+    expect(membership.joined_at).toBeInstanceOf(Date)
+    expect(membership.left_at).toBeNull()
+  })
+
+  it('contact email はUser間およびLocal login emailと重複できる', async () => {
+    const organization = await createOrganization('contact-email')
+    const firstUser = await createUser('contact-first')
+    const secondUser = await createUser('contact-second')
+    const membership = await createMembership(organization.id, firstUser.id)
+
+    await expect(
+      db
+        .insertInto('organization_local_credentials')
+        .values({
+          membership_id: membership.id,
+          organization_id: organization.id,
+          login_email: 'shared-contact@example.com',
+          normalized_login_email: 'shared-contact@example.com',
+          password_hash: passwordHash,
+        })
+        .execute()
+    ).resolves.toBeDefined()
+
+    expect(firstUser.contact_email).toBe(secondUser.contact_email)
+  })
+
+  it('Local CredentialはMembershipのOrganizationと一致し、有効emailはOrganization内で一意になる', async () => {
+    const firstOrganization = await createOrganization('local-first')
+    const secondOrganization = await createOrganization('local-second')
+    const firstUser = await createUser('local-first')
+    const secondUser = await createUser('local-second')
+    const firstMembership = await createMembership(firstOrganization.id, firstUser.id)
+    const secondMembership = await createMembership(firstOrganization.id, secondUser.id)
+
+    await expect(
+      db
+        .insertInto('organization_local_credentials')
+        .values({
+          membership_id: firstMembership.id,
+          organization_id: secondOrganization.id,
+          login_email: 'local@example.com',
+          normalized_login_email: 'local@example.com',
+          password_hash: passwordHash,
+        })
+        .execute()
+    ).rejects.toMatchObject({ code: '23503' })
+
+    await db
+      .insertInto('organization_local_credentials')
+      .values({
+        membership_id: firstMembership.id,
+        organization_id: firstOrganization.id,
+        login_email: 'local@example.com',
+        normalized_login_email: 'local@example.com',
+        password_hash: passwordHash,
+      })
+      .execute()
+
+    await expect(
+      db
+        .insertInto('organization_local_credentials')
+        .values({
+          membership_id: secondMembership.id,
+          organization_id: firstOrganization.id,
+          login_email: 'LOCAL@example.com',
+          normalized_login_email: 'local@example.com',
+          password_hash: passwordHash,
+        })
+        .execute()
+    ).rejects.toMatchObject({ code: '23505' })
+  })
+
+  it('OIDC LinkはMembership・IdentityのUserとProviderのOrganizationを一致させる', async () => {
+    const firstOrganization = await createOrganization('oidc-first')
+    const secondOrganization = await createOrganization('oidc-second')
+    const firstUser = await createUser('oidc-first')
+    const secondUser = await createUser('oidc-second')
+    const membership = await createMembership(firstOrganization.id, firstUser.id)
+    const firstIdentity = await db
+      .insertInto('oidc_identities')
+      .values({
+        user_id: firstUser.id,
+        issuer: 'https://accounts.google.com',
+        subject: 'subject-first-user',
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const secondIdentity = await db
+      .insertInto('oidc_identities')
+      .values({
+        user_id: secondUser.id,
+        issuer: 'https://accounts.google.com',
+        subject: 'subject-second-user',
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const firstProvider = await db
+      .insertInto('organization_oidc_providers')
+      .values({
+        organization_id: firstOrganization.id,
+        name: 'Google First',
+        issuer: 'https://accounts.google.com',
+        client_id: 'first-client-id',
+        scopes: ['openid'],
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const secondProvider = await db
+      .insertInto('organization_oidc_providers')
+      .values({
+        organization_id: secondOrganization.id,
+        name: 'Google Second',
+        issuer: 'https://accounts.google.com',
+        client_id: 'second-client-id',
+        scopes: ['openid'],
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    await expect(
+      db
+        .insertInto('organization_member_oidc_identities')
+        .values({
+          membership_id: membership.id,
+          organization_id: firstOrganization.id,
+          user_id: firstUser.id,
+          organization_oidc_provider_id: secondProvider.id,
+          oidc_identity_id: firstIdentity.id,
+        })
+        .execute()
+    ).rejects.toMatchObject({ code: '23503' })
+
+    await expect(
+      db
+        .insertInto('organization_member_oidc_identities')
+        .values({
+          membership_id: membership.id,
+          organization_id: firstOrganization.id,
+          user_id: firstUser.id,
+          organization_oidc_provider_id: firstProvider.id,
+          oidc_identity_id: secondIdentity.id,
+        })
+        .execute()
+    ).rejects.toMatchObject({ code: '23503' })
+
+    await expect(
+      db
+        .insertInto('organization_member_oidc_identities')
+        .values({
+          membership_id: membership.id,
+          organization_id: firstOrganization.id,
+          user_id: firstUser.id,
+          organization_oidc_provider_id: firstProvider.id,
+          oidc_identity_id: firstIdentity.id,
+        })
+        .execute()
+    ).resolves.toBeDefined()
+  })
+
+  it('Session GrantはSession・MembershipのUser一致と認証元の排他を保証する', async () => {
+    const organization = await createOrganization('grant')
+    const firstUser = await createUser('grant-first')
+    const secondUser = await createUser('grant-second')
+    const membership = await createMembership(organization.id, firstUser.id)
+    const credential = await db
+      .insertInto('organization_local_credentials')
+      .values({
+        membership_id: membership.id,
+        organization_id: organization.id,
+        login_email: 'grant@example.com',
+        normalized_login_email: 'grant@example.com',
+        password_hash: passwordHash,
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const secondUserSession = await db
+      .insertInto('sessions')
+      .values({
+        user_id: secondUser.id,
+        session_hash: 'second-user-session',
+        expires_at: new Date('2026-08-13T00:00:00.000Z'),
+        auth_method: 'password',
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    await expect(
+      db
+        .insertInto('session_membership_authentications')
+        .values({
+          session_id: secondUserSession.id,
+          membership_id: membership.id,
+          user_id: firstUser.id,
+          auth_method: 'local',
+          policy_version: 1,
+          local_credential_id: credential.id,
+          authenticated_at: new Date('2026-08-11T00:00:00.000Z'),
+          expires_at: new Date('2026-08-12T00:00:00.000Z'),
+        })
+        .execute()
+    ).rejects.toMatchObject({ code: '23503' })
+
+    const firstUserSession = await db
+      .insertInto('sessions')
+      .values({
+        user_id: firstUser.id,
+        session_hash: 'first-user-session',
+        expires_at: new Date('2026-08-13T00:00:00.000Z'),
+        auth_method: 'password',
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    await expect(
+      db
+        .insertInto('session_membership_authentications')
+        .values({
+          session_id: firstUserSession.id,
+          membership_id: membership.id,
+          user_id: firstUser.id,
+          auth_method: 'local',
+          policy_version: 1,
+          local_credential_id: null,
+          authenticated_at: new Date('2026-08-11T00:00:00.000Z'),
+          expires_at: new Date('2026-08-12T00:00:00.000Z'),
+        })
+        .execute()
+    ).rejects.toMatchObject({ code: '23514' })
+  })
+
+  it('Session Grantは別MembershipのLocal/OIDC認証元を参照できない', async () => {
+    const firstOrganization = await createOrganization('grant-source-first')
+    const secondOrganization = await createOrganization('grant-source-second')
+    const user = await createUser('grant-source')
+    const firstMembership = await createMembership(firstOrganization.id, user.id)
+    const secondMembership = await createMembership(secondOrganization.id, user.id)
+    const secondCredential = await db
+      .insertInto('organization_local_credentials')
+      .values({
+        membership_id: secondMembership.id,
+        organization_id: secondOrganization.id,
+        login_email: 'second-grant@example.com',
+        normalized_login_email: 'second-grant@example.com',
+        password_hash: passwordHash,
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const identity = await db
+      .insertInto('oidc_identities')
+      .values({
+        user_id: user.id,
+        issuer: 'https://accounts.google.com',
+        subject: 'grant-source-subject',
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const secondProvider = await db
+      .insertInto('organization_oidc_providers')
+      .values({
+        organization_id: secondOrganization.id,
+        name: 'Second Google',
+        issuer: 'https://accounts.google.com',
+        client_id: 'second-grant-client',
+        scopes: ['openid'],
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const secondOidcLink = await db
+      .insertInto('organization_member_oidc_identities')
+      .values({
+        membership_id: secondMembership.id,
+        organization_id: secondOrganization.id,
+        user_id: user.id,
+        organization_oidc_provider_id: secondProvider.id,
+        oidc_identity_id: identity.id,
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const session = await db
+      .insertInto('sessions')
+      .values({
+        user_id: user.id,
+        session_hash: 'grant-source-session',
+        expires_at: new Date('2026-08-13T00:00:00.000Z'),
+        auth_method: 'password',
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const grantBase = {
+      session_id: session.id,
+      membership_id: firstMembership.id,
+      user_id: user.id,
+      policy_version: 1,
+      authenticated_at: new Date('2026-08-11T00:00:00.000Z'),
+      expires_at: new Date('2026-08-12T00:00:00.000Z'),
+    }
+
+    await expect(
+      db
+        .insertInto('session_membership_authentications')
+        .values({
+          ...grantBase,
+          auth_method: 'local',
+          local_credential_id: secondCredential.id,
+        })
+        .execute()
+    ).rejects.toMatchObject({ code: '23503' })
+
+    await expect(
+      db
+        .insertInto('session_membership_authentications')
+        .values({
+          ...grantBase,
+          auth_method: 'oidc',
+          member_oidc_identity_id: secondOidcLink.id,
+        })
+        .execute()
+    ).rejects.toMatchObject({ code: '23503' })
+  })
+
+  it('Membership退出日時と認証Policyの期間をCHECKで保証する', async () => {
+    const organization = await createOrganization('checks')
+    const user = await createUser('checks')
+
+    await expect(
+      db
+        .insertInto('organization_memberships')
+        .values({
+          organization_id: organization.id,
+          user_id: user.id,
+          role: 'member',
+          status: 'left',
+          left_at: null,
+        })
+        .execute()
+    ).rejects.toMatchObject({ code: '23514' })
+
+    await expect(
+      db
+        .insertInto('organization_auth_settings')
+        .values({
+          organization_id: organization.id,
+          local_auth_enabled: true,
+          oidc_auth_enabled: false,
+          policy_version: 1,
+          membership_grant_ttl_seconds: 300,
+          reauthentication_interval_seconds: 301,
+        })
+        .execute()
+    ).rejects.toMatchObject({ code: '23514' })
+
+    await expect(
+      db
+        .insertInto('organization_auth_settings')
+        .values({
+          organization_id: organization.id,
+          local_auth_enabled: false,
+          oidc_auth_enabled: false,
+          policy_version: 1,
+          membership_grant_ttl_seconds: 300,
+          reauthentication_interval_seconds: 300,
+        })
+        .execute()
+    ).rejects.toMatchObject({ code: '23514' })
+  })
+
+  it('OIDC ProviderはNULLを含むscope配列をopenidありとして誤認しない', async () => {
+    const organization = await createOrganization('provider-scope')
+
+    await expect(
+      db
+        .insertInto('organization_oidc_providers')
+        .values({
+          organization_id: organization.id,
+          name: 'Invalid Scopes',
+          issuer: 'https://accounts.google.com',
+          client_id: 'invalid-scopes-client',
+          scopes: [],
+        })
+        .execute()
+    ).rejects.toMatchObject({ code: '23514' })
+
+    await expect(
+      sql`
+        INSERT INTO organization_oidc_providers (
+          organization_id,
+          name,
+          issuer,
+          client_id,
+          scopes
+        ) VALUES (
+          ${organization.id},
+          'Null Scope',
+          'https://accounts.google.com',
+          'null-scope-client',
+          ARRAY[NULL]::text[]
+        )
+      `.execute(db)
+    ).rejects.toMatchObject({ code: '23514' })
+
+    await expect(
+      db
+        .insertInto('organization_oidc_providers')
+        .values({
+          organization_id: organization.id,
+          name: 'Valid Scopes',
+          issuer: 'https://accounts.google.com',
+          client_id: 'valid-scopes-client',
+          scopes: ['email', 'openid'],
+        })
+        .execute()
+    ).resolves.toBeDefined()
+  })
+
+  it('PedestrianとInvite redemptionはMembershipのOrganization境界を越えられない', async () => {
+    const firstOrganization = await createOrganization('tenant-first')
+    const secondOrganization = await createOrganization('tenant-second')
+    const user = await createUser('tenant')
+    const membership = await createMembership(firstOrganization.id, user.id)
+
+    await expect(
+      db
+        .insertInto('pedestrians')
+        .values({
+          display_name: 'Tenant Pedestrian',
+          organization_id: secondOrganization.id,
+          membership_id: membership.id,
+        })
+        .execute()
+    ).rejects.toMatchObject({ code: '23503' })
+
+    await expect(
+      db
+        .insertInto('organization_invites')
+        .values({
+          organization_id: secondOrganization.id,
+          token_hash: 'redeemed-invite-token',
+          email: 'invitee@example.com',
+          role: 'member',
+          max_uses: 1,
+          used_count: 0,
+          expires_at: new Date('2026-08-18T00:00:00.000Z'),
+          created_by_user_id: user.id,
+          redeemed_at: new Date('2026-08-11T00:00:00.000Z'),
+          redeemed_membership_id: membership.id,
+        })
+        .execute()
+    ).rejects.toMatchObject({ code: '23503' })
+  })
+})

--- a/apps/kaede/tests/services/db/oidc-onboarding-schema.test.ts
+++ b/apps/kaede/tests/services/db/oidc-onboarding-schema.test.ts
@@ -122,7 +122,7 @@ describe('OIDC onboarding schema', () => {
     ).rejects.toThrow()
   })
 
-  it('organization invite は member role と usage bounds を制約する', async () => {
+  it('organization invite は member/manager role と usage bounds を制約する', async () => {
     const user = await createUser('invite-creator@example.com')
     const organization = await createOrganization()
 
@@ -134,6 +134,23 @@ describe('OIDC onboarding schema', () => {
           token_hash: 'invite-token-hash',
           email: 'invitee@example.com',
           role: 'manager',
+          max_uses: 1,
+          used_count: 0,
+          expires_at: new Date('2026-06-17T00:00:00.000Z'),
+          revoked_at: null,
+          created_by_user_id: user.id,
+        })
+        .execute()
+    ).resolves.toBeDefined()
+
+    await expect(
+      db
+        .insertInto('organization_invites')
+        .values({
+          organization_id: organization.id,
+          token_hash: 'owner-invite-token-hash',
+          email: 'owner@example.com',
+          role: 'owner',
           max_uses: 1,
           used_count: 0,
           expires_at: new Date('2026-06-17T00:00:00.000Z'),

--- a/apps/kaede/tests/services/memberships/membership-administration.test.ts
+++ b/apps/kaede/tests/services/memberships/membership-administration.test.ts
@@ -1,0 +1,207 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import type { RequestActor } from '../../../src/middleware/request-actor-context.js'
+import { createSession } from '../../../src/services/auth/index.js'
+import { createDb } from '../../../src/services/db/client.js'
+import { updateOrganizationMembership } from '../../../src/usecases/membership-administration/index.js'
+import { resetDatabase } from '../../db/helpers.js'
+
+const db = createDb()
+const now = new Date('2026-08-11T12:00:00.000Z')
+
+const actor = (userId: string, organizationId: string, role: 'member' | 'manager' | 'owner') =>
+  ({
+    type: 'user',
+    user_id: userId,
+    email: `${userId}@example.test`,
+    global_role: 'none',
+    account_state: 'active',
+    memberships: [{ organization_id: organizationId, organization_name: 'Test', role }],
+  }) satisfies RequestActor
+
+const createUser = (suffix: string) =>
+  db
+    .insertInto('users')
+    .values({
+      email: `${suffix}@example.test`,
+      display_name: suffix,
+      global_role: 'none',
+      status: 'active',
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+const createFixture = async (actorRole: 'manager' | 'owner' = 'manager') => {
+  const organization = await db
+    .insertInto('organizations')
+    .values({ name: 'Membership Administration' })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const actorUser = await createUser('membership-admin-actor')
+  const targetUser = await createUser('membership-admin-target')
+  const actorMembership = await db
+    .insertInto('organization_memberships')
+    .values({ organization_id: organization.id, user_id: actorUser.id, role: actorRole })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const targetMembership = await db
+    .insertInto('organization_memberships')
+    .values({ organization_id: organization.id, user_id: targetUser.id, role: 'member' })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const credential = await db
+    .insertInto('organization_local_credentials')
+    .values({
+      membership_id: targetMembership.id,
+      organization_id: organization.id,
+      login_email: 'membership-target@example.test',
+      normalized_login_email: 'membership-target@example.test',
+      password_hash: 'test-password-hash',
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const { session } = await createSession({ userId: targetUser.id, now }, db)
+  await db
+    .insertInto('session_membership_authentications')
+    .values({
+      session_id: session.id,
+      membership_id: targetMembership.id,
+      user_id: targetUser.id,
+      auth_method: 'local',
+      policy_version: 1,
+      local_credential_id: credential.id,
+      authenticated_at: now,
+      expires_at: new Date(now.getTime() + 3_600_000),
+    })
+    .execute()
+
+  return {
+    actor: actor(actorUser.id, organization.id, actorRole),
+    actorMembership,
+    credential,
+    organization,
+    targetMembership,
+    targetUser,
+  }
+}
+
+describe('membership administration', () => {
+  beforeEach(async () => resetDatabase(db))
+  afterAll(async () => db.destroy())
+
+  it('managerはmemberをsuspendでき、対象Grantだけをrevokeする', async () => {
+    const fixture = await createFixture()
+
+    const result = await updateOrganizationMembership(
+      fixture.actor,
+      fixture.organization.id,
+      fixture.targetMembership.id,
+      { status: 'suspended' },
+      now,
+      db
+    )
+
+    expect(result).toMatchObject({ ok: true, value: { status: 'suspended', left_at: null } })
+    await expect(
+      db
+        .selectFrom('session_membership_authentications')
+        .select('revoked_at')
+        .where('membership_id', '=', fixture.targetMembership.id)
+        .executeTakeFirstOrThrow()
+    ).resolves.toEqual({ revoked_at: now })
+    await expect(
+      db
+        .selectFrom('organization_local_credentials')
+        .select('enabled')
+        .where('id', '=', fixture.credential.id)
+        .executeTakeFirstOrThrow()
+    ).resolves.toEqual({ enabled: true })
+  })
+
+  it('managerはmemberをmanagerへ昇格できない', async () => {
+    const fixture = await createFixture()
+
+    const result = await updateOrganizationMembership(
+      fixture.actor,
+      fixture.organization.id,
+      fixture.targetMembership.id,
+      { role: 'manager' },
+      now,
+      db
+    )
+
+    expect(result).toEqual({ ok: false, error: { type: 'MEMBERSHIP_ROLE_FORBIDDEN' } })
+  })
+
+  it('ownerがmemberをleftにするとleft_atを設定し認証元も無効化する', async () => {
+    const fixture = await createFixture('owner')
+
+    const result = await updateOrganizationMembership(
+      fixture.actor,
+      fixture.organization.id,
+      fixture.targetMembership.id,
+      { status: 'left' },
+      now,
+      db
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: { status: 'left', left_at: now.toISOString() },
+    })
+    await expect(
+      db
+        .selectFrom('organization_local_credentials')
+        .select('enabled')
+        .where('id', '=', fixture.credential.id)
+        .executeTakeFirstOrThrow()
+    ).resolves.toEqual({ enabled: false })
+    const audit = await db
+      .selectFrom('audit_events')
+      .select(['actor_membership_id', 'target_id', 'changed_fields'])
+      .executeTakeFirstOrThrow()
+    expect(audit).toEqual({
+      actor_membership_id: fixture.actorMembership.id,
+      target_id: fixture.targetMembership.id,
+      changed_fields: ['status'],
+    })
+  })
+
+  it('最後のactive ownerはsuspendできない', async () => {
+    const fixture = await createFixture('owner')
+
+    const result = await updateOrganizationMembership(
+      fixture.actor,
+      fixture.organization.id,
+      fixture.actorMembership.id,
+      { status: 'suspended' },
+      now,
+      db
+    )
+
+    expect(result).toEqual({ ok: false, error: { type: 'MEMBERSHIP_LAST_OWNER' } })
+  })
+
+  it('別のactive ownerがいればownerをmanagerへ変更できる', async () => {
+    const fixture = await createFixture('owner')
+    const secondOwnerUser = await createUser('second-owner')
+    await db
+      .insertInto('organization_memberships')
+      .values({
+        organization_id: fixture.organization.id,
+        user_id: secondOwnerUser.id,
+        role: 'owner',
+      })
+      .execute()
+
+    const result = await updateOrganizationMembership(
+      fixture.actor,
+      fixture.organization.id,
+      fixture.actorMembership.id,
+      { role: 'manager' },
+      now,
+      db
+    )
+
+    expect(result).toMatchObject({ ok: true, value: { role: 'manager', status: 'active' } })
+  })
+})

--- a/apps/kaede/tests/services/organization-auth-methods/methods.test.ts
+++ b/apps/kaede/tests/services/organization-auth-methods/methods.test.ts
@@ -1,0 +1,100 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { createDb } from '../../../src/services/db/client.js'
+import { getPublicOrganizationAuthMethods } from '../../../src/usecases/organization-auth-methods/index.js'
+import { resetDatabase } from '../../db/helpers.js'
+
+const db = createDb()
+
+describe('organization auth methods discovery', () => {
+  beforeEach(async () => {
+    await resetDatabase(db)
+  })
+
+  afterAll(async () => {
+    await db.destroy()
+  })
+
+  it('有効な認証方式とenabled OIDC providerの公開情報だけを返す', async () => {
+    const organization = await db
+      .insertInto('organizations')
+      .values({ name: 'Discovery Organization', slug: 'discovery-organization' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    await db
+      .insertInto('organization_auth_settings')
+      .values({
+        organization_id: organization.id,
+        local_auth_enabled: true,
+        oidc_auth_enabled: true,
+        membership_grant_ttl_seconds: 28_800,
+        reauthentication_interval_seconds: 14_400,
+      })
+      .execute()
+    const [enabledProvider] = await db
+      .insertInto('organization_oidc_providers')
+      .values([
+        {
+          organization_id: organization.id,
+          name: 'Enabled Provider',
+          issuer: 'https://enabled.example.test',
+          client_id: 'enabled-client',
+          client_secret_ref: 'secret/enabled',
+          scopes: ['openid', 'email'],
+          enabled: true,
+        },
+        {
+          organization_id: organization.id,
+          name: 'Disabled Provider',
+          issuer: 'https://disabled.example.test',
+          client_id: 'disabled-client',
+          client_secret_ref: 'secret/disabled',
+          scopes: ['openid'],
+          enabled: false,
+        },
+      ])
+      .returningAll()
+      .execute()
+
+    await expect(getPublicOrganizationAuthMethods(organization.slug, db)).resolves.toStrictEqual({
+      local_auth_enabled: true,
+      allowed_auth_methods: ['local', 'oidc'],
+      oidc_providers: [{ id: enabledProvider.id, display_name: 'Enabled Provider' }],
+    })
+  })
+
+  it('存在しないslug・inactive組織・設定欠落を同じ最小レスポンスにする', async () => {
+    const [inactiveOrganization, missingSettingsOrganization] = await db
+      .insertInto('organizations')
+      .values([
+        { name: 'Inactive Organization', slug: 'inactive-organization', status: 'suspended' },
+        { name: 'Missing Settings Organization', slug: 'missing-settings-organization' },
+      ])
+      .returningAll()
+      .execute()
+    await db
+      .insertInto('organization_auth_settings')
+      .values({
+        organization_id: inactiveOrganization.id,
+        local_auth_enabled: true,
+        oidc_auth_enabled: false,
+        membership_grant_ttl_seconds: 28_800,
+        reauthentication_interval_seconds: 14_400,
+      })
+      .execute()
+
+    const unavailable = {
+      local_auth_enabled: false,
+      allowed_auth_methods: [],
+      oidc_providers: [],
+    }
+    await expect(getPublicOrganizationAuthMethods('unknown', db)).resolves.toStrictEqual(
+      unavailable
+    )
+    await expect(
+      getPublicOrganizationAuthMethods(inactiveOrganization.slug, db)
+    ).resolves.toStrictEqual(unavailable)
+    await expect(
+      getPublicOrganizationAuthMethods(missingSettingsOrganization.slug, db)
+    ).resolves.toStrictEqual(unavailable)
+  })
+})

--- a/apps/kaede/tests/services/organization-auth-settings/organization-auth-settings.test.ts
+++ b/apps/kaede/tests/services/organization-auth-settings/organization-auth-settings.test.ts
@@ -1,0 +1,172 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import type { RequestActor } from '../../../src/middleware/request-actor-context.js'
+import { createDb } from '../../../src/services/db/client.js'
+import { patchOrganizationAuthSettings } from '../../../src/usecases/organization-auth-settings/index.js'
+import { resetDatabase } from '../../db/helpers.js'
+
+const db = createDb()
+const passwordHash =
+  '$argon2id$v=19$m=65536,t=3,p=4$ZHVtbXk$zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'
+
+const createFixture = async () => {
+  const owner = await db
+    .insertInto('users')
+    .values({
+      email: 'auth-settings-owner@example.com',
+      display_name: 'Auth Settings Owner',
+      password_hash: null,
+      global_role: 'none',
+      status: 'active',
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const organization = await db
+    .insertInto('organizations')
+    .values({ name: 'Auth Settings Organization', slug: 'auth-settings-org' })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const membership = await db
+    .insertInto('organization_memberships')
+    .values({
+      organization_id: organization.id,
+      user_id: owner.id,
+      role: 'owner',
+      status: 'active',
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  if (!membership.id) throw new Error('membership id is required')
+  await db
+    .insertInto('organization_auth_settings')
+    .values({
+      organization_id: organization.id,
+      local_auth_enabled: true,
+      oidc_auth_enabled: false,
+      membership_grant_ttl_seconds: 28_800,
+      reauthentication_interval_seconds: 14_400,
+    })
+    .execute()
+  const credential = await db
+    .insertInto('organization_local_credentials')
+    .values({
+      membership_id: membership.id,
+      organization_id: organization.id,
+      login_email: owner.email,
+      normalized_login_email: owner.email,
+      password_hash: passwordHash,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  const session = await db
+    .insertInto('sessions')
+    .values({
+      user_id: owner.id,
+      session_hash: 'auth-settings-session-hash',
+      expires_at: new Date('2026-08-13T00:00:00.000Z'),
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  await db
+    .insertInto('session_membership_authentications')
+    .values({
+      session_id: session.id,
+      membership_id: membership.id,
+      user_id: owner.id,
+      auth_method: 'local',
+      policy_version: 1,
+      local_credential_id: credential.id,
+      member_oidc_identity_id: null,
+      authenticated_at: new Date('2026-08-11T00:00:00.000Z'),
+      expires_at: new Date('2026-08-12T00:00:00.000Z'),
+    })
+    .execute()
+
+  const actor: RequestActor = {
+    type: 'user',
+    user_id: owner.id,
+    email: owner.email,
+    global_role: 'none',
+    account_state: 'active',
+    memberships: [
+      {
+        organization_id: organization.id,
+        organization_name: organization.name,
+        role: 'owner',
+      },
+    ],
+  }
+  return { actor, membership, organization, session }
+}
+
+describe('organization auth settings with database', () => {
+  beforeEach(async () => resetDatabase(db))
+  afterAll(async () => db.destroy())
+
+  it('PolicyとversionとAuditを同時に更新し、既存Grantは一括更新しない', async () => {
+    const fixture = await createFixture()
+
+    const result = await patchOrganizationAuthSettings(
+      fixture.actor,
+      fixture.organization.id,
+      { membership_grant_ttl_seconds: 36_000, reauthentication_interval_seconds: 18_000 },
+      db
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        policy_version: 2,
+        membership_grant_ttl_seconds: 36_000,
+        reauthentication_interval_seconds: 18_000,
+      },
+    })
+    const stored = await db
+      .selectFrom('organization_auth_settings')
+      .selectAll()
+      .where('organization_id', '=', fixture.organization.id)
+      .executeTakeFirstOrThrow()
+    expect(stored.policy_version).toBe('2')
+
+    const grant = await db
+      .selectFrom('session_membership_authentications')
+      .select(['policy_version', 'revoked_at'])
+      .where('session_id', '=', fixture.session.id)
+      .executeTakeFirstOrThrow()
+    expect(grant).toMatchObject({ policy_version: '1', revoked_at: null })
+
+    const event = await db
+      .selectFrom('audit_events')
+      .selectAll()
+      .where('organization_id', '=', fixture.organization.id)
+      .where('target_type', '=', 'organization_auth_settings')
+      .executeTakeFirstOrThrow()
+    expect(event).toMatchObject({
+      actor_user_id: fixture.actor.user_id,
+      actor_membership_id: fixture.membership.id,
+      action: 'update',
+      changed_fields: ['membership_grant_ttl_seconds', 'reauthentication_interval_seconds'],
+    })
+  })
+
+  it('enabled Providerがない状態ではOIDC master switchを有効化しない', async () => {
+    const fixture = await createFixture()
+
+    await expect(
+      patchOrganizationAuthSettings(
+        fixture.actor,
+        fixture.organization.id,
+        { oidc_auth_enabled: true },
+        db
+      )
+    ).resolves.toEqual({ ok: false, error: { type: 'OIDC_PROVIDER_REQUIRED' } })
+
+    const stored = await db
+      .selectFrom('organization_auth_settings')
+      .select(['oidc_auth_enabled', 'policy_version'])
+      .where('organization_id', '=', fixture.organization.id)
+      .executeTakeFirstOrThrow()
+    expect(stored).toEqual({ oidc_auth_enabled: false, policy_version: '1' })
+    const events = await db.selectFrom('audit_events').select('id').execute()
+    expect(events).toHaveLength(0)
+  })
+})

--- a/apps/kaede/tests/services/organization-authorization/repository.test.ts
+++ b/apps/kaede/tests/services/organization-authorization/repository.test.ts
@@ -96,4 +96,49 @@ describe('organization authorization repository', () => {
     })
     expect(contexts[0]?.membership_id).not.toBe(leftMembership.id)
   })
+
+  it('Auth Settingsがないcurrent Membershipも落とさず明示contextで返す', async () => {
+    const user = await db
+      .insertInto('users')
+      .values({
+        email: 'missing-settings@example.com',
+        display_name: 'Missing Settings',
+        password_hash: passwordHash,
+        global_role: 'none',
+        status: 'active',
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const organization = await db
+      .insertInto('organizations')
+      .values({ name: 'Missing Settings Organization' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const membership = await db
+      .insertInto('organization_memberships')
+      .values({ organization_id: organization.id, user_id: user.id, role: 'member' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const session = await db
+      .insertInto('sessions')
+      .values({
+        user_id: user.id,
+        session_hash: 'missing-settings-session',
+        expires_at: new Date('2026-08-13T00:00:00.000Z'),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    await expect(
+      findMembershipGrantContext(session.id, user.id, organization.id, db)
+    ).resolves.toMatchObject({
+      organization_id: organization.id,
+      organization_name: organization.name,
+      organization_slug: organization.slug,
+      membership_id: membership.id,
+      auth_settings_available: false,
+      local_auth_enabled: null,
+      oidc_auth_enabled: null,
+    })
+  })
 })

--- a/apps/kaede/tests/services/organization-authorization/repository.test.ts
+++ b/apps/kaede/tests/services/organization-authorization/repository.test.ts
@@ -1,0 +1,99 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { createDb } from '../../../src/services/db/client.js'
+import {
+  findMembershipGrantContext,
+  listMembershipGrantContexts,
+} from '../../../src/services/organization-authorization/index.js'
+import { resetDatabase } from '../../db/helpers.js'
+
+const db = createDb()
+const passwordHash =
+  '$argon2id$v=19$m=65536,t=3,p=4$ZHVtbXk$zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'
+
+describe('organization authorization repository', () => {
+  beforeEach(async () => {
+    await resetDatabase(db)
+  })
+
+  afterAll(async () => {
+    await db.destroy()
+  })
+
+  it('left Membershipを除外し、再参加後のcurrent active Membershipだけを返す', async () => {
+    const user = await db
+      .insertInto('users')
+      .values({
+        email: 'grant-current@example.com',
+        display_name: 'Grant Current',
+        password_hash: passwordHash,
+        global_role: 'none',
+        status: 'active',
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const [leftOrganization, activeOrganization] = await db
+      .insertInto('organizations')
+      .values([{ name: 'Left Organization' }, { name: 'Active Organization' }])
+      .returningAll()
+      .execute()
+    const [leftMembership, activeMembership] = await db
+      .insertInto('organization_memberships')
+      .values([
+        {
+          organization_id: leftOrganization.id,
+          user_id: user.id,
+          role: 'member',
+          status: 'left',
+          left_at: new Date('2026-08-10T00:00:00.000Z'),
+        },
+        {
+          organization_id: activeOrganization.id,
+          user_id: user.id,
+          role: 'manager',
+          status: 'active',
+        },
+      ])
+      .returningAll()
+      .execute()
+    await db
+      .insertInto('organization_auth_settings')
+      .values([
+        {
+          organization_id: leftOrganization.id,
+          local_auth_enabled: true,
+          oidc_auth_enabled: false,
+          membership_grant_ttl_seconds: 7200,
+          reauthentication_interval_seconds: 3600,
+        },
+        {
+          organization_id: activeOrganization.id,
+          local_auth_enabled: true,
+          oidc_auth_enabled: false,
+          membership_grant_ttl_seconds: 7200,
+          reauthentication_interval_seconds: 3600,
+        },
+      ])
+      .execute()
+    const session = await db
+      .insertInto('sessions')
+      .values({
+        user_id: user.id,
+        session_hash: 'current-membership-session',
+        expires_at: new Date('2026-08-13T00:00:00.000Z'),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    await expect(
+      findMembershipGrantContext(session.id, user.id, leftOrganization.id, db)
+    ).resolves.toBeUndefined()
+    const contexts = await listMembershipGrantContexts(session.id, user.id, db)
+    expect(contexts).toHaveLength(1)
+    expect(contexts[0]).toMatchObject({
+      organization_id: activeOrganization.id,
+      membership_id: activeMembership.id,
+      membership_status: 'active',
+    })
+    expect(contexts[0]?.membership_id).not.toBe(leftMembership.id)
+  })
+})

--- a/apps/kaede/tests/services/organizations/organization-creation-requests.test.ts
+++ b/apps/kaede/tests/services/organizations/organization-creation-requests.test.ts
@@ -188,6 +188,25 @@ describe('organization creation request usecase', () => {
       .where('user_id', '=', requester.user.id)
       .executeTakeFirstOrThrow()
     expect(membership.role).toBe('owner')
+    await expect(
+      db
+        .selectFrom('organization_auth_settings')
+        .select([
+          'local_auth_enabled',
+          'oidc_auth_enabled',
+          'policy_version',
+          'membership_grant_ttl_seconds',
+          'reauthentication_interval_seconds',
+        ])
+        .where('organization_id', '=', organization.id)
+        .executeTakeFirstOrThrow()
+    ).resolves.toEqual({
+      local_auth_enabled: true,
+      oidc_auth_enabled: false,
+      policy_version: '1',
+      membership_grant_ttl_seconds: 28_800,
+      reauthentication_interval_seconds: 14_400,
+    })
   })
 
   it('approve rejects duplicate slug', async () => {

--- a/apps/kaede/tests/services/organizations/organizations.test.ts
+++ b/apps/kaede/tests/services/organizations/organizations.test.ts
@@ -1282,8 +1282,8 @@ describe('organizations usecase', () => {
         create_pedestrian: true,
         pedestrian: {
           display_name: 'Pedestrian A',
-          height: 170.5,
-          stride_length: 72,
+          height: 1.705,
+          stride_length: 0.72,
           attributes: {
             team: 'A',
           },
@@ -1301,8 +1301,8 @@ describe('organizations usecase', () => {
         pedestrian: {
           organization_id: organization.id,
           display_name: 'Pedestrian A',
-          height: 170.5,
-          stride_length: 72,
+          height: 1.705,
+          stride_length: 0.72,
           attributes: {
             team: 'A',
           },

--- a/apps/kaede/tests/services/organizations/organizations.test.ts
+++ b/apps/kaede/tests/services/organizations/organizations.test.ts
@@ -184,6 +184,25 @@ describe('organizations usecase', () => {
       .executeTakeFirstOrThrow()
 
     expect(organization.name).toBe('Group A')
+    await expect(
+      db
+        .selectFrom('organization_auth_settings')
+        .select([
+          'local_auth_enabled',
+          'oidc_auth_enabled',
+          'policy_version',
+          'membership_grant_ttl_seconds',
+          'reauthentication_interval_seconds',
+        ])
+        .where('organization_id', '=', organization.id)
+        .executeTakeFirstOrThrow()
+    ).resolves.toEqual({
+      local_auth_enabled: true,
+      oidc_auth_enabled: false,
+      policy_version: '1',
+      membership_grant_ttl_seconds: 28_800,
+      reauthentication_interval_seconds: 14_400,
+    })
   })
 
   it('admin can list organizations', async () => {

--- a/apps/kaede/tests/services/profiles/profiles.test.ts
+++ b/apps/kaede/tests/services/profiles/profiles.test.ts
@@ -1,4 +1,3 @@
-import { sql } from 'kysely'
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 import type { RequestActor } from '../../../src/middleware/request-actor-context.js'
 import { createDb } from '../../../src/services/db/client.js'
@@ -176,10 +175,6 @@ describe('profile usecases with database', () => {
     await db
       .transaction()
       .execute(async (trx) => {
-        await sql`ALTER TABLE organization_memberships DROP CONSTRAINT organization_memberships_pkey`.execute(
-          trx
-        )
-
         const leftMembership = await trx
           .insertInto('organization_memberships')
           .values({

--- a/apps/kaede/tests/services/profiles/profiles.test.ts
+++ b/apps/kaede/tests/services/profiles/profiles.test.ts
@@ -171,6 +171,15 @@ describe('profile usecases with database', () => {
       .values({ name: 'Rejoined Profile Organization' })
       .returningAll()
       .executeTakeFirstOrThrow()
+    await db
+      .insertInto('user_profiles')
+      .values({
+        user_id: user.id,
+        display_name: 'Rejoined Member',
+        locale: 'ja-JP',
+        timezone: 'Asia/Tokyo',
+      })
+      .execute()
 
     await db
       .transaction()

--- a/apps/kaede/tests/services/profiles/profiles.test.ts
+++ b/apps/kaede/tests/services/profiles/profiles.test.ts
@@ -1,0 +1,219 @@
+import { sql } from 'kysely'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import type { RequestActor } from '../../../src/middleware/request-actor-context.js'
+import { createDb } from '../../../src/services/db/client.js'
+import { findMemberProfileContextByUser } from '../../../src/services/profiles/index.js'
+import {
+  getMyOrganizationMemberProfile,
+  updateOrganizationMemberProfile,
+} from '../../../src/usecases/profiles/index.js'
+import { resetDatabase } from '../../db/helpers.js'
+
+const db = createDb()
+
+const createUser = async (email: string, displayName: string) =>
+  db
+    .insertInto('users')
+    .values({
+      email,
+      display_name: displayName,
+      password_hash: null,
+      global_role: 'none',
+      status: 'active',
+      password_changed_at: null,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+describe('profile usecases with database', () => {
+  beforeEach(async () => resetDatabase(db))
+  afterAll(async () => db.destroy())
+
+  it('override未設定時はUser Profileへfallbackする', async () => {
+    const user = await createUser('self-profile@example.com', 'Legacy')
+    const organization = await db
+      .insertInto('organizations')
+      .values({ name: 'Profile Organization' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const membership = await db
+      .insertInto('organization_memberships')
+      .values({ organization_id: organization.id, user_id: user.id, role: 'member' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    await db
+      .insertInto('user_profiles')
+      .values({
+        user_id: user.id,
+        display_name: 'Global Profile',
+        locale: 'ja-JP',
+        timezone: 'Asia/Tokyo',
+      })
+      .execute()
+
+    const actor: RequestActor = {
+      type: 'user',
+      user_id: user.id,
+      email: user.email,
+      global_role: 'none',
+      account_state: 'active',
+      memberships: [
+        { organization_id: organization.id, organization_name: organization.name, role: 'member' },
+      ],
+    }
+
+    const result = await getMyOrganizationMemberProfile(actor, organization.id)
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        membership_id: membership.id,
+        global: { display_name: 'Global Profile' },
+        override: { display_name: null, height_meters: null, stride_length_meters: null },
+        effective: { display_name: 'Global Profile', display_name_source: 'global' },
+      },
+    })
+  })
+
+  it('managerによるmember Profile変更とAudit Eventを同時に保存する', async () => {
+    const manager = await createUser('profile-manager@example.com', 'Manager')
+    const member = await createUser('profile-member@example.com', 'Member')
+    const organization = await db
+      .insertInto('organizations')
+      .values({ name: 'Managed Profile Organization' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const managerMembership = await db
+      .insertInto('organization_memberships')
+      .values({ organization_id: organization.id, user_id: manager.id, role: 'manager' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const memberMembership = await db
+      .insertInto('organization_memberships')
+      .values({ organization_id: organization.id, user_id: member.id, role: 'member' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    if (!managerMembership.id || !memberMembership.id) {
+      throw new Error('membership ids must be populated')
+    }
+    await db
+      .insertInto('user_profiles')
+      .values([
+        {
+          user_id: manager.id,
+          display_name: 'Manager',
+          locale: 'ja-JP',
+          timezone: 'Asia/Tokyo',
+        },
+        {
+          user_id: member.id,
+          display_name: 'Member',
+          locale: 'ja-JP',
+          timezone: 'Asia/Tokyo',
+        },
+      ])
+      .execute()
+
+    const actor: RequestActor = {
+      type: 'user',
+      user_id: manager.id,
+      email: manager.email,
+      global_role: 'none',
+      account_state: 'active',
+      memberships: [
+        {
+          organization_id: organization.id,
+          organization_name: organization.name,
+          role: 'manager',
+        },
+      ],
+    }
+
+    const result = await updateOrganizationMemberProfile(
+      actor,
+      organization.id,
+      memberMembership.id,
+      { display_name: 'Managed Member', height_meters: 1.705, stride_length_meters: 0.72 }
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        effective: {
+          display_name: 'Managed Member',
+          display_name_source: 'organization_override',
+        },
+        update_context: { kind: 'forced', actor_role: 'manager' },
+      },
+    })
+
+    const storedProfile = await db
+      .selectFrom('organization_member_profiles')
+      .selectAll()
+      .where('membership_id', '=', memberMembership.id)
+      .executeTakeFirstOrThrow()
+    expect(storedProfile.display_name).toBe('Managed Member')
+    expect(Number(storedProfile.height_meters)).toBe(1.705)
+    expect(Number(storedProfile.stride_length_meters)).toBe(0.72)
+
+    const audit = await db
+      .selectFrom('audit_events')
+      .selectAll()
+      .where('target_id', '=', memberMembership.id)
+      .executeTakeFirstOrThrow()
+    expect(audit.actor_membership_id).toBe(managerMembership.id)
+    expect(audit.changed_fields).toEqual(['display_name', 'height_meters', 'stride_length_meters'])
+  })
+
+  it('再参加でleftとactive Membershipが併存するときcurrent Membershipを選ぶ', async () => {
+    const user = await createUser('rejoined-profile@example.com', 'Rejoined Member')
+    const organization = await db
+      .insertInto('organizations')
+      .values({ name: 'Rejoined Profile Organization' })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    await db
+      .transaction()
+      .execute(async (trx) => {
+        await sql`ALTER TABLE organization_memberships DROP CONSTRAINT organization_memberships_pkey`.execute(
+          trx
+        )
+
+        const leftMembership = await trx
+          .insertInto('organization_memberships')
+          .values({
+            organization_id: organization.id,
+            user_id: user.id,
+            role: 'member',
+            status: 'left',
+            left_at: new Date('2026-08-10T00:00:00.000Z'),
+          })
+          .returningAll()
+          .executeTakeFirstOrThrow()
+        const activeMembership = await trx
+          .insertInto('organization_memberships')
+          .values({
+            organization_id: organization.id,
+            user_id: user.id,
+            role: 'member',
+            status: 'active',
+          })
+          .returningAll()
+          .executeTakeFirstOrThrow()
+
+        const selected = await findMemberProfileContextByUser(organization.id, user.id, trx)
+
+        expect(selected?.membership_id).toBe(activeMembership.id)
+        expect(selected?.membership_id).not.toBe(leftMembership.id)
+        expect(selected?.status).toBe('active')
+
+        throw new Error('rollback rejoined membership test')
+      })
+      .catch((error: unknown) => {
+        if (!(error instanceof Error) || error.message !== 'rollback rejoined membership test') {
+          throw error
+        }
+      })
+  })
+})

--- a/apps/nozomi/tests/test_kaede_contract.py
+++ b/apps/nozomi/tests/test_kaede_contract.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+from typing import Any, cast
+
+from src.schemas.analysis import AnalyzeRequest
+
+CONTRACT_PATH = (
+    Path(__file__).parents[3]
+    / "contracts"
+    / "kaede-nozomi"
+    / "trajectory-analysis.json"
+)
+
+
+def load_contract() -> dict[str, Any]:
+    return cast(dict[str, Any], json.loads(CONTRACT_PATH.read_text()))
+
+
+def test_kaede_analyze_request_matches_nozomi_schema() -> None:
+    contract = load_contract()
+    payload = contract["analyze_request"]
+
+    request = AnalyzeRequest.model_validate(payload)
+
+    assert request.model_dump(mode="json", exclude_none=True) == payload
+    assert set(payload).isdisjoint({"user_id", "membership_id", "session_id"})
+    assert request.result_object_key.startswith("organizations/")
+
+
+def test_nozomi_completed_callback_preserves_kaede_correlation_values() -> None:
+    contract = load_contract()
+    request = contract["analyze_request"]
+    callback = contract["completed_callback"]
+
+    assert callback == {
+        "trajectory_id": request["trajectory_id"],
+        "status": "completed",
+        "callback_token": request["callback_token"],
+        "result_object_key": request["result_object_key"],
+    }

--- a/contracts/kaede-nozomi/trajectory-analysis.json
+++ b/contracts/kaede-nozomi/trajectory-analysis.json
@@ -1,0 +1,35 @@
+{
+  "analyze_request": {
+    "trajectory_id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+    "recording_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+    "floor_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    "floor_scale": 0.01,
+    "constraints": [
+      {
+        "seq": 0,
+        "point_type": "start",
+        "x": 12.34,
+        "y": 56.78,
+        "direction": 90.0
+      }
+    ],
+    "raw_data_urls": {
+      "acce": "https://storage.example.test/raw/acce.csv?signature=acce",
+      "gyro": "https://storage.example.test/raw/gyro.csv?signature=gyro"
+    },
+    "result_upload_url": "https://storage.example.test/result.csv?signature=result",
+    "result_object_key": "organizations/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/trajectories/dddddddd-dddd-4ddd-8ddd-dddddddddddd/analyzed/result.csv",
+    "callback_url": "https://kaede.example.test/api/trajectories/callback",
+    "callback_token": "signed-callback-token"
+  },
+  "accepted_response": {
+    "trajectory_id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+    "status": "accepted"
+  },
+  "completed_callback": {
+    "trajectory_id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+    "status": "completed",
+    "callback_token": "signed-callback-token",
+    "result_object_key": "organizations/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/trajectories/dddddddd-dddd-4ddd-8ddd-dddddddddddd/analyzed/result.csv"
+  }
+}

--- a/db/migrations/20260811010000_add_multi_org_membership_columns.sql
+++ b/db/migrations/20260811010000_add_multi_org_membership_columns.sql
@@ -1,0 +1,60 @@
+-- migrate:up
+
+ALTER TABLE users
+  ADD COLUMN contact_email text,
+  ADD COLUMN normalized_contact_email text,
+  ADD COLUMN contact_email_verified_at timestamptz,
+  ADD CONSTRAINT users_contact_email_state_chk
+    CHECK (
+      contact_email IS NOT NULL
+      OR (
+        normalized_contact_email IS NULL
+        AND contact_email_verified_at IS NULL
+      )
+    ) NOT VALID;
+
+ALTER TABLE organizations
+  ADD COLUMN status text,
+  ADD CONSTRAINT organizations_status_chk
+    CHECK (status IN ('active', 'suspended')) NOT VALID;
+
+ALTER TABLE organizations
+  ALTER COLUMN status SET DEFAULT 'active';
+
+ALTER TABLE organization_memberships
+  ADD COLUMN id uuid,
+  ADD COLUMN status text,
+  ADD COLUMN joined_at timestamptz,
+  ADD COLUMN left_at timestamptz,
+  ADD CONSTRAINT organization_memberships_status_chk
+    CHECK (status IN ('active', 'suspended', 'left')) NOT VALID,
+  ADD CONSTRAINT organization_memberships_left_at_chk
+    CHECK (
+      (status = 'left' AND left_at IS NOT NULL)
+      OR (status <> 'left' AND left_at IS NULL)
+    ) NOT VALID;
+
+ALTER TABLE organization_memberships
+  ALTER COLUMN id SET DEFAULT gen_random_uuid(),
+  ALTER COLUMN status SET DEFAULT 'active',
+  ALTER COLUMN joined_at SET DEFAULT NOW();
+
+-- migrate:down
+
+ALTER TABLE organization_memberships
+  DROP CONSTRAINT IF EXISTS organization_memberships_left_at_chk,
+  DROP CONSTRAINT IF EXISTS organization_memberships_status_chk,
+  DROP COLUMN IF EXISTS left_at,
+  DROP COLUMN IF EXISTS joined_at,
+  DROP COLUMN IF EXISTS status,
+  DROP COLUMN IF EXISTS id;
+
+ALTER TABLE organizations
+  DROP CONSTRAINT IF EXISTS organizations_status_chk,
+  DROP COLUMN IF EXISTS status;
+
+ALTER TABLE users
+  DROP CONSTRAINT IF EXISTS users_contact_email_state_chk,
+  DROP COLUMN IF EXISTS contact_email_verified_at,
+  DROP COLUMN IF EXISTS normalized_contact_email,
+  DROP COLUMN IF EXISTS contact_email;

--- a/db/migrations/20260811010051_add_membership_id_index.sql
+++ b/db/migrations/20260811010051_add_membership_id_index.sql
@@ -1,0 +1,10 @@
+-- migrate:up transaction:false
+
+-- Keep this as a standalone unique index so the Backfill PR can promote it with
+-- ADD PRIMARY KEY USING INDEX without rebuilding it.
+CREATE UNIQUE INDEX CONCURRENTLY organization_memberships_id_key
+  ON organization_memberships (id);
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS organization_memberships_id_key;

--- a/db/migrations/20260811010052_add_membership_id_user_index.sql
+++ b/db/migrations/20260811010052_add_membership_id_user_index.sql
@@ -1,0 +1,8 @@
+-- migrate:up transaction:false
+
+CREATE UNIQUE INDEX CONCURRENTLY organization_memberships_id_user_key
+  ON organization_memberships (id, user_id);
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS organization_memberships_id_user_key;

--- a/db/migrations/20260811010053_add_membership_id_organization_index.sql
+++ b/db/migrations/20260811010053_add_membership_id_organization_index.sql
@@ -1,0 +1,8 @@
+-- migrate:up transaction:false
+
+CREATE UNIQUE INDEX CONCURRENTLY organization_memberships_id_organization_key
+  ON organization_memberships (id, organization_id);
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS organization_memberships_id_organization_key;

--- a/db/migrations/20260811010054_add_membership_user_status_index.sql
+++ b/db/migrations/20260811010054_add_membership_user_status_index.sql
@@ -1,0 +1,8 @@
+-- migrate:up transaction:false
+
+CREATE INDEX CONCURRENTLY organization_memberships_user_status_idx
+  ON organization_memberships (user_id, status);
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS organization_memberships_user_status_idx;

--- a/db/migrations/20260811010055_add_membership_org_status_role_index.sql
+++ b/db/migrations/20260811010055_add_membership_org_status_role_index.sql
@@ -1,0 +1,8 @@
+-- migrate:up transaction:false
+
+CREATE INDEX CONCURRENTLY organization_memberships_org_status_role_idx
+  ON organization_memberships (organization_id, status, role);
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS organization_memberships_org_status_role_idx;

--- a/db/migrations/20260811010056_add_session_id_user_index.sql
+++ b/db/migrations/20260811010056_add_session_id_user_index.sql
@@ -1,0 +1,8 @@
+-- migrate:up transaction:false
+
+CREATE UNIQUE INDEX CONCURRENTLY sessions_id_user_key
+  ON sessions (id, user_id);
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS sessions_id_user_key;

--- a/db/migrations/20260811010057_add_session_active_user_index.sql
+++ b/db/migrations/20260811010057_add_session_active_user_index.sql
@@ -1,0 +1,9 @@
+-- migrate:up transaction:false
+
+CREATE INDEX CONCURRENTLY sessions_active_user_idx
+  ON sessions (user_id)
+  WHERE revoked_at IS NULL;
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS sessions_active_user_idx;

--- a/db/migrations/20260811010058_add_session_active_expiry_index.sql
+++ b/db/migrations/20260811010058_add_session_active_expiry_index.sql
@@ -1,0 +1,9 @@
+-- migrate:up transaction:false
+
+CREATE INDEX CONCURRENTLY sessions_active_expires_at_idx
+  ON sessions (expires_at)
+  WHERE revoked_at IS NULL;
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS sessions_active_expires_at_idx;

--- a/db/migrations/20260811010100_create_profiles_and_auth_policy.sql
+++ b/db/migrations/20260811010100_create_profiles_and_auth_policy.sql
@@ -1,0 +1,88 @@
+-- migrate:up
+
+CREATE TABLE user_profiles (
+  user_id uuid PRIMARY KEY REFERENCES users(id) ON DELETE RESTRICT,
+  display_name text NOT NULL,
+  locale text NOT NULL DEFAULT 'ja-JP',
+  timezone text NOT NULL DEFAULT 'Asia/Tokyo',
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  CONSTRAINT user_profiles_display_name_chk
+    CHECK (length(btrim(display_name)) BETWEEN 1 AND 255),
+  CONSTRAINT user_profiles_locale_nonempty_chk
+    CHECK (length(btrim(locale)) > 0),
+  CONSTRAINT user_profiles_timezone_nonempty_chk
+    CHECK (length(btrim(timezone)) > 0)
+);
+
+CREATE TABLE organization_member_profiles (
+  membership_id uuid PRIMARY KEY
+    REFERENCES organization_memberships(id) ON DELETE RESTRICT,
+  display_name text,
+  height_meters numeric(5, 3),
+  stride_length_meters numeric(5, 3),
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  CONSTRAINT organization_member_profiles_display_name_chk
+    CHECK (
+      display_name IS NULL
+      OR length(btrim(display_name)) BETWEEN 1 AND 255
+    ),
+  CONSTRAINT organization_member_profiles_height_positive_chk
+    CHECK (height_meters IS NULL OR height_meters > 0),
+  CONSTRAINT organization_member_profiles_stride_positive_chk
+    CHECK (stride_length_meters IS NULL OR stride_length_meters > 0)
+);
+
+CREATE TABLE organization_auth_settings (
+  organization_id uuid PRIMARY KEY
+    REFERENCES organizations(id) ON DELETE RESTRICT,
+  local_auth_enabled boolean NOT NULL,
+  oidc_auth_enabled boolean NOT NULL,
+  policy_version bigint NOT NULL DEFAULT 1,
+  membership_grant_ttl_seconds integer NOT NULL,
+  reauthentication_interval_seconds integer NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  CONSTRAINT organization_auth_settings_policy_version_chk
+    CHECK (policy_version >= 1),
+  CONSTRAINT organization_auth_settings_grant_ttl_chk
+    CHECK (membership_grant_ttl_seconds > 0),
+  CONSTRAINT organization_auth_settings_reauth_interval_chk
+    CHECK (reauthentication_interval_seconds > 0),
+  CONSTRAINT organization_auth_settings_reauth_lte_ttl_chk
+    CHECK (
+      reauthentication_interval_seconds <= membership_grant_ttl_seconds
+    ),
+  CONSTRAINT organization_auth_settings_auth_method_chk
+    CHECK (
+      local_auth_enabled OR oidc_auth_enabled
+    )
+);
+
+CREATE TRIGGER set_updated_at_user_profiles
+BEFORE UPDATE ON user_profiles
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_updated_at_organization_member_profiles
+BEFORE UPDATE ON organization_member_profiles
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_updated_at_organization_auth_settings
+BEFORE UPDATE ON organization_auth_settings
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at();
+
+-- migrate:down
+
+DROP TRIGGER IF EXISTS set_updated_at_organization_auth_settings
+  ON organization_auth_settings;
+DROP TRIGGER IF EXISTS set_updated_at_organization_member_profiles
+  ON organization_member_profiles;
+DROP TRIGGER IF EXISTS set_updated_at_user_profiles ON user_profiles;
+
+DROP TABLE IF EXISTS organization_auth_settings;
+DROP TABLE IF EXISTS organization_member_profiles;
+DROP TABLE IF EXISTS user_profiles;

--- a/db/migrations/20260811010200_add_pedestrian_membership.sql
+++ b/db/migrations/20260811010200_add_pedestrian_membership.sql
@@ -1,0 +1,17 @@
+-- migrate:up
+
+ALTER TABLE pedestrians
+  ADD COLUMN membership_id uuid;
+
+ALTER TABLE pedestrians
+  ADD CONSTRAINT pedestrians_membership_organization_fkey
+  FOREIGN KEY (membership_id, organization_id)
+  REFERENCES organization_memberships(id, organization_id)
+  ON DELETE RESTRICT
+  NOT VALID;
+
+-- migrate:down
+
+ALTER TABLE pedestrians
+  DROP CONSTRAINT IF EXISTS pedestrians_membership_organization_fkey,
+  DROP COLUMN IF EXISTS membership_id;

--- a/db/migrations/20260811010250_add_pedestrian_membership_index.sql
+++ b/db/migrations/20260811010250_add_pedestrian_membership_index.sql
@@ -1,0 +1,9 @@
+-- migrate:up transaction:false
+
+CREATE UNIQUE INDEX CONCURRENTLY pedestrians_membership_id_key
+  ON pedestrians (membership_id)
+  WHERE membership_id IS NOT NULL;
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS pedestrians_membership_id_key;

--- a/db/migrations/20260811010300_create_membership_credentials_and_oidc_links.sql
+++ b/db/migrations/20260811010300_create_membership_credentials_and_oidc_links.sql
@@ -1,0 +1,171 @@
+-- migrate:up
+
+CREATE TABLE organization_oidc_providers (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE RESTRICT,
+  name text NOT NULL,
+  issuer text NOT NULL,
+  client_id text NOT NULL,
+  client_secret_ref text,
+  scopes text[] NOT NULL,
+  allowed_hosted_domains text[],
+  enabled boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  CONSTRAINT organization_oidc_providers_name_nonempty_chk
+    CHECK (length(btrim(name)) > 0),
+  CONSTRAINT organization_oidc_providers_issuer_nonempty_chk
+    CHECK (length(btrim(issuer)) > 0),
+  CONSTRAINT organization_oidc_providers_client_id_nonempty_chk
+    CHECK (length(btrim(client_id)) > 0),
+  CONSTRAINT organization_oidc_providers_openid_scope_chk
+    CHECK (COALESCE('openid' = ANY(scopes), false)),
+  CONSTRAINT organization_oidc_providers_hosted_domains_nonempty_chk
+    CHECK (
+      allowed_hosted_domains IS NULL
+      OR cardinality(allowed_hosted_domains) > 0
+    ),
+  CONSTRAINT organization_oidc_providers_org_issuer_client_key
+    UNIQUE (organization_id, issuer, client_id),
+  CONSTRAINT organization_oidc_providers_id_org_key
+    UNIQUE (id, organization_id)
+);
+
+CREATE TABLE organization_local_credentials (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  membership_id uuid NOT NULL,
+  organization_id uuid NOT NULL,
+  login_email text NOT NULL,
+  normalized_login_email text NOT NULL,
+  password_hash text NOT NULL,
+  password_changed_at timestamptz NOT NULL DEFAULT NOW(),
+  failed_login_attempts integer NOT NULL DEFAULT 0,
+  locked_until timestamptz,
+  enabled boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  CONSTRAINT organization_local_credentials_membership_key
+    UNIQUE (membership_id),
+  CONSTRAINT organization_local_credentials_id_membership_key
+    UNIQUE (id, membership_id),
+  CONSTRAINT organization_local_credentials_membership_org_fkey
+    FOREIGN KEY (membership_id, organization_id)
+    REFERENCES organization_memberships(id, organization_id)
+    ON DELETE RESTRICT,
+  CONSTRAINT organization_local_credentials_login_email_nonempty_chk
+    CHECK (length(btrim(login_email)) > 0),
+  CONSTRAINT organization_local_credentials_normalized_email_nonempty_chk
+    CHECK (length(btrim(normalized_login_email)) > 0),
+  CONSTRAINT organization_local_credentials_password_hash_nonempty_chk
+    CHECK (length(btrim(password_hash)) > 0),
+  CONSTRAINT organization_local_credentials_failed_attempts_chk
+    CHECK (failed_login_attempts >= 0)
+);
+
+CREATE UNIQUE INDEX organization_local_credentials_active_email_key
+  ON organization_local_credentials (
+    organization_id,
+    normalized_login_email
+  )
+  WHERE enabled;
+
+CREATE TABLE oidc_identities (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  issuer text NOT NULL,
+  subject text NOT NULL,
+  last_claimed_email text,
+  last_claimed_email_verified boolean,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  CONSTRAINT oidc_identities_issuer_nonempty_chk
+    CHECK (length(btrim(issuer)) > 0),
+  CONSTRAINT oidc_identities_subject_nonempty_chk
+    CHECK (length(btrim(subject)) > 0),
+  CONSTRAINT oidc_identities_issuer_subject_key
+    UNIQUE (issuer, subject),
+  CONSTRAINT oidc_identities_id_user_key
+    UNIQUE (id, user_id)
+);
+
+CREATE TABLE organization_member_oidc_identities (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  membership_id uuid NOT NULL,
+  organization_id uuid NOT NULL,
+  user_id uuid NOT NULL,
+  organization_oidc_provider_id uuid NOT NULL,
+  oidc_identity_id uuid NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  revoked_at timestamptz,
+  CONSTRAINT organization_member_oidc_membership_user_fkey
+    FOREIGN KEY (membership_id, user_id)
+    REFERENCES organization_memberships(id, user_id)
+    ON DELETE RESTRICT,
+  CONSTRAINT organization_member_oidc_identity_user_fkey
+    FOREIGN KEY (oidc_identity_id, user_id)
+    REFERENCES oidc_identities(id, user_id)
+    ON DELETE RESTRICT,
+  CONSTRAINT organization_member_oidc_membership_org_fkey
+    FOREIGN KEY (membership_id, organization_id)
+    REFERENCES organization_memberships(id, organization_id)
+    ON DELETE RESTRICT,
+  CONSTRAINT organization_member_oidc_provider_org_fkey
+    FOREIGN KEY (organization_oidc_provider_id, organization_id)
+    REFERENCES organization_oidc_providers(id, organization_id)
+    ON DELETE RESTRICT,
+  CONSTRAINT organization_member_oidc_id_membership_key
+    UNIQUE (id, membership_id),
+  CONSTRAINT organization_member_oidc_link_key
+    UNIQUE (
+      membership_id,
+      organization_oidc_provider_id,
+      oidc_identity_id
+    )
+);
+
+CREATE UNIQUE INDEX organization_member_oidc_active_provider_identity_key
+  ON organization_member_oidc_identities (
+    organization_oidc_provider_id,
+    oidc_identity_id
+  )
+  WHERE revoked_at IS NULL;
+
+CREATE INDEX organization_member_oidc_active_membership_idx
+  ON organization_member_oidc_identities (membership_id)
+  WHERE revoked_at IS NULL;
+
+CREATE TRIGGER set_updated_at_organization_oidc_providers
+BEFORE UPDATE ON organization_oidc_providers
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_updated_at_organization_local_credentials
+BEFORE UPDATE ON organization_local_credentials
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_updated_at_oidc_identities
+BEFORE UPDATE ON oidc_identities
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_updated_at_organization_member_oidc_identities
+BEFORE UPDATE ON organization_member_oidc_identities
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at();
+
+-- migrate:down
+
+DROP TRIGGER IF EXISTS set_updated_at_organization_member_oidc_identities
+  ON organization_member_oidc_identities;
+DROP TRIGGER IF EXISTS set_updated_at_oidc_identities ON oidc_identities;
+DROP TRIGGER IF EXISTS set_updated_at_organization_local_credentials
+  ON organization_local_credentials;
+DROP TRIGGER IF EXISTS set_updated_at_organization_oidc_providers
+  ON organization_oidc_providers;
+
+DROP TABLE IF EXISTS organization_member_oidc_identities;
+DROP TABLE IF EXISTS oidc_identities;
+DROP TABLE IF EXISTS organization_local_credentials;
+DROP TABLE IF EXISTS organization_oidc_providers;

--- a/db/migrations/20260811010400_create_membership_session_grants.sql
+++ b/db/migrations/20260811010400_create_membership_session_grants.sql
@@ -1,0 +1,182 @@
+-- migrate:up
+
+CREATE TABLE session_membership_authentications (
+  session_id uuid NOT NULL,
+  membership_id uuid NOT NULL,
+  user_id uuid NOT NULL,
+  auth_method text NOT NULL,
+  policy_version bigint NOT NULL,
+  local_credential_id uuid,
+  member_oidc_identity_id uuid,
+  authenticated_at timestamptz NOT NULL,
+  expires_at timestamptz NOT NULL,
+  revoked_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (session_id, membership_id),
+  CONSTRAINT session_membership_auth_session_user_fkey
+    FOREIGN KEY (session_id, user_id)
+    REFERENCES sessions(id, user_id)
+    ON DELETE RESTRICT,
+  CONSTRAINT session_membership_auth_membership_user_fkey
+    FOREIGN KEY (membership_id, user_id)
+    REFERENCES organization_memberships(id, user_id)
+    ON DELETE RESTRICT,
+  CONSTRAINT session_membership_auth_local_source_fkey
+    FOREIGN KEY (local_credential_id, membership_id)
+    REFERENCES organization_local_credentials(id, membership_id)
+    ON DELETE RESTRICT,
+  CONSTRAINT session_membership_auth_oidc_source_fkey
+    FOREIGN KEY (member_oidc_identity_id, membership_id)
+    REFERENCES organization_member_oidc_identities(id, membership_id)
+    ON DELETE RESTRICT,
+  CONSTRAINT session_membership_auth_policy_version_chk
+    CHECK (policy_version >= 1),
+  CONSTRAINT session_membership_auth_expiry_chk
+    CHECK (expires_at > authenticated_at),
+  CONSTRAINT session_membership_auth_source_chk
+    CHECK (
+      (
+        auth_method = 'local'
+        AND local_credential_id IS NOT NULL
+        AND member_oidc_identity_id IS NULL
+      )
+      OR
+      (
+        auth_method = 'oidc'
+        AND local_credential_id IS NULL
+        AND member_oidc_identity_id IS NOT NULL
+      )
+    )
+);
+
+CREATE INDEX session_membership_auth_active_membership_idx
+  ON session_membership_authentications (membership_id)
+  WHERE revoked_at IS NULL;
+
+CREATE INDEX session_membership_auth_active_local_credential_idx
+  ON session_membership_authentications (local_credential_id)
+  WHERE revoked_at IS NULL;
+
+CREATE INDEX session_membership_auth_active_oidc_identity_idx
+  ON session_membership_authentications (member_oidc_identity_id)
+  WHERE revoked_at IS NULL;
+
+CREATE TABLE oidc_login_transactions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  state_hash text NOT NULL UNIQUE,
+  organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE RESTRICT,
+  organization_oidc_provider_id uuid NOT NULL,
+  session_id uuid REFERENCES sessions(id) ON DELETE RESTRICT,
+  invite_id uuid REFERENCES organization_invites(id) ON DELETE RESTRICT,
+  intent text NOT NULL,
+  nonce text NOT NULL,
+  pkce_code_verifier_ciphertext text NOT NULL,
+  return_to text NOT NULL,
+  expires_at timestamptz NOT NULL,
+  consumed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  CONSTRAINT oidc_login_transactions_provider_org_fkey
+    FOREIGN KEY (organization_oidc_provider_id, organization_id)
+    REFERENCES organization_oidc_providers(id, organization_id)
+    ON DELETE RESTRICT,
+  CONSTRAINT oidc_login_transactions_state_hash_nonempty_chk
+    CHECK (length(btrim(state_hash)) > 0),
+  CONSTRAINT oidc_login_transactions_nonce_nonempty_chk
+    CHECK (length(btrim(nonce)) > 0),
+  CONSTRAINT oidc_login_transactions_pkce_nonempty_chk
+    CHECK (length(btrim(pkce_code_verifier_ciphertext)) > 0),
+  CONSTRAINT oidc_login_transactions_return_to_chk
+    CHECK (
+      left(return_to, 1) = '/'
+      AND left(return_to, 2) <> '//'
+      AND position(E'\\' IN return_to) = 0
+    ),
+  CONSTRAINT oidc_login_transactions_intent_chk
+    CHECK (intent IN ('login', 'reauthenticate', 'accept_invite', 'link_identity')),
+  CONSTRAINT oidc_login_transactions_intent_state_chk
+    CHECK (
+      (intent = 'login' AND session_id IS NULL AND invite_id IS NULL)
+      OR (intent = 'reauthenticate' AND session_id IS NOT NULL AND invite_id IS NULL)
+      OR (intent = 'accept_invite' AND invite_id IS NOT NULL)
+      OR (intent = 'link_identity' AND session_id IS NOT NULL AND invite_id IS NULL)
+    )
+);
+
+CREATE INDEX oidc_login_transactions_expires_at_idx
+  ON oidc_login_transactions (expires_at);
+
+CREATE TABLE authentication_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  occurred_at timestamptz NOT NULL DEFAULT NOW(),
+  event_type text NOT NULL,
+  outcome text NOT NULL,
+  failure_code text,
+  user_id uuid,
+  organization_id uuid,
+  membership_id uuid,
+  session_id uuid,
+  auth_method text,
+  credential_reference_id uuid,
+  request_id text,
+  ip_address_hash text,
+  user_agent text,
+  CONSTRAINT authentication_events_event_type_nonempty_chk
+    CHECK (length(btrim(event_type)) > 0),
+  CONSTRAINT authentication_events_outcome_chk
+    CHECK (outcome IN ('success', 'failure')),
+  CONSTRAINT authentication_events_auth_method_chk
+    CHECK (auth_method IS NULL OR auth_method IN ('local', 'oidc'))
+);
+
+CREATE INDEX authentication_events_org_occurred_at_idx
+  ON authentication_events (organization_id, occurred_at DESC);
+
+CREATE INDEX authentication_events_user_occurred_at_idx
+  ON authentication_events (user_id, occurred_at DESC);
+
+CREATE INDEX authentication_events_occurred_at_idx
+  ON authentication_events (occurred_at);
+
+CREATE TABLE audit_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  occurred_at timestamptz NOT NULL DEFAULT NOW(),
+  actor_user_id uuid,
+  actor_membership_id uuid,
+  organization_id uuid,
+  target_type text NOT NULL,
+  target_id uuid NOT NULL,
+  action text NOT NULL,
+  changed_fields text[] NOT NULL,
+  before_values jsonb,
+  after_values jsonb,
+  request_id text,
+  CONSTRAINT audit_events_target_type_nonempty_chk
+    CHECK (length(btrim(target_type)) > 0),
+  CONSTRAINT audit_events_action_nonempty_chk
+    CHECK (length(btrim(action)) > 0)
+);
+
+CREATE INDEX audit_events_org_occurred_at_idx
+  ON audit_events (organization_id, occurred_at DESC);
+
+CREATE INDEX audit_events_target_occurred_at_idx
+  ON audit_events (target_type, target_id, occurred_at DESC);
+
+CREATE INDEX audit_events_occurred_at_idx
+  ON audit_events (occurred_at);
+
+CREATE TRIGGER set_updated_at_session_membership_authentications
+BEFORE UPDATE ON session_membership_authentications
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at();
+
+-- migrate:down
+
+DROP TRIGGER IF EXISTS set_updated_at_session_membership_authentications
+  ON session_membership_authentications;
+
+DROP TABLE IF EXISTS audit_events;
+DROP TABLE IF EXISTS authentication_events;
+DROP TABLE IF EXISTS oidc_login_transactions;
+DROP TABLE IF EXISTS session_membership_authentications;

--- a/db/migrations/20260811010500_expand_organization_invites.sql
+++ b/db/migrations/20260811010500_expand_organization_invites.sql
@@ -1,0 +1,57 @@
+-- migrate:up
+
+ALTER TABLE organization_invites
+  ADD COLUMN created_by_membership_id uuid,
+  ADD COLUMN redeemed_at timestamptz,
+  ADD COLUMN redeemed_membership_id uuid,
+  ADD CONSTRAINT organization_invites_creator_org_fkey
+    FOREIGN KEY (created_by_membership_id, organization_id)
+    REFERENCES organization_memberships(id, organization_id)
+    ON DELETE RESTRICT
+    NOT VALID,
+  ADD CONSTRAINT organization_invites_redeemed_membership_org_fkey
+    FOREIGN KEY (redeemed_membership_id, organization_id)
+    REFERENCES organization_memberships(id, organization_id)
+    ON DELETE RESTRICT
+    NOT VALID,
+  ADD CONSTRAINT organization_invites_redemption_state_chk
+    CHECK (
+      (redeemed_at IS NULL AND redeemed_membership_id IS NULL)
+      OR (redeemed_at IS NOT NULL AND redeemed_membership_id IS NOT NULL)
+    ) NOT VALID,
+  ADD CONSTRAINT organization_invites_revoked_redeemed_chk
+    CHECK (revoked_at IS NULL OR redeemed_at IS NULL) NOT VALID;
+
+ALTER TABLE organization_invites
+  DROP CONSTRAINT organization_invites_role_chk,
+  ADD CONSTRAINT organization_invites_role_chk
+    CHECK (role IN ('member', 'manager')) NOT VALID;
+
+-- migrate:down
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM organization_invites
+    WHERE role <> 'member'
+  ) THEN
+    RAISE EXCEPTION
+      'cannot rollback organization invite role expansion while non-member invites exist';
+  END IF;
+END
+$$;
+
+ALTER TABLE organization_invites
+  DROP CONSTRAINT organization_invites_role_chk,
+  ADD CONSTRAINT organization_invites_role_chk
+    CHECK (role = 'member');
+
+ALTER TABLE organization_invites
+  DROP CONSTRAINT IF EXISTS organization_invites_revoked_redeemed_chk,
+  DROP CONSTRAINT IF EXISTS organization_invites_redemption_state_chk,
+  DROP CONSTRAINT IF EXISTS organization_invites_redeemed_membership_org_fkey,
+  DROP CONSTRAINT IF EXISTS organization_invites_creator_org_fkey,
+  DROP COLUMN IF EXISTS redeemed_membership_id,
+  DROP COLUMN IF EXISTS redeemed_at,
+  DROP COLUMN IF EXISTS created_by_membership_id;

--- a/db/migrations/20260811010551_add_invite_redeemed_membership_index.sql
+++ b/db/migrations/20260811010551_add_invite_redeemed_membership_index.sql
@@ -1,0 +1,8 @@
+-- migrate:up transaction:false
+
+CREATE UNIQUE INDEX CONCURRENTLY organization_invites_redeemed_membership_key
+  ON organization_invites (redeemed_membership_id);
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS organization_invites_redeemed_membership_key;

--- a/db/migrations/20260811010552_add_invite_org_created_index.sql
+++ b/db/migrations/20260811010552_add_invite_org_created_index.sql
@@ -1,0 +1,8 @@
+-- migrate:up transaction:false
+
+CREATE INDEX CONCURRENTLY organization_invites_org_created_at_idx
+  ON organization_invites (organization_id, created_at DESC);
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS organization_invites_org_created_at_idx;

--- a/db/migrations/20260811010553_add_invite_active_expiry_index.sql
+++ b/db/migrations/20260811010553_add_invite_active_expiry_index.sql
@@ -1,0 +1,9 @@
+-- migrate:up transaction:false
+
+CREATE INDEX CONCURRENTLY organization_invites_active_expires_at_idx
+  ON organization_invites (expires_at)
+  WHERE revoked_at IS NULL AND redeemed_at IS NULL;
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS organization_invites_active_expires_at_idx;

--- a/db/migrations/20260812010000_enforce_meter_measurement_bounds.sql
+++ b/db/migrations/20260812010000_enforce_meter_measurement_bounds.sql
@@ -1,0 +1,23 @@
+-- migrate:up
+
+ALTER TABLE organization_member_profiles
+  ADD CONSTRAINT organization_member_profiles_height_meter_bounds_chk
+  CHECK (height_meters IS NULL OR height_meters <= 3) NOT VALID,
+  ADD CONSTRAINT organization_member_profiles_stride_meter_bounds_chk
+  CHECK (stride_length_meters IS NULL OR stride_length_meters <= 3) NOT VALID;
+
+ALTER TABLE pedestrians
+  ADD CONSTRAINT pedestrians_height_meter_bounds_chk
+  CHECK (height IS NULL OR (height > 0 AND height <= 3)) NOT VALID,
+  ADD CONSTRAINT pedestrians_stride_meter_bounds_chk
+  CHECK (stride_length IS NULL OR (stride_length > 0 AND stride_length <= 3)) NOT VALID;
+
+-- migrate:down
+
+ALTER TABLE pedestrians
+  DROP CONSTRAINT pedestrians_stride_meter_bounds_chk,
+  DROP CONSTRAINT pedestrians_height_meter_bounds_chk;
+
+ALTER TABLE organization_member_profiles
+  DROP CONSTRAINT organization_member_profiles_stride_meter_bounds_chk,
+  DROP CONSTRAINT organization_member_profiles_height_meter_bounds_chk;

--- a/db/migrations/20260812020000_add_current_membership_unique_index.sql
+++ b/db/migrations/20260812020000_add_current_membership_unique_index.sql
@@ -1,0 +1,9 @@
+-- migrate:up transaction:false
+
+CREATE UNIQUE INDEX CONCURRENTLY organization_memberships_current_user_org_key
+  ON organization_memberships (organization_id, user_id)
+  WHERE status IN ('active', 'suspended');
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS organization_memberships_current_user_org_key;

--- a/db/migrations/20260812020100_promote_membership_uuid_primary_key.sql
+++ b/db/migrations/20260812020100_promote_membership_uuid_primary_key.sql
@@ -1,0 +1,67 @@
+-- migrate:up
+
+SET LOCAL lock_timeout = '5s';
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM organization_memberships
+    WHERE id IS NULL OR status IS NULL OR joined_at IS NULL
+  ) THEN
+    RAISE EXCEPTION
+      'membership UUID primary key promotion requires the multi-organization auth backfill';
+  END IF;
+END
+$$;
+
+ALTER TABLE organization_memberships ALTER COLUMN id SET NOT NULL;
+ALTER TABLE organization_memberships ALTER COLUMN status SET NOT NULL;
+ALTER TABLE organization_memberships ALTER COLUMN joined_at SET NOT NULL;
+
+ALTER TABLE organization_memberships
+  DROP CONSTRAINT organization_memberships_pkey;
+
+ALTER TABLE organization_memberships
+  ADD CONSTRAINT organization_memberships_pkey
+  PRIMARY KEY USING INDEX organization_memberships_id_key;
+
+-- migrate:down
+
+SET LOCAL lock_timeout = '5s';
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM organization_memberships
+    GROUP BY organization_id, user_id
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION
+      'cannot restore the legacy membership primary key after a user has rejoined an organization';
+  END IF;
+END
+$$;
+
+CREATE UNIQUE INDEX organization_memberships_id_key
+  ON organization_memberships (id);
+
+ALTER TABLE organization_member_profiles
+  DROP CONSTRAINT organization_member_profiles_membership_id_fkey;
+
+ALTER TABLE organization_memberships
+  DROP CONSTRAINT organization_memberships_pkey;
+
+ALTER TABLE organization_memberships
+  ADD CONSTRAINT organization_memberships_pkey
+  PRIMARY KEY (organization_id, user_id);
+
+ALTER TABLE organization_member_profiles
+  ADD CONSTRAINT organization_member_profiles_membership_id_fkey
+  FOREIGN KEY (membership_id)
+  REFERENCES organization_memberships(id) ON DELETE RESTRICT;
+
+ALTER TABLE organization_memberships ALTER COLUMN id DROP NOT NULL;
+ALTER TABLE organization_memberships ALTER COLUMN status DROP NOT NULL;
+ALTER TABLE organization_memberships ALTER COLUMN joined_at DROP NOT NULL;

--- a/db/migrations/20260812020100_promote_membership_uuid_primary_key.sql
+++ b/db/migrations/20260812020100_promote_membership_uuid_primary_key.sql
@@ -2,6 +2,20 @@
 
 SET LOCAL lock_timeout = '5s';
 
+-- dbmate applies all pending migrations in one run. Populate the fields needed
+-- by the primary-key change here so the schema can be promoted before the
+-- application-level one-shot cutover migrates profiles and credentials.
+UPDATE organizations
+SET status = 'active'
+WHERE status IS NULL;
+
+UPDATE organization_memberships
+SET
+  id = COALESCE(id, gen_random_uuid()),
+  status = COALESCE(status, 'active'),
+  joined_at = COALESCE(joined_at, created_at)
+WHERE id IS NULL OR status IS NULL OR joined_at IS NULL;
+
 DO $$
 BEGIN
   IF EXISTS (

--- a/db/migrations/20260812020200_create_application_data_migrations.sql
+++ b/db/migrations/20260812020200_create_application_data_migrations.sql
@@ -1,0 +1,13 @@
+-- migrate:up
+
+CREATE TABLE application_data_migrations (
+  name text PRIMARY KEY,
+  completed_at timestamptz NOT NULL DEFAULT NOW(),
+  details jsonb NOT NULL DEFAULT '{}'::jsonb,
+  CONSTRAINT application_data_migrations_name_nonempty_chk
+    CHECK (length(btrim(name)) > 0)
+);
+
+-- migrate:down
+
+DROP TABLE IF EXISTS application_data_migrations;

--- a/db/multi-organization-auth-backfill.md
+++ b/db/multi-organization-auth-backfill.md
@@ -1,0 +1,93 @@
+# Multi-Organization Auth Backfill Runbook
+
+この手順は、multi-organization authのExpand schema適用後に既存データを移行するためのものです。
+旧column/API/sessionはこの手順では削除・切替しません。
+
+## 安全原則
+
+- 本番と同等のsnapshotで事前リハーサルする。
+- `preflight` のblocking issueを手動で解消し、データを推測で修正しない。
+- backfillはbatch実行し、再実行可能であることを確認する。
+- Organizationの認証方式はglobal runtime設定から推測しない。各Organizationについて明示的に決定する。
+- 既存Sessionのrevoke、auth cutover、旧column削除、Membership PK切替は後続PRで行う。
+
+## 測定値の正規化
+
+`pedestrians.height` と `pedestrians.stride_length` は次の規則でmeterへ統一する。
+
+| 既存値                      | 判定       | 保存値                             |
+| --------------------------- | ---------- | ---------------------------------- |
+| `NULL`                      | 未設定     | `NULL`                             |
+| `0 < value <= 3`            | 既にmeter  | 小数第3位へ丸める                  |
+| `3 < value <= 300`          | centimeter | `value / 100`後、小数第3位へ丸める |
+| 上記以外、または丸め後に`0` | 不正       | blocking issue。自動修正しない     |
+
+`preflight` は `already_m / converted_cm / invalid` の値数を返す。`backfill-core`も実際に書き込んだ
+`measurement_values_already_m / measurement_values_converted_cm`を返す。
+
+## 実行コマンド
+
+Kaede directoryで実行する。
+
+```sh
+pnpm multi-org-auth-backfill preflight
+pnpm multi-org-auth-backfill backfill-core --batch-size 500
+pnpm multi-org-auth-backfill verify
+```
+
+`backfill-core`の対象は次の通り。
+
+- Organization status
+- Membership UUID/status/joined_at（`joined_at`は旧Membershipの`created_at`を使用）
+- User contact emailと共通Profile
+- PedestrianとMembershipの関連
+- Organization member profile（表示名override、meterへ正規化した身長・歩幅）
+- Invite creator Membership
+
+## 認証設定とCredential移行
+
+先に各Organizationの`organization_auth_settings`を運用者が明示的に登録する。OIDCを有効にする場合は、
+そのOrganizationにcanonical issuer `https://accounts.google.com`を持つ有効なProviderを1件登録する。
+作成者のemail domainやglobal環境変数からpolicy/hosted domainを自動設定しない。
+
+設定後に再度preflightを実行する。
+
+```sh
+pnpm multi-org-auth-backfill preflight
+pnpm multi-org-auth-backfill backfill-auth --batch-size 500
+```
+
+`backfill-auth`は次を行う。
+
+- Local auth有効Organizationだけ、現在Membershipとlegacy passwordからLocal Credentialを作る。
+- login emailは`lower(btrim(email))`で正規化し、Organization内collisionがあれば全auth backfillを停止する。
+- legacy Google Identityをcanonical `issuer + subject`へ移す。emailはIdentity keyにしない。
+- OIDC auth有効かつGoogle Providerが一意に決まるOrganizationだけMembership Linkを作る。
+
+認証policy不足、Providerの不足/複数候補、Identity owner conflictがある場合は何も自動修正せず停止する。
+
+## Constraint validation
+
+core verifyが全て0になった後だけ実行する。
+
+```sh
+pnpm multi-org-auth-backfill validate
+```
+
+これはExpandで`NOT VALID`として追加した、今回のbackfillで安全に検証できるconstraintを`VALIDATE`し、
+Organization statusとMembership UUID/status/joined_atを`NOT NULL`へ昇格する。
+NOT NULL昇格では短い`lock_timeout`と一時的な`NOT VALID` CHECKの事前検証を利用し、長時間のlockと再scanを避ける。
+Membershipの旧`(organization_id, user_id)` PKと同じ意味になるcurrent Membership partial unique indexはこのPRでは追加しない。
+現行Repositoryが同制約をupsert conflict targetとして使っているため、UUID PKへの切替はRepository互換対応と同じPRで行う。
+
+## blocking issueの扱い
+
+- `LOCAL_LOGIN_EMAIL_COLLISION`: 対象のlogin emailを運用判断で変更してから再実行する。
+- `MISSING_ORGANIZATION_AUTH_POLICY`: OrganizationごとのLocal/OIDC policyを明示する。
+- `OIDC_PROVIDER_MAPPING_MISSING_OR_AMBIGUOUS`: Providerを一意に確定する。
+- `OIDC_IDENTITY_OWNER_CONFLICT`: account linkを自動統合せず、本人確認を伴う別手順で解消する。
+- `PEDESTRIAN_MEMBERSHIP_NOT_FOUND`: Membershipとの対応を確認する。
+- `PEDESTRIAN_MEASUREMENT_OUT_OF_RANGE`: 元データの単位・値を確認して修正する。
+- `INVITE_CREATOR_MEMBERSHIP_NOT_FOUND`: 発行者Membershipを確認する。
+- `LEGACY_MULTI_USE_INVITE`: 権限を持つmanager/ownerが新しいsingle-use Inviteを発行する。
+- `PENDING_ACTIVATION_USER`: cutover前にactivation状態を運用判断する。

--- a/db/multi-organization-auth-backfill.md
+++ b/db/multi-organization-auth-backfill.md
@@ -1,103 +1,102 @@
-# Multi-Organization Auth Backfill Runbook
+# Multi-Organization Auth One-shot Cutover Runbook
 
-この手順は、multi-organization authのExpand schema適用後に既存データを移行するためのものです。
-旧column/API/sessionはこの手順では削除・切替しません。
+この手順は、multi-organization authの旧データを1回のメンテナンス時間内で新形式へ全件移行するためのものです。
+新旧Applicationや新旧認証データを並行運用しません。Applicationを停止してからSchema追加、全件移行、検証、
+Membership主キー昇格、旧契約削除までを完了し、新Applicationだけを起動します。
 
-## 安全原則
+## 原則
 
-- 本番と同等のsnapshotで事前リハーサルする。
-- `preflight` のblocking issueを手動で解消し、データを推測で修正しない。
-- backfillはbatch実行し、再実行可能であることを確認する。
-- Organizationの認証方式はglobal runtime設定から推測しない。各Organizationについて明示的に決定する。
-- 既存Sessionのrevoke、auth cutover、旧column削除、Membership PK切替は後続PRで行う。
+- 本番相当snapshotで同じ手順を事前にrehearsalする。
+- 開始前に書込みとbackground workerをすべて停止する。
+- `preflight`のblocking issueを事前に解消し、値を推測して自動修正しない。
+- 移行中に旧Applicationを再起動しない。
+- 既存SessionからMembership Grantを推測せず、全Sessionをrevokeする。
+- 失敗時は新旧混在状態でサービスを再開せず、切替前backupへDatabase全体をrestoreする。
+- 成功後は新構造だけをsource of truthとし、旧Columnへのread/writeやdual-writeを行わない。
 
-## 測定値の正規化
+## 事前準備
 
-`pedestrians.height` と `pedestrians.stride_length` は現行APIと同じくmeterとして扱う。
-値の大きさからcentimeterと推測して自動変換しない。
+1. 本番snapshotで所要時間、WAL量、必要disk容量、restore時間を計測する。
+2. `pnpm multi-org-auth-backfill preflight`を実行する。
+3. 次のblocking issueをすべて解消する。
+   - `LOCAL_LOGIN_EMAIL_COLLISION`
+   - `MISSING_ORGANIZATION_AUTH_POLICY`
+   - `OIDC_PROVIDER_MAPPING_MISSING_OR_AMBIGUOUS`
+   - `OIDC_IDENTITY_OWNER_CONFLICT`
+   - `PEDESTRIAN_MEMBERSHIP_NOT_FOUND`
+   - `PEDESTRIAN_MEASUREMENT_OUT_OF_RANGE`
+   - `INVITE_CREATOR_MEMBERSHIP_NOT_FOUND`
+   - `LEGACY_MULTI_USE_INVITE`
+   - `PENDING_ACTIVATION_USER`
+4. Organizationごとの認証PolicyとOIDC Providerを明示的に決定する。email domainやglobal設定から推測しない。
+5. Database backupを取得し、restoreできることを確認する。
 
-| 既存値                      | 判定             | 保存値                         |
-| --------------------------- | ---------------- | ------------------------------ |
-| `NULL`                      | 未設定           | `NULL`                         |
-| `0 < value <= 3`            | meter            | 小数第3位へ丸める              |
-| `value > 3`                 | 単位不一致の疑い | blocking issue。自動変換しない |
-| 上記以外、または丸め後に`0` | 不正             | blocking issue。自動修正しない |
+`pedestrians.height`と`stride_length`はmeterとして扱います。`0 < value <= 3`以外はblocking issueとし、
+centimeterと推測して変換しません。
 
-`preflight` は `valid_meters / invalid` の値数を返す。`backfill-core`も実際に書き込んだ
-`measurement_values_copied_meters`を返す。
+## Cutover手順
 
-## 実行コマンド
-
-Kaede directoryで実行する。
+Kaede directoryで実行します。
 
 ```sh
+# 1. maintenance modeへ切り替え、Kaede/Mio/workerからの全書込みを停止
+
+# 2. 新Table・Columnを追加するmigrationを適用
+make db-up ENV=production
+
+# 3. OrganizationごとのAuth Settings / OIDC Providerを確定・登録
+
+# 4. 最終preflight
 pnpm multi-org-auth-backfill preflight
-pnpm multi-org-auth-backfill backfill-core --batch-size 500
-pnpm multi-org-auth-backfill verify
+
+# 5. 全データを1 transactionで移行・検証し、全Sessionをrevoke
+pnpm multi-org-auth-backfill cutover --batch-size 500
+
+# 6. Membership UUID primary key昇格と同時リリース対象のContract migrationを適用
+make db-up ENV=production
+
+# 7. 新Kaedeを起動し、smoke test後に新Mioを公開
 ```
 
-`backfill-core`の対象は次の通り。
+`cutover`は次を単一transactionで実行します。
 
-- Organization status
-- Membership UUID/status/joined_at（`joined_at`は旧Membershipの`created_at`を使用）
-- User contact emailと共通Profile
-- PedestrianとMembershipの関連
-- Organization member profile（表示名override、meterの身長・歩幅）
-- Invite creator Membership
+1. 全scopeのpreflightを再検証する。
+2. Organization、Membership、contact email、User Profile、Member Profile、Pedestrian、Invite creatorを全件移行する。
+3. Membership単位Local Credential、canonical OIDC Identity、Membership OIDC Linkを全件移行する。
+4. core migrationの未移行件数がすべて0であることを検証する。
+5. auth backfillを再実行し、追加行が0であることを検証する。
+6. FK/CHECK/NOT NULL制約をvalidateする。
+7. 既存Sessionをすべてrevokeする。
 
-## 認証設定とCredential移行
+途中で失敗した場合はtransaction全体がrollbackされます。原因を修正して最初から再実行します。
 
-先に各Organizationの`organization_auth_settings`を運用者が明示的に登録する。OIDCを有効にする場合は、
-そのOrganizationにcanonical issuer `https://accounts.google.com`を持つ有効なProviderを1件登録する。
-作成者のemail domainやglobal環境変数からpolicy/hosted domainを自動設定しない。
+## 移行内容
 
-設定後に再度preflightを実行する。
+- `users.email`を`users.contact_email`へ移す。contact emailはLocal login keyにしない。
+- `users.display_name`を`user_profiles.display_name`へ移す。
+- MembershipにUUID、status、joined_atを設定する。
+- Pedestrianを対応するMembershipへ関連付ける。
+- 身長・歩幅をmeterのままOrganization Member Profileへ移す。
+- Local auth有効Organizationでは、現在Membershipごとにlegacy password hashをLocal Credentialへ複製する。
+- Google Identityはcanonical issuer `https://accounts.google.com`と`subject`で移す。
+- OIDC auth有効Organizationでは、ProviderとMembership Identity Linkを作る。
+- 旧multi-use Inviteとpending activationは自動変換せず、事前に失効・解消して新Inviteを発行する。
 
-```sh
-pnpm multi-org-auth-backfill preflight
-pnpm multi-org-auth-backfill backfill-auth --batch-size 500
-```
+## 成功判定
 
-`backfill-auth`は次を行う。
+- `cutover`が`validated: true`を返す。
+- coreのpending件数がすべて0である。
+- authの2回目backfillが0件である。
+- 全旧Sessionがrevoke済みである。
+- Membership UUID primary key migrationが成功する。
+- 新しいLocal/OIDC login、Organization切替、Invite受領、Profile取得が成功する。
+- 旧endpointと旧ColumnへのApplication read/writeが存在しない。
 
-- Local auth有効Organizationだけ、現在Membershipとlegacy passwordからLocal Credentialを作る。
-- login emailは`lower(btrim(email))`で正規化し、Organization内collisionがあれば全auth backfillを停止する。
-- legacy Google Identityをcanonical `issuer + subject`へ移す。emailはIdentity keyにしない。
-- OIDC auth有効かつGoogle Providerが一意に決まるOrganizationだけMembership Linkを作る。
+## Rollback
 
-認証policy不足、Providerの不足/複数候補、Identity owner conflictがある場合は何も自動修正せず停止する。
+一括Cutover後に旧Applicationだけを再起動してはいけません。新Credentialの変更を旧`users.password_hash`へ
+逆同期しないため、Application rollbackだけでは認証データが一致しません。
 
-## Constraint validation
-
-core verifyが全て0になった後だけ実行する。
-
-```sh
-pnpm multi-org-auth-backfill validate
-```
-
-これはExpandで`NOT VALID`として追加した、今回のbackfillで安全に検証できるconstraintを`VALIDATE`し、
-Organization statusとMembership UUID/status/joined_atを`NOT NULL`へ昇格する。
-NOT NULL昇格では短い`lock_timeout`と一時的な`NOT VALID` CHECKの事前検証を利用し、長時間のlockと再scanを避ける。
-
-全件が検証済みになった後、Membership Lifecycle migrationを適用する。このmigrationはcurrent Membership用の
-partial unique indexを先に作成してから、旧`(organization_id, user_id)` primary keyをUUID `id` primary keyへ
-切り替える。これ以降、`left` Membershipは履歴として残し、再参加時は新しいMembership IDを作成できる。
-
-```sh
-make db-up ENV=local
-```
-
-UUID primary key切替migrationは未backfill行がある場合に停止する。再参加後は旧primary keyへ戻せないため、
-本番運用はroll-forwardを基本とする。
-
-## blocking issueの扱い
-
-- `LOCAL_LOGIN_EMAIL_COLLISION`: 対象のlogin emailを運用判断で変更してから再実行する。
-- `MISSING_ORGANIZATION_AUTH_POLICY`: OrganizationごとのLocal/OIDC policyを明示する。
-- `OIDC_PROVIDER_MAPPING_MISSING_OR_AMBIGUOUS`: Providerを一意に確定する。
-- `OIDC_IDENTITY_OWNER_CONFLICT`: account linkを自動統合せず、本人確認を伴う別手順で解消する。
-- `PEDESTRIAN_MEMBERSHIP_NOT_FOUND`: Membershipとの対応を確認する。
-- `PEDESTRIAN_MEASUREMENT_OUT_OF_RANGE`: 元データの単位・値を確認して修正する。
-- `INVITE_CREATOR_MEMBERSHIP_NOT_FOUND`: 発行者Membershipを確認する。
-- `LEGACY_MULTI_USE_INVITE`: 権限を持つmanager/ownerが新しいsingle-use Inviteを発行する。
-- `PENDING_ACTIVATION_USER`: cutover前にactivation状態を運用判断する。
+サービス再開前に失敗した場合はtransaction rollbackまたは切替前backup restoreを行います。サービス再開後に
+重大障害が見つかった場合も、旧形式へ部分的に戻さず、DatabaseとApplicationを同じ時点へ全体restoreするか、
+新形式のままroll-forwardします。

--- a/db/multi-organization-auth-backfill.md
+++ b/db/multi-organization-auth-backfill.md
@@ -13,17 +13,18 @@
 
 ## 測定値の正規化
 
-`pedestrians.height` と `pedestrians.stride_length` は次の規則でmeterへ統一する。
+`pedestrians.height` と `pedestrians.stride_length` は現行APIと同じくmeterとして扱う。
+値の大きさからcentimeterと推測して自動変換しない。
 
-| 既存値                      | 判定       | 保存値                             |
-| --------------------------- | ---------- | ---------------------------------- |
-| `NULL`                      | 未設定     | `NULL`                             |
-| `0 < value <= 3`            | 既にmeter  | 小数第3位へ丸める                  |
-| `3 < value <= 300`          | centimeter | `value / 100`後、小数第3位へ丸める |
-| 上記以外、または丸め後に`0` | 不正       | blocking issue。自動修正しない     |
+| 既存値                      | 判定             | 保存値                         |
+| --------------------------- | ---------------- | ------------------------------ |
+| `NULL`                      | 未設定           | `NULL`                         |
+| `0 < value <= 3`            | meter            | 小数第3位へ丸める              |
+| `value > 3`                 | 単位不一致の疑い | blocking issue。自動変換しない |
+| 上記以外、または丸め後に`0` | 不正             | blocking issue。自動修正しない |
 
-`preflight` は `already_m / converted_cm / invalid` の値数を返す。`backfill-core`も実際に書き込んだ
-`measurement_values_already_m / measurement_values_converted_cm`を返す。
+`preflight` は `valid_meters / invalid` の値数を返す。`backfill-core`も実際に書き込んだ
+`measurement_values_copied_meters`を返す。
 
 ## 実行コマンド
 
@@ -41,7 +42,7 @@ pnpm multi-org-auth-backfill verify
 - Membership UUID/status/joined_at（`joined_at`は旧Membershipの`created_at`を使用）
 - User contact emailと共通Profile
 - PedestrianとMembershipの関連
-- Organization member profile（表示名override、meterへ正規化した身長・歩幅）
+- Organization member profile（表示名override、meterの身長・歩幅）
 - Invite creator Membership
 
 ## 認証設定とCredential移行

--- a/db/multi-organization-auth-backfill.md
+++ b/db/multi-organization-auth-backfill.md
@@ -78,8 +78,17 @@ pnpm multi-org-auth-backfill validate
 これはExpandで`NOT VALID`として追加した、今回のbackfillで安全に検証できるconstraintを`VALIDATE`し、
 Organization statusとMembership UUID/status/joined_atを`NOT NULL`へ昇格する。
 NOT NULL昇格では短い`lock_timeout`と一時的な`NOT VALID` CHECKの事前検証を利用し、長時間のlockと再scanを避ける。
-Membershipの旧`(organization_id, user_id)` PKと同じ意味になるcurrent Membership partial unique indexはこのPRでは追加しない。
-現行Repositoryが同制約をupsert conflict targetとして使っているため、UUID PKへの切替はRepository互換対応と同じPRで行う。
+
+全件が検証済みになった後、Membership Lifecycle migrationを適用する。このmigrationはcurrent Membership用の
+partial unique indexを先に作成してから、旧`(organization_id, user_id)` primary keyをUUID `id` primary keyへ
+切り替える。これ以降、`left` Membershipは履歴として残し、再参加時は新しいMembership IDを作成できる。
+
+```sh
+make db-up ENV=local
+```
+
+UUID primary key切替migrationは未backfill行がある場合に停止する。再参加後は旧primary keyへ戻せないため、
+本番運用はroll-forwardを基本とする。
 
 ## blocking issueの扱い
 

--- a/db/multi-organization-auth-backfill.md
+++ b/db/multi-organization-auth-backfill.md
@@ -28,7 +28,8 @@ Membership主キー昇格、旧契約削除までを完了し、新Application�
    - `INVITE_CREATOR_MEMBERSHIP_NOT_FOUND`
    - `LEGACY_MULTI_USE_INVITE`
    - `PENDING_ACTIVATION_USER`
-4. Organizationごとの認証PolicyとOIDC Providerを明示的に決定する。email domainやglobal設定から推測しない。
+4. 既存Organizationの初期認証Policyは、Cutover時点の明示的な`PASSWORD_LOGIN_ENABLED` / `OIDC_ENABLED`
+   とGoogle Client IDから作成される。Organization固有設定がすでに存在する場合は上書きしない。
 5. Database backupを取得し、restoreできることを確認する。
 
 `pedestrians.height`と`stride_length`はmeterとして扱います。`0 < value <= 3`以外はblocking issueとし、
@@ -41,10 +42,9 @@ Kaede directoryで実行します。
 ```sh
 # 1. maintenance modeへ切り替え、Kaede/Mio/workerからの全書込みを停止
 
-# 2. 新Table・Columnを追加するmigrationを適用
+# 2. deploy scriptがKaede migration runnerをbuild
+# 3. 新Table・Columnを追加するmigrationを適用
 make db-up ENV=production
-
-# 3. OrganizationごとのAuth Settings / OIDC Providerを確定・登録
 
 # 4. 最終preflight
 pnpm multi-org-auth-backfill preflight
@@ -52,23 +52,23 @@ pnpm multi-org-auth-backfill preflight
 # 5. 全データを1 transactionで移行・検証し、全Sessionをrevoke
 pnpm multi-org-auth-backfill cutover --batch-size 500
 
-# 6. Membership UUID primary key昇格と同時リリース対象のContract migrationを適用
-make db-up ENV=production
-
-# 7. 新Kaedeを起動し、smoke test後に新Mioを公開
+# 6. 新Kaedeを起動し、smoke test後に新Mioを公開
 ```
 
 `cutover`は次を単一transactionで実行します。
 
-1. 全scopeのpreflightを再検証する。
-2. Organization、Membership、contact email、User Profile、Member Profile、Pedestrian、Invite creatorを全件移行する。
-3. Membership単位Local Credential、canonical OIDC Identity、Membership OIDC Linkを全件移行する。
-4. core migrationの未移行件数がすべて0であることを検証する。
-5. auth backfillを再実行し、追加行が0であることを検証する。
-6. FK/CHECK/NOT NULL制約をvalidateする。
-7. 既存Sessionをすべてrevokeする。
+1. advisory lockを取得し、完了markerがあれば安全にno-opで終了する。
+2. 未設定Organizationだけに既存環境の認証方式を初期Policyとして登録する。
+3. 全scopeのpreflightを再検証する。
+4. Organization、Membership、contact email、User Profile、Member Profile、Pedestrian、Invite creatorを全件移行する。
+5. Membership単位Local Credential、canonical OIDC Identity、Membership OIDC Linkを全件移行する。
+6. core migrationの未移行件数がすべて0であることを検証する。
+7. auth backfillを再実行し、追加行が0であることを検証する。
+8. FK/CHECK/NOT NULL制約をvalidateする。
+9. 既存Sessionをすべてrevokeし、完了markerを保存する。
 
-途中で失敗した場合はtransaction全体がrollbackされます。原因を修正して最初から再実行します。
+途中で失敗した場合はtransaction全体がrollbackされます。原因を修正して最初から再実行します。完了後の通常deployでは
+markerを検出してno-opになるため、既存Sessionを再度revokeしません。
 
 ## 移行内容
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -375,9 +375,9 @@ CREATE TABLE public.organization_memberships (
     role text NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    id uuid DEFAULT gen_random_uuid(),
-    status text DEFAULT 'active'::text,
-    joined_at timestamp with time zone DEFAULT now(),
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    status text DEFAULT 'active'::text NOT NULL,
+    joined_at timestamp with time zone DEFAULT now() NOT NULL,
     left_at timestamp with time zone,
     CONSTRAINT organization_memberships_role_chk CHECK ((role = ANY (ARRAY['member'::text, 'manager'::text, 'owner'::text])))
 );
@@ -868,7 +868,7 @@ ALTER TABLE public.organization_memberships
 --
 
 ALTER TABLE ONLY public.organization_memberships
-    ADD CONSTRAINT organization_memberships_pkey PRIMARY KEY (organization_id, user_id);
+    ADD CONSTRAINT organization_memberships_pkey PRIMARY KEY (id);
 
 
 --
@@ -1252,10 +1252,10 @@ CREATE UNIQUE INDEX organization_member_oidc_active_provider_identity_key ON pub
 
 
 --
--- Name: organization_memberships_id_key; Type: INDEX; Schema: public; Owner: -
+-- Name: organization_memberships_current_user_org_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX organization_memberships_id_key ON public.organization_memberships USING btree (id);
+CREATE UNIQUE INDEX organization_memberships_current_user_org_key ON public.organization_memberships USING btree (organization_id, user_id) WHERE (status = ANY (ARRAY['active'::text, 'suspended'::text]));
 
 
 --
@@ -2057,4 +2057,6 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20260811010551'),
     ('20260811010552'),
     ('20260811010553'),
-    ('20260812010000');
+    ('20260812010000'),
+    ('20260812020000'),
+    ('20260812020100');

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -832,11 +832,27 @@ ALTER TABLE ONLY public.organization_member_oidc_identities
 
 
 --
+-- Name: organization_member_profiles organization_member_profiles_height_meter_bounds_chk; Type: CHECK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE public.organization_member_profiles
+    ADD CONSTRAINT organization_member_profiles_height_meter_bounds_chk CHECK (((height_meters IS NULL) OR (height_meters <= (3)::numeric))) NOT VALID;
+
+
+--
 -- Name: organization_member_profiles organization_member_profiles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.organization_member_profiles
     ADD CONSTRAINT organization_member_profiles_pkey PRIMARY KEY (membership_id);
+
+
+--
+-- Name: organization_member_profiles organization_member_profiles_stride_meter_bounds_chk; Type: CHECK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE public.organization_member_profiles
+    ADD CONSTRAINT organization_member_profiles_stride_meter_bounds_chk CHECK (((stride_length_meters IS NULL) OR (stride_length_meters <= (3)::numeric))) NOT VALID;
 
 
 --
@@ -912,11 +928,27 @@ ALTER TABLE public.organizations
 
 
 --
+-- Name: pedestrians pedestrians_height_meter_bounds_chk; Type: CHECK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE public.pedestrians
+    ADD CONSTRAINT pedestrians_height_meter_bounds_chk CHECK (((height IS NULL) OR ((height > (0)::double precision) AND (height <= (3)::double precision)))) NOT VALID;
+
+
+--
 -- Name: pedestrians pedestrians_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.pedestrians
     ADD CONSTRAINT pedestrians_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: pedestrians pedestrians_stride_meter_bounds_chk; Type: CHECK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE public.pedestrians
+    ADD CONSTRAINT pedestrians_stride_meter_bounds_chk CHECK (((stride_length IS NULL) OR ((stride_length > (0)::double precision) AND (stride_length <= (3)::double precision)))) NOT VALID;
 
 
 --
@@ -2024,4 +2056,5 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20260811010500'),
     ('20260811010551'),
     ('20260811010552'),
-    ('20260811010553');
+    ('20260811010553'),
+    ('20260812010000');

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -75,6 +75,18 @@ CREATE TABLE public.analysis_runs (
 -- Name: audit_events; Type: TABLE; Schema: public; Owner: -
 --
 
+CREATE TABLE public.application_data_migrations (
+    name text NOT NULL,
+    completed_at timestamp with time zone DEFAULT now() NOT NULL,
+    details jsonb DEFAULT '{}'::jsonb NOT NULL,
+    CONSTRAINT application_data_migrations_name_nonempty_chk CHECK ((length(btrim(name)) > 0))
+);
+
+
+ALTER TABLE ONLY public.application_data_migrations
+    ADD CONSTRAINT application_data_migrations_pkey PRIMARY KEY (name);
+
+
 CREATE TABLE public.audit_events (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     occurred_at timestamp with time zone DEFAULT now() NOT NULL,

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,7 +1,7 @@
 \restrict dbmate
 
--- Dumped from database version 17.9
--- Dumped by pg_dump version 18.3
+-- Dumped from database version 17.10
+-- Dumped by pg_dump version 18.4
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -34,6 +34,18 @@ SET default_tablespace = '';
 SET default_table_access_method = heap;
 
 --
+-- Name: analysis_run_trajectories; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.analysis_run_trajectories (
+    analysis_run_id uuid NOT NULL,
+    trajectory_id uuid NOT NULL,
+    seq integer NOT NULL,
+    CONSTRAINT analysis_run_trajectories_seq_check CHECK ((seq >= 0))
+);
+
+
+--
 -- Name: analysis_runs; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -60,14 +72,24 @@ CREATE TABLE public.analysis_runs (
 
 
 --
--- Name: analysis_run_trajectories; Type: TABLE; Schema: public; Owner: -
+-- Name: audit_events; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.analysis_run_trajectories (
-    analysis_run_id uuid NOT NULL,
-    trajectory_id uuid NOT NULL,
-    seq integer NOT NULL,
-    CONSTRAINT analysis_run_trajectories_seq_check CHECK ((seq >= 0))
+CREATE TABLE public.audit_events (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    occurred_at timestamp with time zone DEFAULT now() NOT NULL,
+    actor_user_id uuid,
+    actor_membership_id uuid,
+    organization_id uuid,
+    target_type text NOT NULL,
+    target_id uuid NOT NULL,
+    action text NOT NULL,
+    changed_fields text[] NOT NULL,
+    before_values jsonb,
+    after_values jsonb,
+    request_id text,
+    CONSTRAINT audit_events_action_nonempty_chk CHECK ((length(btrim(action)) > 0)),
+    CONSTRAINT audit_events_target_type_nonempty_chk CHECK ((length(btrim(target_type)) > 0))
 );
 
 
@@ -86,6 +108,31 @@ CREATE TABLE public.auth_identities (
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
     CONSTRAINT auth_identities_provider_chk CHECK ((provider = 'google'::text))
+);
+
+
+--
+-- Name: authentication_events; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.authentication_events (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    occurred_at timestamp with time zone DEFAULT now() NOT NULL,
+    event_type text NOT NULL,
+    outcome text NOT NULL,
+    failure_code text,
+    user_id uuid,
+    organization_id uuid,
+    membership_id uuid,
+    session_id uuid,
+    auth_method text,
+    credential_reference_id uuid,
+    request_id text,
+    ip_address_hash text,
+    user_agent text,
+    CONSTRAINT authentication_events_auth_method_chk CHECK (((auth_method IS NULL) OR (auth_method = ANY (ARRAY['local'::text, 'oidc'::text])))),
+    CONSTRAINT authentication_events_event_type_nonempty_chk CHECK ((length(btrim(event_type)) > 0)),
+    CONSTRAINT authentication_events_outcome_chk CHECK ((outcome = ANY (ARRAY['success'::text, 'failure'::text])))
 );
 
 
@@ -120,9 +167,75 @@ CREATE TABLE public.floors (
     organization_id uuid NOT NULL,
     map_width_px integer,
     map_height_px integer,
+    CONSTRAINT floors_image_object_path_format_chk CHECK (((image_object_path ~ '^maps/[0-9a-fA-F-]+/[0-9a-fA-F-]+\.(svg|png)$'::text) OR (image_object_path ~ '^organizations/[0-9a-fA-F-]+/floors/[0-9a-fA-F-]+/map\.(svg|png)$'::text))),
     CONSTRAINT floors_map_dimensions_bounds_chk CHECK (((map_width_px IS NULL) OR ((map_width_px > 0) AND (map_height_px > 0) AND (map_width_px <= 20000) AND (map_height_px <= 20000) AND (((map_width_px)::bigint * (map_height_px)::bigint) <= 100000000)))),
-    CONSTRAINT floors_map_dimensions_presence_chk CHECK ((((map_width_px IS NULL) AND (map_height_px IS NULL)) OR ((map_width_px IS NOT NULL) AND (map_height_px IS NOT NULL)))),
-    CONSTRAINT floors_image_object_path_format_chk CHECK (((image_object_path ~ '^maps/[0-9a-fA-F-]+/[0-9a-fA-F-]+\.(svg|png)$'::text) OR (image_object_path ~ '^organizations/[0-9a-fA-F-]+/floors/[0-9a-fA-F-]+/map\.(svg|png)$'::text)))
+    CONSTRAINT floors_map_dimensions_presence_chk CHECK ((((map_width_px IS NULL) AND (map_height_px IS NULL)) OR ((map_width_px IS NOT NULL) AND (map_height_px IS NOT NULL))))
+);
+
+
+--
+-- Name: oidc_identities; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.oidc_identities (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    user_id uuid NOT NULL,
+    issuer text NOT NULL,
+    subject text NOT NULL,
+    last_claimed_email text,
+    last_claimed_email_verified boolean,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT oidc_identities_issuer_nonempty_chk CHECK ((length(btrim(issuer)) > 0)),
+    CONSTRAINT oidc_identities_subject_nonempty_chk CHECK ((length(btrim(subject)) > 0))
+);
+
+
+--
+-- Name: oidc_login_transactions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.oidc_login_transactions (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    state_hash text NOT NULL,
+    organization_id uuid NOT NULL,
+    organization_oidc_provider_id uuid NOT NULL,
+    session_id uuid,
+    invite_id uuid,
+    intent text NOT NULL,
+    nonce text NOT NULL,
+    pkce_code_verifier_ciphertext text NOT NULL,
+    return_to text NOT NULL,
+    expires_at timestamp with time zone NOT NULL,
+    consumed_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT oidc_login_transactions_intent_chk CHECK ((intent = ANY (ARRAY['login'::text, 'reauthenticate'::text, 'accept_invite'::text, 'link_identity'::text]))),
+    CONSTRAINT oidc_login_transactions_intent_state_chk CHECK ((((intent = 'login'::text) AND (session_id IS NULL) AND (invite_id IS NULL)) OR ((intent = 'reauthenticate'::text) AND (session_id IS NOT NULL) AND (invite_id IS NULL)) OR ((intent = 'accept_invite'::text) AND (invite_id IS NOT NULL)) OR ((intent = 'link_identity'::text) AND (session_id IS NOT NULL) AND (invite_id IS NULL)))),
+    CONSTRAINT oidc_login_transactions_nonce_nonempty_chk CHECK ((length(btrim(nonce)) > 0)),
+    CONSTRAINT oidc_login_transactions_pkce_nonempty_chk CHECK ((length(btrim(pkce_code_verifier_ciphertext)) > 0)),
+    CONSTRAINT oidc_login_transactions_return_to_chk CHECK ((("left"(return_to, 1) = '/'::text) AND ("left"(return_to, 2) <> '//'::text) AND (POSITION(('\'::text) IN (return_to)) = 0))),
+    CONSTRAINT oidc_login_transactions_state_hash_nonempty_chk CHECK ((length(btrim(state_hash)) > 0))
+);
+
+
+--
+-- Name: organization_auth_settings; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.organization_auth_settings (
+    organization_id uuid NOT NULL,
+    local_auth_enabled boolean NOT NULL,
+    oidc_auth_enabled boolean NOT NULL,
+    policy_version bigint DEFAULT 1 NOT NULL,
+    membership_grant_ttl_seconds integer NOT NULL,
+    reauthentication_interval_seconds integer NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT organization_auth_settings_auth_method_chk CHECK ((local_auth_enabled OR oidc_auth_enabled)),
+    CONSTRAINT organization_auth_settings_grant_ttl_chk CHECK ((membership_grant_ttl_seconds > 0)),
+    CONSTRAINT organization_auth_settings_policy_version_chk CHECK ((policy_version >= 1)),
+    CONSTRAINT organization_auth_settings_reauth_interval_chk CHECK ((reauthentication_interval_seconds > 0)),
+    CONSTRAINT organization_auth_settings_reauth_lte_ttl_chk CHECK ((reauthentication_interval_seconds <= membership_grant_ttl_seconds))
 );
 
 
@@ -183,12 +296,72 @@ CREATE TABLE public.organization_invites (
     created_by_user_id uuid NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_by_membership_id uuid,
+    redeemed_at timestamp with time zone,
+    redeemed_membership_id uuid,
     CONSTRAINT organization_invites_email_nonempty_chk CHECK ((length(btrim(email)) > 0)),
     CONSTRAINT organization_invites_max_uses_chk CHECK ((max_uses > 0)),
-    CONSTRAINT organization_invites_role_chk CHECK ((role = 'member'::text)),
     CONSTRAINT organization_invites_token_hash_nonempty_chk CHECK ((length(btrim(token_hash)) > 0)),
     CONSTRAINT organization_invites_usage_bounds_chk CHECK ((used_count <= max_uses)),
     CONSTRAINT organization_invites_used_count_chk CHECK ((used_count >= 0))
+);
+
+
+--
+-- Name: organization_local_credentials; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.organization_local_credentials (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    membership_id uuid NOT NULL,
+    organization_id uuid NOT NULL,
+    login_email text NOT NULL,
+    normalized_login_email text NOT NULL,
+    password_hash text NOT NULL,
+    password_changed_at timestamp with time zone DEFAULT now() NOT NULL,
+    failed_login_attempts integer DEFAULT 0 NOT NULL,
+    locked_until timestamp with time zone,
+    enabled boolean DEFAULT true NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT organization_local_credentials_failed_attempts_chk CHECK ((failed_login_attempts >= 0)),
+    CONSTRAINT organization_local_credentials_login_email_nonempty_chk CHECK ((length(btrim(login_email)) > 0)),
+    CONSTRAINT organization_local_credentials_normalized_email_nonempty_chk CHECK ((length(btrim(normalized_login_email)) > 0)),
+    CONSTRAINT organization_local_credentials_password_hash_nonempty_chk CHECK ((length(btrim(password_hash)) > 0))
+);
+
+
+--
+-- Name: organization_member_oidc_identities; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.organization_member_oidc_identities (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    membership_id uuid NOT NULL,
+    organization_id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    organization_oidc_provider_id uuid NOT NULL,
+    oidc_identity_id uuid NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    revoked_at timestamp with time zone
+);
+
+
+--
+-- Name: organization_member_profiles; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.organization_member_profiles (
+    membership_id uuid NOT NULL,
+    display_name text,
+    height_meters numeric(5,3),
+    stride_length_meters numeric(5,3),
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT organization_member_profiles_display_name_chk CHECK (((display_name IS NULL) OR ((length(btrim(display_name)) >= 1) AND (length(btrim(display_name)) <= 255)))),
+    CONSTRAINT organization_member_profiles_height_positive_chk CHECK (((height_meters IS NULL) OR (height_meters > (0)::numeric))),
+    CONSTRAINT organization_member_profiles_stride_positive_chk CHECK (((stride_length_meters IS NULL) OR (stride_length_meters > (0)::numeric)))
 );
 
 
@@ -202,7 +375,35 @@ CREATE TABLE public.organization_memberships (
     role text NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    id uuid DEFAULT gen_random_uuid(),
+    status text DEFAULT 'active'::text,
+    joined_at timestamp with time zone DEFAULT now(),
+    left_at timestamp with time zone,
     CONSTRAINT organization_memberships_role_chk CHECK ((role = ANY (ARRAY['member'::text, 'manager'::text, 'owner'::text])))
+);
+
+
+--
+-- Name: organization_oidc_providers; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.organization_oidc_providers (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    name text NOT NULL,
+    issuer text NOT NULL,
+    client_id text NOT NULL,
+    client_secret_ref text,
+    scopes text[] NOT NULL,
+    allowed_hosted_domains text[],
+    enabled boolean DEFAULT true NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT organization_oidc_providers_client_id_nonempty_chk CHECK ((length(btrim(client_id)) > 0)),
+    CONSTRAINT organization_oidc_providers_hosted_domains_nonempty_chk CHECK (((allowed_hosted_domains IS NULL) OR (cardinality(allowed_hosted_domains) > 0))),
+    CONSTRAINT organization_oidc_providers_issuer_nonempty_chk CHECK ((length(btrim(issuer)) > 0)),
+    CONSTRAINT organization_oidc_providers_name_nonempty_chk CHECK ((length(btrim(name)) > 0)),
+    CONSTRAINT organization_oidc_providers_openid_scope_chk CHECK (COALESCE(('openid'::text = ANY (scopes)), false))
 );
 
 
@@ -216,6 +417,7 @@ CREATE TABLE public.organizations (
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
     slug text DEFAULT ('org-'::text || replace((gen_random_uuid())::text, '-'::text, ''::text)) NOT NULL,
+    status text DEFAULT 'active'::text,
     CONSTRAINT organizations_name_nonempty_chk CHECK ((length(btrim(name)) > 0)),
     CONSTRAINT organizations_slug_format_chk CHECK (((slug ~ '^[a-z0-9]+(-[a-z0-9]+)*$'::text) AND ((length(slug) >= 3) AND (length(slug) <= 63)))),
     CONSTRAINT organizations_slug_reserved_chk CHECK ((slug <> ALL (ARRAY['admin'::text, 'api'::text, 'auth'::text, 'platform'::text, 'new'::text, 'settings'::text])))
@@ -236,6 +438,7 @@ CREATE TABLE public.pedestrians (
     display_name text NOT NULL,
     user_id uuid,
     organization_id uuid NOT NULL,
+    membership_id uuid,
     CONSTRAINT pedestrians_display_name_nonempty_chk CHECK ((length(btrim(display_name)) > 0))
 );
 
@@ -267,6 +470,29 @@ CREATE TABLE public.recordings (
 
 CREATE TABLE public.schema_migrations (
     version character varying NOT NULL
+);
+
+
+--
+-- Name: session_membership_authentications; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.session_membership_authentications (
+    session_id uuid NOT NULL,
+    membership_id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    auth_method text NOT NULL,
+    policy_version bigint NOT NULL,
+    local_credential_id uuid,
+    member_oidc_identity_id uuid,
+    authenticated_at timestamp with time zone NOT NULL,
+    expires_at timestamp with time zone NOT NULL,
+    revoked_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT session_membership_auth_expiry_chk CHECK ((expires_at > authenticated_at)),
+    CONSTRAINT session_membership_auth_policy_version_chk CHECK ((policy_version >= 1)),
+    CONSTRAINT session_membership_auth_source_chk CHECK ((((auth_method = 'local'::text) AND (local_credential_id IS NOT NULL) AND (member_oidc_identity_id IS NULL)) OR ((auth_method = 'oidc'::text) AND (local_credential_id IS NULL) AND (member_oidc_identity_id IS NOT NULL))))
 );
 
 
@@ -330,6 +556,23 @@ CREATE TABLE public.user_activation_tokens (
 
 
 --
+-- Name: user_profiles; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_profiles (
+    user_id uuid NOT NULL,
+    display_name text NOT NULL,
+    locale text DEFAULT 'ja-JP'::text NOT NULL,
+    timezone text DEFAULT 'Asia/Tokyo'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT user_profiles_display_name_chk CHECK (((length(btrim(display_name)) >= 1) AND (length(btrim(display_name)) <= 255))),
+    CONSTRAINT user_profiles_locale_nonempty_chk CHECK ((length(btrim(locale)) > 0)),
+    CONSTRAINT user_profiles_timezone_nonempty_chk CHECK ((length(btrim(timezone)) > 0))
+);
+
+
+--
 -- Name: users; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -345,6 +588,9 @@ CREATE TABLE public.users (
     failed_login_attempts integer DEFAULT 0 NOT NULL,
     locked_until timestamp with time zone,
     status text NOT NULL,
+    contact_email text,
+    normalized_contact_email text,
+    contact_email_verified_at timestamp with time zone,
     CONSTRAINT users_display_name_nonempty_chk CHECK ((length(btrim(display_name)) > 0)),
     CONSTRAINT users_email_nonempty_chk CHECK ((length(btrim(email)) > 0)),
     CONSTRAINT users_global_role_chk CHECK ((global_role = ANY (ARRAY['none'::text, 'admin'::text]))),
@@ -354,19 +600,35 @@ CREATE TABLE public.users (
 
 
 --
--- Name: auth_identities auth_identities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: analysis_run_trajectories analysis_run_trajectories_analysis_run_id_seq_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.analysis_run_trajectories
+    ADD CONSTRAINT analysis_run_trajectories_analysis_run_id_seq_key UNIQUE (analysis_run_id, seq);
+
+
+--
+-- Name: analysis_run_trajectories analysis_run_trajectories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.analysis_run_trajectories
+    ADD CONSTRAINT analysis_run_trajectories_pkey PRIMARY KEY (analysis_run_id, trajectory_id);
+
+
+--
+-- Name: analysis_runs analysis_runs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.analysis_runs
     ADD CONSTRAINT analysis_runs_pkey PRIMARY KEY (id);
 
 
-ALTER TABLE ONLY public.analysis_run_trajectories
-    ADD CONSTRAINT analysis_run_trajectories_pkey PRIMARY KEY (analysis_run_id, trajectory_id);
+--
+-- Name: audit_events audit_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
-
-ALTER TABLE ONLY public.analysis_run_trajectories
-    ADD CONSTRAINT analysis_run_trajectories_analysis_run_id_seq_key UNIQUE (analysis_run_id, seq);
+ALTER TABLE ONLY public.audit_events
+    ADD CONSTRAINT audit_events_pkey PRIMARY KEY (id);
 
 
 --
@@ -386,6 +648,14 @@ ALTER TABLE ONLY public.auth_identities
 
 
 --
+-- Name: authentication_events authentication_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.authentication_events
+    ADD CONSTRAINT authentication_events_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: buildings buildings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -399,6 +669,54 @@ ALTER TABLE ONLY public.buildings
 
 ALTER TABLE ONLY public.floors
     ADD CONSTRAINT floors_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: oidc_identities oidc_identities_id_user_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oidc_identities
+    ADD CONSTRAINT oidc_identities_id_user_key UNIQUE (id, user_id);
+
+
+--
+-- Name: oidc_identities oidc_identities_issuer_subject_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oidc_identities
+    ADD CONSTRAINT oidc_identities_issuer_subject_key UNIQUE (issuer, subject);
+
+
+--
+-- Name: oidc_identities oidc_identities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oidc_identities
+    ADD CONSTRAINT oidc_identities_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: oidc_login_transactions oidc_login_transactions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oidc_login_transactions
+    ADD CONSTRAINT oidc_login_transactions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: oidc_login_transactions oidc_login_transactions_state_hash_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oidc_login_transactions
+    ADD CONSTRAINT oidc_login_transactions_state_hash_key UNIQUE (state_hash);
+
+
+--
+-- Name: organization_auth_settings organization_auth_settings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_auth_settings
+    ADD CONSTRAINT organization_auth_settings_pkey PRIMARY KEY (organization_id);
 
 
 --
@@ -434,6 +752,30 @@ ALTER TABLE ONLY public.organization_invites
 
 
 --
+-- Name: organization_invites organization_invites_redemption_state_chk; Type: CHECK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE public.organization_invites
+    ADD CONSTRAINT organization_invites_redemption_state_chk CHECK ((((redeemed_at IS NULL) AND (redeemed_membership_id IS NULL)) OR ((redeemed_at IS NOT NULL) AND (redeemed_membership_id IS NOT NULL)))) NOT VALID;
+
+
+--
+-- Name: organization_invites organization_invites_revoked_redeemed_chk; Type: CHECK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE public.organization_invites
+    ADD CONSTRAINT organization_invites_revoked_redeemed_chk CHECK (((revoked_at IS NULL) OR (redeemed_at IS NULL))) NOT VALID;
+
+
+--
+-- Name: organization_invites organization_invites_role_chk; Type: CHECK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE public.organization_invites
+    ADD CONSTRAINT organization_invites_role_chk CHECK ((role = ANY (ARRAY['member'::text, 'manager'::text]))) NOT VALID;
+
+
+--
 -- Name: organization_invites organization_invites_token_hash_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -442,11 +784,107 @@ ALTER TABLE ONLY public.organization_invites
 
 
 --
+-- Name: organization_local_credentials organization_local_credentials_id_membership_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_local_credentials
+    ADD CONSTRAINT organization_local_credentials_id_membership_key UNIQUE (id, membership_id);
+
+
+--
+-- Name: organization_local_credentials organization_local_credentials_membership_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_local_credentials
+    ADD CONSTRAINT organization_local_credentials_membership_key UNIQUE (membership_id);
+
+
+--
+-- Name: organization_local_credentials organization_local_credentials_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_local_credentials
+    ADD CONSTRAINT organization_local_credentials_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: organization_member_oidc_identities organization_member_oidc_id_membership_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_member_oidc_identities
+    ADD CONSTRAINT organization_member_oidc_id_membership_key UNIQUE (id, membership_id);
+
+
+--
+-- Name: organization_member_oidc_identities organization_member_oidc_identities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_member_oidc_identities
+    ADD CONSTRAINT organization_member_oidc_identities_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: organization_member_oidc_identities organization_member_oidc_link_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_member_oidc_identities
+    ADD CONSTRAINT organization_member_oidc_link_key UNIQUE (membership_id, organization_oidc_provider_id, oidc_identity_id);
+
+
+--
+-- Name: organization_member_profiles organization_member_profiles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_member_profiles
+    ADD CONSTRAINT organization_member_profiles_pkey PRIMARY KEY (membership_id);
+
+
+--
+-- Name: organization_memberships organization_memberships_left_at_chk; Type: CHECK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE public.organization_memberships
+    ADD CONSTRAINT organization_memberships_left_at_chk CHECK ((((status = 'left'::text) AND (left_at IS NOT NULL)) OR ((status <> 'left'::text) AND (left_at IS NULL)))) NOT VALID;
+
+
+--
 -- Name: organization_memberships organization_memberships_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.organization_memberships
     ADD CONSTRAINT organization_memberships_pkey PRIMARY KEY (organization_id, user_id);
+
+
+--
+-- Name: organization_memberships organization_memberships_status_chk; Type: CHECK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE public.organization_memberships
+    ADD CONSTRAINT organization_memberships_status_chk CHECK ((status = ANY (ARRAY['active'::text, 'suspended'::text, 'left'::text]))) NOT VALID;
+
+
+--
+-- Name: organization_oidc_providers organization_oidc_providers_id_org_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_oidc_providers
+    ADD CONSTRAINT organization_oidc_providers_id_org_key UNIQUE (id, organization_id);
+
+
+--
+-- Name: organization_oidc_providers organization_oidc_providers_org_issuer_client_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_oidc_providers
+    ADD CONSTRAINT organization_oidc_providers_org_issuer_client_key UNIQUE (organization_id, issuer, client_id);
+
+
+--
+-- Name: organization_oidc_providers organization_oidc_providers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_oidc_providers
+    ADD CONSTRAINT organization_oidc_providers_pkey PRIMARY KEY (id);
 
 
 --
@@ -463,6 +901,14 @@ ALTER TABLE ONLY public.organizations
 
 ALTER TABLE ONLY public.organizations
     ADD CONSTRAINT organizations_slug_key UNIQUE (slug);
+
+
+--
+-- Name: organizations organizations_status_chk; Type: CHECK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE public.organizations
+    ADD CONSTRAINT organizations_status_chk CHECK ((status = ANY (ARRAY['active'::text, 'suspended'::text]))) NOT VALID;
 
 
 --
@@ -495,6 +941,14 @@ ALTER TABLE ONLY public.recordings
 
 ALTER TABLE ONLY public.schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: session_membership_authentications session_membership_authentications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.session_membership_authentications
+    ADD CONSTRAINT session_membership_authentications_pkey PRIMARY KEY (session_id, membership_id);
 
 
 --
@@ -538,6 +992,22 @@ ALTER TABLE ONLY public.user_activation_tokens
 
 
 --
+-- Name: user_profiles user_profiles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_profiles
+    ADD CONSTRAINT user_profiles_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: users users_contact_email_state_chk; Type: CHECK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE public.users
+    ADD CONSTRAINT users_contact_email_state_chk CHECK (((contact_email IS NOT NULL) OR ((normalized_contact_email IS NULL) AND (contact_email_verified_at IS NULL)))) NOT VALID;
+
+
+--
 -- Name: users users_email_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -554,13 +1024,38 @@ ALTER TABLE ONLY public.users
 
 
 --
--- Name: auth_identities_one_google_identity_per_user; Type: INDEX; Schema: public; Owner: -
+-- Name: analysis_run_trajectories_trajectory_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX analysis_run_trajectories_trajectory_id_idx ON public.analysis_run_trajectories USING btree (trajectory_id);
+
+
+--
+-- Name: analysis_runs_organization_created_at_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX analysis_runs_organization_created_at_id_idx ON public.analysis_runs USING btree (organization_id, created_at DESC, id DESC);
 
 
-CREATE INDEX analysis_run_trajectories_trajectory_id_idx ON public.analysis_run_trajectories USING btree (trajectory_id);
+--
+-- Name: audit_events_occurred_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX audit_events_occurred_at_idx ON public.audit_events USING btree (occurred_at);
+
+
+--
+-- Name: audit_events_org_occurred_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX audit_events_org_occurred_at_idx ON public.audit_events USING btree (organization_id, occurred_at DESC);
+
+
+--
+-- Name: audit_events_target_occurred_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX audit_events_target_occurred_at_idx ON public.audit_events USING btree (target_type, target_id, occurred_at DESC);
 
 
 --
@@ -575,6 +1070,27 @@ CREATE UNIQUE INDEX auth_identities_one_google_identity_per_user ON public.auth_
 --
 
 CREATE INDEX auth_identities_user_id_idx ON public.auth_identities USING btree (user_id);
+
+
+--
+-- Name: authentication_events_occurred_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX authentication_events_occurred_at_idx ON public.authentication_events USING btree (occurred_at);
+
+
+--
+-- Name: authentication_events_org_occurred_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX authentication_events_org_occurred_at_idx ON public.authentication_events USING btree (organization_id, occurred_at DESC);
+
+
+--
+-- Name: authentication_events_user_occurred_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX authentication_events_user_occurred_at_idx ON public.authentication_events USING btree (user_id, occurred_at DESC);
 
 
 --
@@ -596,6 +1112,13 @@ CREATE INDEX floors_building_id_idx ON public.floors USING btree (building_id);
 --
 
 CREATE INDEX floors_organization_id_idx ON public.floors USING btree (organization_id);
+
+
+--
+-- Name: oidc_login_transactions_expires_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX oidc_login_transactions_expires_at_idx ON public.oidc_login_transactions USING btree (expires_at);
 
 
 --
@@ -627,6 +1150,13 @@ CREATE INDEX organization_invite_redemptions_user_id_idx ON public.organization_
 
 
 --
+-- Name: organization_invites_active_expires_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX organization_invites_active_expires_at_idx ON public.organization_invites USING btree (expires_at) WHERE ((revoked_at IS NULL) AND (redeemed_at IS NULL));
+
+
+--
 -- Name: organization_invites_created_by_user_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -648,6 +1178,13 @@ CREATE INDEX organization_invites_expires_at_idx ON public.organization_invites 
 
 
 --
+-- Name: organization_invites_org_created_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX organization_invites_org_created_at_idx ON public.organization_invites USING btree (organization_id, created_at DESC);
+
+
+--
 -- Name: organization_invites_organization_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -655,10 +1192,80 @@ CREATE INDEX organization_invites_organization_id_idx ON public.organization_inv
 
 
 --
+-- Name: organization_invites_redeemed_membership_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX organization_invites_redeemed_membership_key ON public.organization_invites USING btree (redeemed_membership_id);
+
+
+--
+-- Name: organization_local_credentials_active_email_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX organization_local_credentials_active_email_key ON public.organization_local_credentials USING btree (organization_id, normalized_login_email) WHERE enabled;
+
+
+--
+-- Name: organization_member_oidc_active_membership_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX organization_member_oidc_active_membership_idx ON public.organization_member_oidc_identities USING btree (membership_id) WHERE (revoked_at IS NULL);
+
+
+--
+-- Name: organization_member_oidc_active_provider_identity_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX organization_member_oidc_active_provider_identity_key ON public.organization_member_oidc_identities USING btree (organization_oidc_provider_id, oidc_identity_id) WHERE (revoked_at IS NULL);
+
+
+--
+-- Name: organization_memberships_id_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX organization_memberships_id_key ON public.organization_memberships USING btree (id);
+
+
+--
+-- Name: organization_memberships_id_organization_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX organization_memberships_id_organization_key ON public.organization_memberships USING btree (id, organization_id);
+
+
+--
+-- Name: organization_memberships_id_user_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX organization_memberships_id_user_key ON public.organization_memberships USING btree (id, user_id);
+
+
+--
+-- Name: organization_memberships_org_status_role_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX organization_memberships_org_status_role_idx ON public.organization_memberships USING btree (organization_id, status, role);
+
+
+--
 -- Name: organization_memberships_user_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX organization_memberships_user_id_idx ON public.organization_memberships USING btree (user_id);
+
+
+--
+-- Name: organization_memberships_user_status_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX organization_memberships_user_status_idx ON public.organization_memberships USING btree (user_id, status);
+
+
+--
+-- Name: pedestrians_membership_id_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX pedestrians_membership_id_key ON public.pedestrians USING btree (membership_id) WHERE (membership_id IS NOT NULL);
 
 
 --
@@ -704,10 +1311,52 @@ CREATE INDEX recordings_pedestrian_id_created_at_active_idx ON public.recordings
 
 
 --
+-- Name: session_membership_auth_active_local_credential_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX session_membership_auth_active_local_credential_idx ON public.session_membership_authentications USING btree (local_credential_id) WHERE (revoked_at IS NULL);
+
+
+--
+-- Name: session_membership_auth_active_membership_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX session_membership_auth_active_membership_idx ON public.session_membership_authentications USING btree (membership_id) WHERE (revoked_at IS NULL);
+
+
+--
+-- Name: session_membership_auth_active_oidc_identity_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX session_membership_auth_active_oidc_identity_idx ON public.session_membership_authentications USING btree (member_oidc_identity_id) WHERE (revoked_at IS NULL);
+
+
+--
+-- Name: sessions_active_expires_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sessions_active_expires_at_idx ON public.sessions USING btree (expires_at) WHERE (revoked_at IS NULL);
+
+
+--
+-- Name: sessions_active_user_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sessions_active_user_idx ON public.sessions USING btree (user_id) WHERE (revoked_at IS NULL);
+
+
+--
 -- Name: sessions_expires_at_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX sessions_expires_at_idx ON public.sessions USING btree (expires_at);
+
+
+--
+-- Name: sessions_id_user_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX sessions_id_user_key ON public.sessions USING btree (id, user_id);
 
 
 --
@@ -725,17 +1374,17 @@ CREATE INDEX sessions_user_id_idx ON public.sessions USING btree (user_id);
 
 
 --
--- Name: trajectories_organization_id_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX trajectories_organization_id_idx ON public.trajectories USING btree (organization_id);
-
-
---
 -- Name: trajectories_organization_created_at_id_active_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX trajectories_organization_created_at_id_active_idx ON public.trajectories USING btree (organization_id, created_at DESC, id DESC) WHERE (deleted_at IS NULL);
+
+
+--
+-- Name: trajectories_organization_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX trajectories_organization_id_idx ON public.trajectories USING btree (organization_id);
 
 
 --
@@ -816,6 +1465,20 @@ CREATE TRIGGER set_updated_at_floors BEFORE UPDATE ON public.floors FOR EACH ROW
 
 
 --
+-- Name: oidc_identities set_updated_at_oidc_identities; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER set_updated_at_oidc_identities BEFORE UPDATE ON public.oidc_identities FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+
+--
+-- Name: organization_auth_settings set_updated_at_organization_auth_settings; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER set_updated_at_organization_auth_settings BEFORE UPDATE ON public.organization_auth_settings FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+
+--
 -- Name: organization_creation_requests set_updated_at_organization_creation_requests; Type: TRIGGER; Schema: public; Owner: -
 --
 
@@ -830,10 +1493,38 @@ CREATE TRIGGER set_updated_at_organization_invites BEFORE UPDATE ON public.organ
 
 
 --
+-- Name: organization_local_credentials set_updated_at_organization_local_credentials; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER set_updated_at_organization_local_credentials BEFORE UPDATE ON public.organization_local_credentials FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+
+--
+-- Name: organization_member_oidc_identities set_updated_at_organization_member_oidc_identities; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER set_updated_at_organization_member_oidc_identities BEFORE UPDATE ON public.organization_member_oidc_identities FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+
+--
+-- Name: organization_member_profiles set_updated_at_organization_member_profiles; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER set_updated_at_organization_member_profiles BEFORE UPDATE ON public.organization_member_profiles FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+
+--
 -- Name: organization_memberships set_updated_at_organization_memberships; Type: TRIGGER; Schema: public; Owner: -
 --
 
 CREATE TRIGGER set_updated_at_organization_memberships BEFORE UPDATE ON public.organization_memberships FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+
+--
+-- Name: organization_oidc_providers set_updated_at_organization_oidc_providers; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER set_updated_at_organization_oidc_providers BEFORE UPDATE ON public.organization_oidc_providers FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
 
 
 --
@@ -858,10 +1549,24 @@ CREATE TRIGGER set_updated_at_recordings BEFORE UPDATE ON public.recordings FOR 
 
 
 --
+-- Name: session_membership_authentications set_updated_at_session_membership_authentications; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER set_updated_at_session_membership_authentications BEFORE UPDATE ON public.session_membership_authentications FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+
+--
 -- Name: trajectories set_updated_at_trajectories; Type: TRIGGER; Schema: public; Owner: -
 --
 
 CREATE TRIGGER set_updated_at_trajectories BEFORE UPDATE ON public.trajectories FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+
+--
+-- Name: user_profiles set_updated_at_user_profiles; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER set_updated_at_user_profiles BEFORE UPDATE ON public.user_profiles FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
 
 
 --
@@ -872,23 +1577,35 @@ CREATE TRIGGER set_updated_at_users BEFORE UPDATE ON public.users FOR EACH ROW E
 
 
 --
--- Name: auth_identities auth_identities_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: analysis_run_trajectories analysis_run_trajectories_analysis_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.analysis_run_trajectories
+    ADD CONSTRAINT analysis_run_trajectories_analysis_run_id_fkey FOREIGN KEY (analysis_run_id) REFERENCES public.analysis_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: analysis_run_trajectories analysis_run_trajectories_trajectory_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.analysis_run_trajectories
+    ADD CONSTRAINT analysis_run_trajectories_trajectory_id_fkey FOREIGN KEY (trajectory_id) REFERENCES public.trajectories(id);
+
+
+--
+-- Name: analysis_runs analysis_runs_floor_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.analysis_runs
     ADD CONSTRAINT analysis_runs_floor_id_fkey FOREIGN KEY (floor_id) REFERENCES public.floors(id);
 
 
+--
+-- Name: analysis_runs analysis_runs_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.analysis_runs
     ADD CONSTRAINT analysis_runs_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
-
-
-ALTER TABLE ONLY public.analysis_run_trajectories
-    ADD CONSTRAINT analysis_run_trajectories_analysis_run_id_fkey FOREIGN KEY (analysis_run_id) REFERENCES public.analysis_runs(id) ON DELETE CASCADE;
-
-
-ALTER TABLE ONLY public.analysis_run_trajectories
-    ADD CONSTRAINT analysis_run_trajectories_trajectory_id_fkey FOREIGN KEY (trajectory_id) REFERENCES public.trajectories(id);
 
 
 --
@@ -921,6 +1638,54 @@ ALTER TABLE ONLY public.floors
 
 ALTER TABLE ONLY public.floors
     ADD CONSTRAINT floors_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: oidc_identities oidc_identities_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oidc_identities
+    ADD CONSTRAINT oidc_identities_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: oidc_login_transactions oidc_login_transactions_invite_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oidc_login_transactions
+    ADD CONSTRAINT oidc_login_transactions_invite_id_fkey FOREIGN KEY (invite_id) REFERENCES public.organization_invites(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: oidc_login_transactions oidc_login_transactions_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oidc_login_transactions
+    ADD CONSTRAINT oidc_login_transactions_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: oidc_login_transactions oidc_login_transactions_provider_org_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oidc_login_transactions
+    ADD CONSTRAINT oidc_login_transactions_provider_org_fkey FOREIGN KEY (organization_oidc_provider_id, organization_id) REFERENCES public.organization_oidc_providers(id, organization_id) ON DELETE RESTRICT;
+
+
+--
+-- Name: oidc_login_transactions oidc_login_transactions_session_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oidc_login_transactions
+    ADD CONSTRAINT oidc_login_transactions_session_id_fkey FOREIGN KEY (session_id) REFERENCES public.sessions(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: organization_auth_settings organization_auth_settings_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_auth_settings
+    ADD CONSTRAINT organization_auth_settings_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE RESTRICT;
 
 
 --
@@ -972,11 +1737,75 @@ ALTER TABLE ONLY public.organization_invites
 
 
 --
+-- Name: organization_invites organization_invites_creator_org_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_invites
+    ADD CONSTRAINT organization_invites_creator_org_fkey FOREIGN KEY (created_by_membership_id, organization_id) REFERENCES public.organization_memberships(id, organization_id) ON DELETE RESTRICT NOT VALID;
+
+
+--
 -- Name: organization_invites organization_invites_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.organization_invites
     ADD CONSTRAINT organization_invites_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: organization_invites organization_invites_redeemed_membership_org_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_invites
+    ADD CONSTRAINT organization_invites_redeemed_membership_org_fkey FOREIGN KEY (redeemed_membership_id, organization_id) REFERENCES public.organization_memberships(id, organization_id) ON DELETE RESTRICT NOT VALID;
+
+
+--
+-- Name: organization_local_credentials organization_local_credentials_membership_org_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_local_credentials
+    ADD CONSTRAINT organization_local_credentials_membership_org_fkey FOREIGN KEY (membership_id, organization_id) REFERENCES public.organization_memberships(id, organization_id) ON DELETE RESTRICT;
+
+
+--
+-- Name: organization_member_oidc_identities organization_member_oidc_identity_user_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_member_oidc_identities
+    ADD CONSTRAINT organization_member_oidc_identity_user_fkey FOREIGN KEY (oidc_identity_id, user_id) REFERENCES public.oidc_identities(id, user_id) ON DELETE RESTRICT;
+
+
+--
+-- Name: organization_member_oidc_identities organization_member_oidc_membership_org_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_member_oidc_identities
+    ADD CONSTRAINT organization_member_oidc_membership_org_fkey FOREIGN KEY (membership_id, organization_id) REFERENCES public.organization_memberships(id, organization_id) ON DELETE RESTRICT;
+
+
+--
+-- Name: organization_member_oidc_identities organization_member_oidc_membership_user_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_member_oidc_identities
+    ADD CONSTRAINT organization_member_oidc_membership_user_fkey FOREIGN KEY (membership_id, user_id) REFERENCES public.organization_memberships(id, user_id) ON DELETE RESTRICT;
+
+
+--
+-- Name: organization_member_oidc_identities organization_member_oidc_provider_org_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_member_oidc_identities
+    ADD CONSTRAINT organization_member_oidc_provider_org_fkey FOREIGN KEY (organization_oidc_provider_id, organization_id) REFERENCES public.organization_oidc_providers(id, organization_id) ON DELETE RESTRICT;
+
+
+--
+-- Name: organization_member_profiles organization_member_profiles_membership_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_member_profiles
+    ADD CONSTRAINT organization_member_profiles_membership_id_fkey FOREIGN KEY (membership_id) REFERENCES public.organization_memberships(id) ON DELETE RESTRICT;
 
 
 --
@@ -993,6 +1822,22 @@ ALTER TABLE ONLY public.organization_memberships
 
 ALTER TABLE ONLY public.organization_memberships
     ADD CONSTRAINT organization_memberships_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: organization_oidc_providers organization_oidc_providers_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_oidc_providers
+    ADD CONSTRAINT organization_oidc_providers_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: pedestrians pedestrians_membership_organization_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.pedestrians
+    ADD CONSTRAINT pedestrians_membership_organization_fkey FOREIGN KEY (membership_id, organization_id) REFERENCES public.organization_memberships(id, organization_id) ON DELETE RESTRICT NOT VALID;
 
 
 --
@@ -1033,6 +1878,38 @@ ALTER TABLE ONLY public.recordings
 
 ALTER TABLE ONLY public.recordings
     ADD CONSTRAINT recordings_pedestrian_id_fkey FOREIGN KEY (pedestrian_id) REFERENCES public.pedestrians(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: session_membership_authentications session_membership_auth_local_source_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.session_membership_authentications
+    ADD CONSTRAINT session_membership_auth_local_source_fkey FOREIGN KEY (local_credential_id, membership_id) REFERENCES public.organization_local_credentials(id, membership_id) ON DELETE RESTRICT;
+
+
+--
+-- Name: session_membership_authentications session_membership_auth_membership_user_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.session_membership_authentications
+    ADD CONSTRAINT session_membership_auth_membership_user_fkey FOREIGN KEY (membership_id, user_id) REFERENCES public.organization_memberships(id, user_id) ON DELETE RESTRICT;
+
+
+--
+-- Name: session_membership_authentications session_membership_auth_oidc_source_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.session_membership_authentications
+    ADD CONSTRAINT session_membership_auth_oidc_source_fkey FOREIGN KEY (member_oidc_identity_id, membership_id) REFERENCES public.organization_member_oidc_identities(id, membership_id) ON DELETE RESTRICT;
+
+
+--
+-- Name: session_membership_authentications session_membership_auth_session_user_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.session_membership_authentications
+    ADD CONSTRAINT session_membership_auth_session_user_fkey FOREIGN KEY (session_id, user_id) REFERENCES public.sessions(id, user_id) ON DELETE RESTRICT;
 
 
 --
@@ -1092,6 +1969,14 @@ ALTER TABLE ONLY public.user_activation_tokens
 
 
 --
+-- Name: user_profiles user_profiles_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_profiles
+    ADD CONSTRAINT user_profiles_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE RESTRICT;
+
+
+--
 -- PostgreSQL database dump complete
 --
 
@@ -1117,4 +2002,26 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20260708010000'),
     ('20260728010000'),
     ('20260728010100'),
-    ('20260728010200');
+    ('20260728010200'),
+    ('20260728010300'),
+    ('20260801010000'),
+    ('20260804010000'),
+    ('20260804020000'),
+    ('20260811010000'),
+    ('20260811010051'),
+    ('20260811010052'),
+    ('20260811010053'),
+    ('20260811010054'),
+    ('20260811010055'),
+    ('20260811010056'),
+    ('20260811010057'),
+    ('20260811010058'),
+    ('20260811010100'),
+    ('20260811010200'),
+    ('20260811010250'),
+    ('20260811010300'),
+    ('20260811010400'),
+    ('20260811010500'),
+    ('20260811010551'),
+    ('20260811010552'),
+    ('20260811010553');

--- a/deploy/scripts/deploy-production.sh
+++ b/deploy/scripts/deploy-production.sh
@@ -181,8 +181,14 @@ compose_cmd pull postgres seaweedfs
 log "Starting dependent services for env: production"
 compose_cmd up -d postgres seaweedfs
 
+log "Building Kaede migration runner for env: production"
+compose_cmd build kaede
+
 log "Running database migrations for env: production"
 compose_cmd --profile tools run --rm -e DBMATE_SCHEMA_FILE=/tmp/schema.sql dbmate up
+
+log "Running one-shot multi-organization auth cutover for env: production"
+compose_cmd run --rm --no-deps kaede node dist/cli/multi-org-auth-backfill.js cutover
 
 log "Initializing object storage for env: production"
 compose_cmd --profile tools run --rm storage-bootstrap

--- a/deploy/scripts/deploy-staging.sh
+++ b/deploy/scripts/deploy-staging.sh
@@ -181,8 +181,14 @@ compose_cmd pull postgres seaweedfs
 log "Starting dependent services for env: staging"
 compose_cmd up -d postgres seaweedfs
 
+log "Building Kaede migration runner for env: staging"
+compose_cmd build kaede
+
 log "Running database migrations for env: staging"
 compose_cmd --profile tools run --rm -e DBMATE_SCHEMA_FILE=/tmp/schema.sql dbmate up
+
+log "Running one-shot multi-organization auth cutover for env: staging"
+compose_cmd run --rm --no-deps kaede node dist/cli/multi-org-auth-backfill.js cutover
 
 log "Initializing object storage for env: staging"
 compose_cmd --profile tools run --rm storage-bootstrap

--- a/deploy/scripts/deploy-test.sh
+++ b/deploy/scripts/deploy-test.sh
@@ -181,8 +181,14 @@ compose_cmd pull postgres seaweedfs
 log "Starting dependent services for env: test"
 compose_cmd up -d postgres seaweedfs
 
+log "Building Kaede migration runner for env: test"
+compose_cmd build kaede
+
 log "Running database migrations for env: test"
 compose_cmd --profile tools run --rm -e DBMATE_SCHEMA_FILE=/tmp/schema.sql dbmate up
+
+log "Running one-shot multi-organization auth cutover for env: test"
+compose_cmd run --rm --no-deps kaede node dist/cli/multi-org-auth-backfill.js cutover
 
 log "Initializing object storage for env: test"
 compose_cmd --profile tools run --rm storage-bootstrap


### PR DESCRIPTION
Closes #219

## 変更内容
- Membership UUID・再参加ライフサイクルを導入
- Membership単位のLocal CredentialとOrganization認証Policyを追加
- OIDC Identity、Provider、Membership Linkを分離
- User SessionとOrganization Membership Grantを分離
- User共通ProfileとOrganization別Profile override APIを追加
- single-use Inviteの発行・受領・取消・再発行を追加
- manager/ownerによるMembership管理と権限境界を追加
- 身長・歩幅をmeterへ統一
- Kaede/Nozomi解析契約を維持

## Database migration
新旧形式は共存運用しません。maintenance中に全書込みを停止し、`multi-org-auth-backfill cutover`で全件Backfill、検証、制約昇格、既存Session全失効を1 transactionで実行します。失敗時はtransaction rollbackまたは切替前backupからDatabase全体をrestoreします。

## Mio
Mio側の対応PR #31〜#34はMio `main`へmerge済みです。

## Validation
- Kaede Unit: 533 tests passed
- Kaede GitHub Actions: checks/build, DB, S3 passed
- Nozomi contract tests passed
- Mio lint, test, client/SSR build passed

## Rollout前の確認
- Production相当snapshotでone-shot migration rehearsal
- OrganizationごとのAuth Policy/OIDC Provider確定
- blocking preflight issueが0件
- backup/restore確認
- maintenance中のKaede/Mio/worker書込み停止
- Cutover後のLocal/OIDC/Invite/Profile/Nozomi smoke test

## Scope外
- Event table partition
- avatar
- multi-use Invite
- Pedestrian旧Profile columnの削除
- Recording/Floor/Trajectory全体のTenant複合FK再設計