### PR TITLE
fix: run one-shot auth cutover during deploy

### DIFF
--- a/apps/kaede/src/cli/multi-org-auth-backfill.ts
+++ b/apps/kaede/src/cli/multi-org-auth-backfill.ts
@@ -46,7 +46,13 @@ export const main = async (argv = process.argv.slice(2)) => {
   } = await import('../services/migrations/multi-org-auth-backfill.js')
 
   if (options.command === 'cutover') {
-    const result = await executeOneShotMultiOrgAuthCutover(options.batchSize)
+    const { getOidcRuntimeConfig } = await import('../config/runtime.js')
+    const config = getOidcRuntimeConfig()
+    const result = await executeOneShotMultiOrgAuthCutover(options.batchSize, undefined, {
+      google_client_id: config.googleClientId,
+      local_auth_enabled: config.passwordLoginEnabled,
+      oidc_auth_enabled: config.enabled,
+    })
     process.stdout.write(`${JSON.stringify(result)}\n`)
     return
   }

--- a/apps/kaede/src/services/db/generated.ts
+++ b/apps/kaede/src/services/db/generated.ts
@@ -50,6 +50,12 @@ export interface AnalysisRunTrajectories {
   trajectory_id: string
 }
 
+export interface ApplicationDataMigrations {
+  completed_at: Generated<Timestamp>
+  details: Generated<Json>
+  name: string
+}
+
 export interface AuditEvents {
   action: string
   actor_membership_id: string | null
@@ -376,6 +382,7 @@ export interface Users {
 export interface DB {
   analysis_run_trajectories: AnalysisRunTrajectories
   analysis_runs: AnalysisRuns
+  application_data_migrations: ApplicationDataMigrations
   audit_events: AuditEvents
   auth_identities: AuthIdentities
   authentication_events: AuthenticationEvents

--- a/apps/kaede/src/services/migrations/multi-org-auth-backfill.ts
+++ b/apps/kaede/src/services/migrations/multi-org-auth-backfill.ts
@@ -44,11 +44,22 @@ export interface BackfillResult {
 }
 
 export interface OneShotCutoverResult {
+  already_completed: boolean
   auth: BackfillResult
+  bootstrapped_auth_settings: number
+  bootstrapped_oidc_providers: number
   core: BackfillResult
   revoked_sessions: number
   validated: true
 }
+
+export interface LegacyAuthPolicyBootstrap {
+  google_client_id: string
+  local_auth_enabled: boolean
+  oidc_auth_enabled: boolean
+}
+
+const cutoverMigrationName = 'multi-organization-auth-v1'
 
 const emptyResult = (): BackfillResult => ({
   auth_settings_unchanged: 0,
@@ -808,9 +819,90 @@ export const validateMultiOrgAuthExpandConstraints = async (
  */
 export const executeOneShotMultiOrgAuthCutover = async (
   batchSize: number,
-  database: Kysely<DB> = db
+  database: Kysely<DB> = db,
+  bootstrap?: LegacyAuthPolicyBootstrap
 ): Promise<OneShotCutoverResult> =>
   database.transaction().execute(async (trx) => {
+    await sql`SELECT pg_advisory_xact_lock(hashtext(${cutoverMigrationName}))`.execute(trx)
+
+    const completed = await sql<{ completed: boolean }>`
+      SELECT EXISTS (
+        SELECT 1 FROM application_data_migrations WHERE name = ${cutoverMigrationName}
+      ) AS completed
+    `.execute(trx)
+    if (completed.rows[0]?.completed) {
+      return {
+        already_completed: true,
+        auth: emptyResult(),
+        bootstrapped_auth_settings: 0,
+        bootstrapped_oidc_providers: 0,
+        core: emptyResult(),
+        revoked_sessions: 0,
+        validated: true,
+      }
+    }
+
+    let bootstrappedAuthSettings = 0
+    let bootstrappedOidcProviders = 0
+    if (bootstrap) {
+      if (!bootstrap.local_auth_enabled && !bootstrap.oidc_auth_enabled) {
+        throw new Error('one-shot cutover requires at least one enabled authentication method')
+      }
+
+      const settings = await sql<{ organization_id: string }>`
+        INSERT INTO organization_auth_settings (
+          organization_id,
+          local_auth_enabled,
+          oidc_auth_enabled,
+          membership_grant_ttl_seconds,
+          reauthentication_interval_seconds
+        )
+        SELECT id, ${bootstrap.local_auth_enabled}, ${bootstrap.oidc_auth_enabled}, 28800, 14400
+        FROM organizations
+        ON CONFLICT (organization_id) DO NOTHING
+        RETURNING organization_id
+      `.execute(trx)
+      bootstrappedAuthSettings = settings.rows.length
+
+      if (bootstrap.oidc_auth_enabled) {
+        if (!bootstrap.google_client_id) {
+          throw new Error('one-shot OIDC cutover requires the configured Google client id')
+        }
+        const providers = await sql<{ id: string }>`
+          INSERT INTO organization_oidc_providers (
+            organization_id,
+            name,
+            issuer,
+            client_id,
+            client_secret_ref,
+            scopes,
+            allowed_hosted_domains,
+            enabled
+          )
+          SELECT
+            settings.organization_id,
+            'Google',
+            ${canonicalGoogleIssuer},
+            ${bootstrap.google_client_id},
+            NULL,
+            ARRAY['openid', 'email', 'profile']::text[],
+            NULL,
+            true
+          FROM organization_auth_settings AS settings
+          WHERE settings.oidc_auth_enabled
+            AND NOT EXISTS (
+              SELECT 1
+              FROM organization_oidc_providers AS provider
+              WHERE provider.organization_id = settings.organization_id
+                AND provider.issuer = ${canonicalGoogleIssuer}
+                AND provider.enabled
+            )
+          RETURNING id
+        `.execute(trx)
+        bootstrappedOidcProviders = providers.rows.length
+      }
+    }
+
     const preflight = await getMultiOrgAuthPreflightReport(trx)
     if (preflight.blocking) {
       throw new Error(
@@ -848,8 +940,23 @@ export const executeOneShotMultiOrgAuthCutover = async (
       RETURNING id
     `.execute(trx)
 
+    await sql`
+      INSERT INTO application_data_migrations (name, details)
+      VALUES (
+        ${cutoverMigrationName},
+        jsonb_build_object(
+          'revoked_sessions', ${revokedSessions.rows.length},
+          'bootstrapped_auth_settings', ${bootstrappedAuthSettings},
+          'bootstrapped_oidc_providers', ${bootstrappedOidcProviders}
+        )
+      )
+    `.execute(trx)
+
     return {
+      already_completed: false,
       auth,
+      bootstrapped_auth_settings: bootstrappedAuthSettings,
+      bootstrapped_oidc_providers: bootstrappedOidcProviders,
       core,
       revoked_sessions: revokedSessions.rows.length,
       validated: true,

--- a/apps/kaede/src/services/migrations/multi-org-auth-backfill.ts
+++ b/apps/kaede/src/services/migrations/multi-org-auth-backfill.ts
@@ -940,16 +940,15 @@ export const executeOneShotMultiOrgAuthCutover = async (
       RETURNING id
     `.execute(trx)
 
+    const cutoverDetails = JSON.stringify({
+      revoked_sessions: revokedSessions.rows.length,
+      bootstrapped_auth_settings: bootstrappedAuthSettings,
+      bootstrapped_oidc_providers: bootstrappedOidcProviders,
+    })
+
     await sql`
       INSERT INTO application_data_migrations (name, details)
-      VALUES (
-        ${cutoverMigrationName},
-        jsonb_build_object(
-          'revoked_sessions', ${revokedSessions.rows.length},
-          'bootstrapped_auth_settings', ${bootstrappedAuthSettings},
-          'bootstrapped_oidc_providers', ${bootstrappedOidcProviders}
-        )
-      )
+      VALUES (${cutoverMigrationName}, ${cutoverDetails}::jsonb)
     `.execute(trx)
 
     return {

--- a/apps/kaede/tests/db/helpers.ts
+++ b/apps/kaede/tests/db/helpers.ts
@@ -5,6 +5,7 @@ import type { DB } from '../../src/services/db/generated.js'
 export const resetDatabase = async (db: Kysely<DB>) => {
   await sql`
     TRUNCATE TABLE
+      application_data_migrations,
       audit_events,
       authentication_events,
       oidc_login_transactions,

--- a/apps/kaede/tests/services/db/multi-org-auth-backfill.test.ts
+++ b/apps/kaede/tests/services/db/multi-org-auth-backfill.test.ts
@@ -403,17 +403,7 @@ describe('multi organization auth backfill', () => {
   })
 
   it('migrates all rows and revokes legacy sessions in one cutover transaction', async () => {
-    const { organization, user } = await createLegacyUserAndMembership('one-shot')
-    await db
-      .insertInto('organization_auth_settings')
-      .values({
-        local_auth_enabled: true,
-        membership_grant_ttl_seconds: 3600,
-        oidc_auth_enabled: false,
-        organization_id: organization.id,
-        reauthentication_interval_seconds: 1800,
-      })
-      .execute()
+    const { user } = await createLegacyUserAndMembership('one-shot')
     await db
       .insertInto('sessions')
       .values({
@@ -423,10 +413,16 @@ describe('multi organization auth backfill', () => {
       })
       .execute()
 
-    const result = await executeOneShotMultiOrgAuthCutover(1, db)
+    const result = await executeOneShotMultiOrgAuthCutover(1, db, {
+      google_client_id: '',
+      local_auth_enabled: true,
+      oidc_auth_enabled: false,
+    })
 
     expect(result).toMatchObject({
+      already_completed: false,
       auth: { local_credentials: 1 },
+      bootstrapped_auth_settings: 1,
       core: { memberships: 1, user_profiles: 1 },
       revoked_sessions: 1,
       validated: true,
@@ -437,5 +433,27 @@ describe('multi organization auth backfill', () => {
     await expect(
       db.selectFrom('organization_local_credentials').select('id').executeTakeFirstOrThrow()
     ).resolves.toEqual({ id: expect.any(String) })
+
+    await db
+      .insertInto('sessions')
+      .values({
+        expires_at: new Date('2026-08-20T00:00:00.000Z'),
+        session_hash: 'post-cutover-session-hash',
+        user_id: user.id,
+      })
+      .execute()
+    const repeated = await executeOneShotMultiOrgAuthCutover(1, db, {
+      google_client_id: '',
+      local_auth_enabled: true,
+      oidc_auth_enabled: false,
+    })
+    expect(repeated).toMatchObject({ already_completed: true, revoked_sessions: 0 })
+    await expect(
+      db
+        .selectFrom('sessions')
+        .select('revoked_at')
+        .where('session_hash', '=', 'post-cutover-session-hash')
+        .executeTakeFirstOrThrow()
+    ).resolves.toEqual({ revoked_at: null })
   })
 })

--- a/db/migrations/20260812020100_promote_membership_uuid_primary_key.sql
+++ b/db/migrations/20260812020100_promote_membership_uuid_primary_key.sql
@@ -2,6 +2,20 @@
 
 SET LOCAL lock_timeout = '5s';
 
+-- dbmate applies all pending migrations in one run. Populate the fields needed
+-- by the primary-key change here so the schema can be promoted before the
+-- application-level one-shot cutover migrates profiles and credentials.
+UPDATE organizations
+SET status = 'active'
+WHERE status IS NULL;
+
+UPDATE organization_memberships
+SET
+  id = COALESCE(id, gen_random_uuid()),
+  status = COALESCE(status, 'active'),
+  joined_at = COALESCE(joined_at, created_at)
+WHERE id IS NULL OR status IS NULL OR joined_at IS NULL;
+
 DO $$
 BEGIN
   IF EXISTS (

--- a/db/migrations/20260812020200_create_application_data_migrations.sql
+++ b/db/migrations/20260812020200_create_application_data_migrations.sql
@@ -1,0 +1,13 @@
+-- migrate:up
+
+CREATE TABLE application_data_migrations (
+  name text PRIMARY KEY,
+  completed_at timestamptz NOT NULL DEFAULT NOW(),
+  details jsonb NOT NULL DEFAULT '{}'::jsonb,
+  CONSTRAINT application_data_migrations_name_nonempty_chk
+    CHECK (length(btrim(name)) > 0)
+);
+
+-- migrate:down
+
+DROP TABLE IF EXISTS application_data_migrations;

--- a/db/multi-organization-auth-backfill.md
+++ b/db/multi-organization-auth-backfill.md
@@ -28,7 +28,8 @@ Membership主キー昇格、旧契約削除までを完了し、新Application�
    - `INVITE_CREATOR_MEMBERSHIP_NOT_FOUND`
    - `LEGACY_MULTI_USE_INVITE`
    - `PENDING_ACTIVATION_USER`
-4. Organizationごとの認証PolicyとOIDC Providerを明示的に決定する。email domainやglobal設定から推測しない。
+4. 既存Organizationの初期認証Policyは、Cutover時点の明示的な`PASSWORD_LOGIN_ENABLED` / `OIDC_ENABLED`
+   とGoogle Client IDから作成される。Organization固有設定がすでに存在する場合は上書きしない。
 5. Database backupを取得し、restoreできることを確認する。
 
 `pedestrians.height`と`stride_length`はmeterとして扱います。`0 < value <= 3`以外はblocking issueとし、
@@ -41,10 +42,9 @@ Kaede directoryで実行します。
 ```sh
 # 1. maintenance modeへ切り替え、Kaede/Mio/workerからの全書込みを停止
 
-# 2. 新Table・Columnを追加するmigrationを適用
+# 2. deploy scriptがKaede migration runnerをbuild
+# 3. 新Table・Columnを追加するmigrationを適用
 make db-up ENV=production
-
-# 3. OrganizationごとのAuth Settings / OIDC Providerを確定・登録
 
 # 4. 最終preflight
 pnpm multi-org-auth-backfill preflight
@@ -52,23 +52,23 @@ pnpm multi-org-auth-backfill preflight
 # 5. 全データを1 transactionで移行・検証し、全Sessionをrevoke
 pnpm multi-org-auth-backfill cutover --batch-size 500
 
-# 6. Membership UUID primary key昇格と同時リリース対象のContract migrationを適用
-make db-up ENV=production
-
-# 7. 新Kaedeを起動し、smoke test後に新Mioを公開
+# 6. 新Kaedeを起動し、smoke test後に新Mioを公開
 ```
 
 `cutover`は次を単一transactionで実行します。
 
-1. 全scopeのpreflightを再検証する。
-2. Organization、Membership、contact email、User Profile、Member Profile、Pedestrian、Invite creatorを全件移行する。
-3. Membership単位Local Credential、canonical OIDC Identity、Membership OIDC Linkを全件移行する。
-4. core migrationの未移行件数がすべて0であることを検証する。
-5. auth backfillを再実行し、追加行が0であることを検証する。
-6. FK/CHECK/NOT NULL制約をvalidateする。
-7. 既存Sessionをすべてrevokeする。
+1. advisory lockを取得し、完了markerがあれば安全にno-opで終了する。
+2. 未設定Organizationだけに既存環境の認証方式を初期Policyとして登録する。
+3. 全scopeのpreflightを再検証する。
+4. Organization、Membership、contact email、User Profile、Member Profile、Pedestrian、Invite creatorを全件移行する。
+5. Membership単位Local Credential、canonical OIDC Identity、Membership OIDC Linkを全件移行する。
+6. core migrationの未移行件数がすべて0であることを検証する。
+7. auth backfillを再実行し、追加行が0であることを検証する。
+8. FK/CHECK/NOT NULL制約をvalidateする。
+9. 既存Sessionをすべてrevokeし、完了markerを保存する。
 
-途中で失敗した場合はtransaction全体がrollbackされます。原因を修正して最初から再実行します。
+途中で失敗した場合はtransaction全体がrollbackされます。原因を修正して最初から再実行します。完了後の通常deployでは
+markerを検出してno-opになるため、既存Sessionを再度revokeしません。
 
 ## 移行内容
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -75,6 +75,18 @@ CREATE TABLE public.analysis_runs (
 -- Name: audit_events; Type: TABLE; Schema: public; Owner: -
 --
 
+CREATE TABLE public.application_data_migrations (
+    name text NOT NULL,
+    completed_at timestamp with time zone DEFAULT now() NOT NULL,
+    details jsonb DEFAULT '{}'::jsonb NOT NULL,
+    CONSTRAINT application_data_migrations_name_nonempty_chk CHECK ((length(btrim(name)) > 0))
+);
+
+
+ALTER TABLE ONLY public.application_data_migrations
+    ADD CONSTRAINT application_data_migrations_pkey PRIMARY KEY (name);
+
+
 CREATE TABLE public.audit_events (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     occurred_at timestamp with time zone DEFAULT now() NOT NULL,

--- a/deploy/scripts/deploy-production.sh
+++ b/deploy/scripts/deploy-production.sh
@@ -181,8 +181,14 @@ compose_cmd pull postgres seaweedfs
 log "Starting dependent services for env: production"
 compose_cmd up -d postgres seaweedfs
 
+log "Building Kaede migration runner for env: production"
+compose_cmd build kaede
+
 log "Running database migrations for env: production"
 compose_cmd --profile tools run --rm -e DBMATE_SCHEMA_FILE=/tmp/schema.sql dbmate up
+
+log "Running one-shot multi-organization auth cutover for env: production"
+compose_cmd run --rm --no-deps kaede node dist/cli/multi-org-auth-backfill.js cutover
 
 log "Initializing object storage for env: production"
 compose_cmd --profile tools run --rm storage-bootstrap

--- a/deploy/scripts/deploy-staging.sh
+++ b/deploy/scripts/deploy-staging.sh
@@ -181,8 +181,14 @@ compose_cmd pull postgres seaweedfs
 log "Starting dependent services for env: staging"
 compose_cmd up -d postgres seaweedfs
 
+log "Building Kaede migration runner for env: staging"
+compose_cmd build kaede
+
 log "Running database migrations for env: staging"
 compose_cmd --profile tools run --rm -e DBMATE_SCHEMA_FILE=/tmp/schema.sql dbmate up
+
+log "Running one-shot multi-organization auth cutover for env: staging"
+compose_cmd run --rm --no-deps kaede node dist/cli/multi-org-auth-backfill.js cutover
 
 log "Initializing object storage for env: staging"
 compose_cmd --profile tools run --rm storage-bootstrap

--- a/deploy/scripts/deploy-test.sh
+++ b/deploy/scripts/deploy-test.sh
@@ -181,8 +181,14 @@ compose_cmd pull postgres seaweedfs
 log "Starting dependent services for env: test"
 compose_cmd up -d postgres seaweedfs
 
+log "Building Kaede migration runner for env: test"
+compose_cmd build kaede
+
 log "Running database migrations for env: test"
 compose_cmd --profile tools run --rm -e DBMATE_SCHEMA_FILE=/tmp/schema.sql dbmate up
+
+log "Running one-shot multi-organization auth cutover for env: test"
+compose_cmd run --rm --no-deps kaede node dist/cli/multi-org-auth-backfill.js cutover
 
 log "Initializing object storage for env: test"
 compose_cmd --profile tools run --rm storage-bootstrap


### PR DESCRIPTION
Parent: #219

## Root cause
`dbmate up`がExpand migrationからMembership UUID主キー昇格まで連続実行する一方、必要なdata backfill commandがdeploy scriptへ接続されていませんでした。そのためlegacy MembershipにNULLが残った状態で昇格migrationが停止しました。

## Fix
- 主キー昇格migrationで昇格必須fieldを安全に全件設定
- test/staging/productionでKaede migration runnerを先にbuild
- dbmate直後、Application起動前にone-shot cutoverを実行
- 未設定Organizationだけを現在の明示的なLocal/OIDC環境設定から初期化
- Cutover markerとadvisory lockを追加し、再deployはno-op
- DB testで初回全件移行・Session revoke・2回目no-opを検証

## Validation
- TypeScript: pass
- ESLint: pass
- Unit: 533 pass
- deploy scripts `sh -n`: pass
- DB migration/cutover testはGitHub DB CIで実行

## Rollout
既に失敗したmigrationはtransaction rollbackされる前提で、同じ`219/main` deployを再実行します。Cutover完了前にApplication serviceは起動しません。