### PR TITLE
fix(kaede): /meのOpenAPI schema競合を解消

### DIFF
--- a/apps/kaede/src/schemas/auth.test.ts
+++ b/apps/kaede/src/schemas/auth.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { authMeResponseSchema } from './auth.js'
+
+describe('authMeResponseSchema', () => {
+  it('Membership直下にallowed_auth_methodsを持つ再認証待ちレスポンスを受理する', () => {
+    expect(
+      authMeResponseSchema.safeParse({
+        session_auth_method: 'oidc',
+        user: {
+          user_id: 'f5fe0359-75c5-4676-b0f3-8986319e18b2',
+          email: 'user@example.com',
+          display_name: 'User',
+          global_role: 'none',
+          status: 'active',
+          account_state: 'active',
+          password_changed_at: null,
+          memberships: [
+            {
+              membership_id: '6dc417b9-932d-47e4-a8eb-1e0f651bca28',
+              organization_id: '80f796d9-8fd3-49da-a4e5-efb34123263f',
+              organization_name: 'Organization',
+              organization_slug: 'organization',
+              role: 'owner',
+              status: 'active',
+              allowed_auth_methods: ['local', 'oidc'],
+              grant_state: {
+                status: 'reauthentication_required',
+                reason: 'grant_missing',
+                auth_method: null,
+                authenticated_at: null,
+                reauthentication_required_at: null,
+                expires_at: null,
+                effective_expires_at: null,
+              },
+            },
+          ],
+        },
+      }).success
+    ).toBe(true)
+  })
+})

--- a/apps/kaede/src/schemas/auth.ts
+++ b/apps/kaede/src/schemas/auth.ts
@@ -40,15 +40,19 @@ export const authMembershipSchema = z
   })
   .openapi('AuthMembership')
 
+const authUserBaseShape = {
+  user_id: uuidSchema,
+  email: z.string().email().max(255),
+  display_name: z.string().min(1).max(255),
+  global_role: z.enum(['none', 'admin']),
+  status: userStatusSchema,
+  account_state: accountStateSchema,
+  password_changed_at: isoDatetimeSchema.nullable(),
+}
+
 export const authUserSchema = z
   .object({
-    user_id: uuidSchema,
-    email: z.string().email().max(255),
-    display_name: z.string().min(1).max(255),
-    global_role: z.enum(['none', 'admin']),
-    status: userStatusSchema,
-    account_state: accountStateSchema,
-    password_changed_at: isoDatetimeSchema.nullable(),
+    ...authUserBaseShape,
     memberships: z.array(authMembershipSchema),
   })
   .openapi('AuthUser')
@@ -123,11 +127,17 @@ export const authMeMembershipSchema = z
   })
   .openapi('AuthMeMembership')
 
-export const authMeResponseSchema = authUserResponseSchema
-  .extend({
-    user: authUserSchema.extend({
-      memberships: z.array(authMeMembershipSchema),
-    }),
+export const authMeUserSchema = z
+  .object({
+    ...authUserBaseShape,
+    memberships: z.array(authMeMembershipSchema),
+  })
+  .openapi('AuthMeUser')
+
+export const authMeResponseSchema = z
+  .object({
+    session_auth_method: authUserResponseSchema.shape.session_auth_method,
+    user: authMeUserSchema,
   })
   .openapi('AuthMeResponse')
 


### PR DESCRIPTION
## 概要

`AuthMeResponse` が旧 `AuthUserResponse` をOpenAPI上で継承し、Membershipの旧形式と新形式を同時に要求していた問題を修正します。

## 変更内容

- `/me` 用User schemaを独立定義
- `AuthMeResponse`から旧Membership schemaとのintersectionを除去
- 実際の `grant_missing` responseを受理するschema testを追加

## 確認

- Prettier / ESLint: passed
- schema test: passed
- TypeScript: passed