### PR TITLE
feat: implement multi-organization auth flow

### DIFF
--- a/apps/kaede/src/config/runtime.test.ts
+++ b/apps/kaede/src/config/runtime.test.ts
@@ -13,6 +13,7 @@ const originalStateCookieSecret = process.env.OIDC_STATE_COOKIE_SECRET
 const originalPasswordLoginEnabled = process.env.PASSWORD_LOGIN_ENABLED
 const originalOrganizationCreationRequestsEnabled =
   process.env.ORGANIZATION_CREATION_REQUESTS_ENABLED
+const originalMobileOidcRedirectUri = process.env.MOBILE_OIDC_REDIRECT_URI
 
 const restoreEnv = () => {
   if (originalAppEnv === undefined) {
@@ -47,6 +48,7 @@ const restoreEnv = () => {
     'ORGANIZATION_CREATION_REQUESTS_ENABLED',
     originalOrganizationCreationRequestsEnabled
   )
+  restoreOptionalEnv('MOBILE_OIDC_REDIRECT_URI', originalMobileOidcRedirectUri)
 
   resetRuntimeConfigForTests()
 }
@@ -165,6 +167,7 @@ describe('getOidcRuntimeConfig', () => {
       stateCookieSecret: 'state-cookie-secret',
       passwordLoginEnabled: false,
       organizationCreationRequestsEnabled: false,
+      mobileRedirectUri: 'https://ayumi.okarin.app/auth/callback',
     })
   })
 })

--- a/apps/kaede/src/config/runtime.ts
+++ b/apps/kaede/src/config/runtime.ts
@@ -44,6 +44,7 @@ export interface OidcRuntimeConfig {
   stateCookieSecret: string
   passwordLoginEnabled: boolean
   organizationCreationRequestsEnabled: boolean
+  mobileRedirectUri: string
 }
 
 export interface StorageRuntimeConfig {
@@ -210,6 +211,10 @@ export const getOidcRuntimeConfig = (): OidcRuntimeConfig => {
     stateCookieSecret: enabled ? getRequiredEnv('OIDC_STATE_COOKIE_SECRET') : '',
     passwordLoginEnabled,
     organizationCreationRequestsEnabled,
+    mobileRedirectUri: getOptionalEnv(
+      'MOBILE_OIDC_REDIRECT_URI',
+      'https://ayumi.okarin.app/auth/callback'
+    ),
   }
 
   return oidcRuntimeConfig

--- a/apps/kaede/src/routes/auth/cookie.ts
+++ b/apps/kaede/src/routes/auth/cookie.ts
@@ -8,14 +8,19 @@ export const getSessionTokenFromCookie = (c: Context): string | undefined => {
   return getCookie(c, sessionCookieName)
 }
 
-export const setSessionCookie = (c: Context, token: string) => {
+export const setSessionCookie = (c: Context, token: string, expiresAt?: Date | string) => {
   const runtimeConfig = getAppRuntimeConfig()
+  const expires = expiresAt ? new Date(expiresAt) : undefined
+  const maxAge = expires
+    ? Math.max(0, Math.floor((expires.getTime() - Date.now()) / 1000))
+    : undefined
 
   setCookie(c, sessionCookieName, token, {
     httpOnly: true,
     path: '/',
     sameSite: runtimeConfig.sessionCookieSameSite,
     secure: runtimeConfig.env !== 'local',
+    ...(maxAge !== undefined ? { maxAge } : {}),
   })
 }
 

--- a/apps/kaede/src/routes/auth/index.ts
+++ b/apps/kaede/src/routes/auth/index.ts
@@ -5,6 +5,7 @@ import { registerChangePasswordRoute } from './change-password.js'
 import { registerLoginRoute } from './login.js'
 import { registerLogoutRoute } from './logout.js'
 import { registerMeRoute } from './me.js'
+import { registerMobileSessionExchangeRoute } from './mobile-session-exchange.js'
 import { registerGoogleOidcCallbackRoute } from './oidc-google-callback.js'
 import { registerGoogleOidcLinkRoute } from './oidc-google-link.js'
 import { registerGoogleOidcLoginRoute } from './oidc-google-login.js'
@@ -20,3 +21,4 @@ registerActivationCompleteRoute(authRoutes)
 registerLogoutRoute(authRoutes)
 registerMeRoute(authRoutes)
 registerChangePasswordRoute(authRoutes)
+registerMobileSessionExchangeRoute(authRoutes)

--- a/apps/kaede/src/routes/auth/mobile-session-exchange.ts
+++ b/apps/kaede/src/routes/auth/mobile-session-exchange.ts
@@ -1,0 +1,61 @@
+import { createRoute, z } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { errorResponseSchema } from '../../schemas/common.js'
+import { rotateSessionToken } from '../../services/auth/index.js'
+import { consumeMobileSessionExchangeCode } from '../../services/mobile-session-exchange/index.js'
+import { setSessionCookie } from './cookie.js'
+
+const requestSchema = z
+  .object({
+    mobile_session_exchange_code: z.string().min(1).max(512),
+    code_verifier: z.string().min(43).max(128),
+  })
+  .openapi('MobileSessionExchangeRequest')
+
+export const registerMobileSessionExchangeRoute = (app: OpenAPIHono) => {
+  const route = createRoute({
+    method: 'post',
+    path: '/mobile/session/exchange',
+    tags: ['Auth'],
+    request: { body: { content: { 'application/json': { schema: requestSchema } } } },
+    responses: {
+      200: {
+        description: 'session cookie established',
+        content: { 'application/json': { schema: z.object({ ok: z.literal(true) }) } },
+      },
+      400: {
+        description: 'invalid mobile session exchange',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+    },
+  })
+
+  app.openapi(route, async (c) => {
+    const payload = c.req.valid('json')
+    const result = await consumeMobileSessionExchangeCode(
+      payload.mobile_session_exchange_code,
+      payload.code_verifier
+    )
+    if (!result) {
+      return c.json(
+        {
+          error_code: 'AUTH_MOBILE_SESSION_EXCHANGE_INVALID',
+          error_message: 'mobile session exchange is invalid',
+        },
+        400
+      )
+    }
+    const rotated = await rotateSessionToken(result.session.id)
+    if (!rotated) {
+      return c.json(
+        {
+          error_code: 'AUTH_MOBILE_SESSION_EXCHANGE_INVALID',
+          error_message: 'mobile session exchange is invalid',
+        },
+        400
+      )
+    }
+    setSessionCookie(c, rotated.token, rotated.session.expires_at)
+    return c.json({ ok: true as const }, 200)
+  })
+}

--- a/apps/kaede/src/routes/auth/mobile-session-exchange.ts
+++ b/apps/kaede/src/routes/auth/mobile-session-exchange.ts
@@ -2,7 +2,6 @@ import { createRoute, z } from '@hono/zod-openapi'
 import type { OpenAPIHono } from '@hono/zod-openapi'
 import { errorResponseSchema } from '../../schemas/common.js'
 import { rotateSessionToken } from '../../services/auth/index.js'
-import { consumeMobileSessionExchangeCode } from '../../services/mobile-session-exchange/index.js'
 import { setSessionCookie } from './cookie.js'
 
 const requestSchema = z
@@ -31,6 +30,10 @@ export const registerMobileSessionExchangeRoute = (app: OpenAPIHono) => {
   })
 
   app.openapi(route, async (c) => {
+    // Keep the database-backed exchange service out of auth route module initialization.
+    // This lets DB-free auth route tests register the route without DATABASE_URL.
+    const { consumeMobileSessionExchangeCode } =
+      await import('../../services/mobile-session-exchange/index.js')
     const payload = c.req.valid('json')
     const result = await consumeMobileSessionExchangeCode(
       payload.mobile_session_exchange_code,

--- a/apps/kaede/src/routes/auth/oidc-google-callback.ts
+++ b/apps/kaede/src/routes/auth/oidc-google-callback.ts
@@ -90,6 +90,14 @@ export const registerGoogleOidcCallbackRoute = (app: OpenAPIHono) => {
           302
         )
       }
+      if (result.value.mobileSessionExchangeCode && result.value.mobileRedirectUri) {
+        const mobileRedirect = new URL(result.value.mobileRedirectUri)
+        mobileRedirect.searchParams.set(
+          'mobile_session_exchange_code',
+          result.value.mobileSessionExchangeCode
+        )
+        return c.redirect(mobileRedirect.toString(), 302)
+      }
       if (result.value.sessionToken) setSessionCookie(c, result.value.sessionToken)
 
       return c.redirect(organizationCompletionUrl('success', result.value.return_to), 302)

--- a/apps/kaede/src/routes/organization-local-auth/local-login.ts
+++ b/apps/kaede/src/routes/organization-local-auth/local-login.ts
@@ -37,6 +37,16 @@ const localAuthError = (type: string) => {
         status: 403 as const,
         body: { error_code: type, error_message: 'user is disabled' },
       }
+    case 'AUTH_UNAUTHENTICATED':
+      return {
+        status: 401 as const,
+        body: { error_code: type, error_message: 'login required' },
+      }
+    case 'AUTH_SESSION_ALREADY_EXISTS':
+      return {
+        status: 409 as const,
+        body: { error_code: type, error_message: 'a valid session already exists' },
+      }
     case 'AUTH_CREDENTIAL_LOCKED':
       return {
         status: 429 as const,
@@ -84,6 +94,10 @@ export const registerLocalOrganizationLoginRoute = (app: OpenAPIHono) => {
         description: 'invalid credentials or session',
         content: { 'application/json': { schema: errorResponseSchema } },
       },
+      409: {
+        description: 'a valid session already exists',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
       403: {
         description: 'local authentication is not allowed',
         content: { 'application/json': { schema: errorResponseSchema } },
@@ -113,7 +127,7 @@ export const registerLocalOrganizationLoginRoute = (app: OpenAPIHono) => {
     }
 
     if (result.value.sessionToken) {
-      setSessionCookie(c, result.value.sessionToken)
+      setSessionCookie(c, result.value.sessionToken, result.value.session.expires_at)
     }
 
     return c.json(

--- a/apps/kaede/src/routes/organization-oidc-auth/start.ts
+++ b/apps/kaede/src/routes/organization-oidc-auth/start.ts
@@ -13,7 +13,13 @@ import { getSessionTokenFromCookie } from '../auth/cookie.js'
 
 const errorStatus = (type: string) => {
   if (type === 'INVITE_INVALID' || type === 'OIDC_PROVIDER_NOT_FOUND') return 404 as const
-  if (type === 'AUTH_SESSION_REQUIRED' || type.includes('SESSION_')) return 401 as const
+  if (type === 'AUTH_SESSION_ALREADY_EXISTS') return 409 as const
+  if (
+    type === 'AUTH_SESSION_REQUIRED' ||
+    type === 'AUTH_UNAUTHENTICATED' ||
+    type.includes('SESSION_')
+  )
+    return 401 as const
   return 403 as const
 }
 
@@ -39,6 +45,10 @@ export const registerOrganizationOidcStartRoute = (app: OpenAPIHono) => {
         description: 'OIDC not allowed',
         content: { 'application/json': { schema: errorResponseSchema } },
       },
+      409: {
+        description: 'a valid session already exists',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
       404: {
         description: 'provider or invite not found',
         content: { 'application/json': { schema: errorResponseSchema } },
@@ -54,6 +64,16 @@ export const registerOrganizationOidcStartRoute = (app: OpenAPIHono) => {
         403
       )
     }
+    const payload = c.req.valid('json')
+    if (payload.mobile && payload.mobile.redirect_uri !== config.mobileRedirectUri) {
+      return c.json(
+        {
+          error_code: 'AUTH_METHOD_NOT_ALLOWED',
+          error_message: 'mobile redirect URI is not allowed',
+        },
+        403
+      )
+    }
     const { organizationSlug, providerId } = c.req.valid('param')
     const client = new GoogleOidcClient({
       clientId: config.googleClientId,
@@ -64,7 +84,7 @@ export const registerOrganizationOidcStartRoute = (app: OpenAPIHono) => {
       organizationSlug,
       providerId,
       getSessionTokenFromCookie(c),
-      c.req.valid('json'),
+      payload,
       {
         client,
         configuredClientId: config.googleClientId,

--- a/apps/kaede/src/routes/organizations/index.ts
+++ b/apps/kaede/src/routes/organizations/index.ts
@@ -22,6 +22,8 @@ import { registerOrganizationMemberProfileRoutes } from './member-profiles.js'
 import { registerMembershipAdministrationRoutes } from './membership-administration.js'
 import { registerOrganizationOidcLinkRoutes } from './oidc-links.js'
 import { registerOrganizationOidcProviderRoutes } from './oidc-providers.js'
+import { registerOrganizationScopedPedestrianRoute } from './scoped-pedestrian.js'
+import { registerOrganizationScopedRecordingRoutes } from './scoped-recordings.js'
 
 export const organizationsRoutes = new OpenAPIHono()
 
@@ -48,3 +50,5 @@ registerMembershipAdministrationRoutes(organizationsRoutes)
 registerOrganizationOidcLinkRoutes(organizationsRoutes)
 registerOrganizationOidcProviderRoutes(organizationsRoutes)
 registerOrganizationInviteRoutes(organizationsRoutes)
+registerOrganizationScopedPedestrianRoute(organizationsRoutes)
+registerOrganizationScopedRecordingRoutes(organizationsRoutes)

--- a/apps/kaede/src/routes/organizations/scoped-pedestrian.ts
+++ b/apps/kaede/src/routes/organizations/scoped-pedestrian.ts
@@ -1,0 +1,56 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { requireRequestActor } from '../../middleware/request-actor-context.js'
+import type { RequestActorContext } from '../../middleware/request-actor-context.js'
+import { errorResponseSchema } from '../../schemas/common.js'
+import { organizationIdParamsSchema } from '../../schemas/organizations.js'
+import { pedestrianSchema } from '../../schemas/pedestrians.js'
+import { getMyPedestrianForOrganization } from '../../usecases/pedestrians/get-my-pedestrian.js'
+import { toGetMyPedestrianErrorResponse } from '../pedestrians/error.js'
+
+export const registerOrganizationScopedPedestrianRoute = (app: OpenAPIHono) => {
+  const route = createRoute({
+    method: 'get',
+    path: '/{organizationId}/pedestrians/me',
+    tags: ['Organization Pedestrians'],
+    description: '指定したOrganizationに属するログインUserのpedestrianを返す',
+    request: { params: organizationIdParamsSchema },
+    responses: {
+      200: {
+        description: 'linked pedestrian',
+        content: { 'application/json': { schema: pedestrianSchema } },
+      },
+      401: {
+        description: 'login required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      403: {
+        description: 'organization grant required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      404: {
+        description: 'resource not found',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+    },
+  })
+
+  app.openapi(route, async (c) => {
+    const { organizationId } = c.req.valid('param')
+    const result = await getMyPedestrianForOrganization(
+      requireRequestActor(c as RequestActorContext),
+      organizationId
+    )
+    if (!result.ok) {
+      const error = toGetMyPedestrianErrorResponse(result.error)
+      if (result.error.type === 'PEDESTRIAN_NOT_FOUND') {
+        return c.json(
+          { error_code: 'RESOURCE_NOT_FOUND', error_message: 'resource not found' },
+          404
+        )
+      }
+      return c.json(error.body, error.status)
+    }
+    return c.json(result.value, 200)
+  })
+}

--- a/apps/kaede/src/routes/organizations/scoped-recordings.ts
+++ b/apps/kaede/src/routes/organizations/scoped-recordings.ts
@@ -1,0 +1,175 @@
+import { createRoute } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { requireRequestActor } from '../../middleware/request-actor-context.js'
+import type { RequestActorContext } from '../../middleware/request-actor-context.js'
+import { errorResponseSchema } from '../../schemas/common.js'
+import { organizationIdParamsSchema } from '../../schemas/organizations.js'
+import {
+  initRecordingRequestSchema,
+  initRecordingResponseSchema,
+  recordingIdParamsSchema,
+  refreshUploadUrlsRequestSchema,
+  refreshUploadUrlsResponseSchema,
+  completeUploadResponseSchema,
+} from '../../schemas/recordings.js'
+import { completeUpload } from '../../usecases/recordings/complete-upload.js'
+import { initRecording } from '../../usecases/recordings/init-recording.js'
+import { refreshUploadUrls } from '../../usecases/recordings/refresh-upload-urls.js'
+import {
+  toInitRecordingErrorResponse,
+  toRefreshUploadUrlsErrorResponse,
+  toCompleteUploadErrorResponse,
+} from '../recordings/error.js'
+
+const notFound = () => ({
+  body: { error_code: 'RESOURCE_NOT_FOUND', error_message: 'resource not found' },
+  status: 404 as const,
+})
+
+const organizationRecordingParamsSchema = organizationIdParamsSchema.extend({
+  recordingId: recordingIdParamsSchema.shape.recordingId,
+})
+
+export const registerOrganizationScopedRecordingRoutes = (app: OpenAPIHono) => {
+  const initRoute = createRoute({
+    method: 'post',
+    path: '/{organizationId}/recordings/init',
+    tags: ['Organization Recordings'],
+    description: '指定したOrganizationにrecordingを作成する',
+    request: {
+      params: organizationIdParamsSchema,
+      body: { content: { 'application/json': { schema: initRecordingRequestSchema } } },
+    },
+    responses: {
+      201: {
+        description: 'recording created',
+        content: { 'application/json': { schema: initRecordingResponseSchema } },
+      },
+      401: {
+        description: 'login required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      403: {
+        description: 'organization grant required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      404: {
+        description: 'resource not found',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      409: {
+        description: 'resource organization mismatch',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+    },
+  })
+  app.openapi(initRoute, async (c) => {
+    const { organizationId } = c.req.valid('param')
+    const result = await initRecording(
+      requireRequestActor(c as RequestActorContext),
+      c.req.valid('json'),
+      organizationId
+    )
+    if (!result.ok) {
+      const error = toInitRecordingErrorResponse(result.error)
+      return c.json(error.body, error.status)
+    }
+    return c.json(result.value, 201)
+  })
+
+  const refreshRoute = createRoute({
+    method: 'post',
+    path: '/{organizationId}/recordings/{recordingId}/refresh-upload-urls',
+    tags: ['Organization Recordings'],
+    description: '指定したOrganizationのrecording upload URLを再発行する',
+    request: {
+      params: organizationRecordingParamsSchema,
+      body: { content: { 'application/json': { schema: refreshUploadUrlsRequestSchema } } },
+    },
+    responses: {
+      200: {
+        description: 'upload urls refreshed',
+        content: { 'application/json': { schema: refreshUploadUrlsResponseSchema } },
+      },
+      401: {
+        description: 'login required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      403: {
+        description: 'organization grant required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      404: {
+        description: 'resource not found',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      409: {
+        description: 'upload cannot be refreshed',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+    },
+  })
+  app.openapi(refreshRoute, async (c) => {
+    const params = c.req.valid('param')
+    const result = await refreshUploadUrls(
+      requireRequestActor(c as RequestActorContext),
+      { recordingId: params.recordingId },
+      c.req.valid('json'),
+      params.organizationId
+    )
+    if (!result.ok) {
+      if (result.error.type === 'RECORDING_NOT_FOUND') return c.json(notFound().body, 404)
+      const error = toRefreshUploadUrlsErrorResponse(result.error)
+      return c.json(error.body, error.status)
+    }
+    return c.json(result.value, 200)
+  })
+
+  const completeRoute = createRoute({
+    method: 'post',
+    path: '/{organizationId}/recordings/{recordingId}/complete-upload',
+    tags: ['Organization Recordings'],
+    description: '指定したOrganizationのrecording uploadを完了する',
+    request: { params: organizationRecordingParamsSchema },
+    responses: {
+      200: {
+        description: 'upload completed',
+        content: { 'application/json': { schema: completeUploadResponseSchema } },
+      },
+      401: {
+        description: 'login required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      403: {
+        description: 'organization grant required',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      404: {
+        description: 'resource not found',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      409: {
+        description: 'upload cannot be completed',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+      500: {
+        description: 'internal recording data error',
+        content: { 'application/json': { schema: errorResponseSchema } },
+      },
+    },
+  })
+  app.openapi(completeRoute, async (c) => {
+    const params = c.req.valid('param')
+    const result = await completeUpload(
+      requireRequestActor(c as RequestActorContext),
+      { recordingId: params.recordingId },
+      params.organizationId
+    )
+    if (!result.ok) {
+      if (result.error.type === 'RECORDING_NOT_FOUND') return c.json(notFound().body, 404)
+      const error = toCompleteUploadErrorResponse(result.error)
+      return c.json(error.body, error.status)
+    }
+    return c.json(result.value, 200)
+  })
+}

--- a/apps/kaede/src/routes/recordings/error.ts
+++ b/apps/kaede/src/routes/recordings/error.ts
@@ -75,6 +75,11 @@ export const toInitRecordingErrorResponse = (error: InitRecordingError) => {
     case 'AUTH_DASHBOARD_FORBIDDEN':
     case 'AUTH_ORGANIZATION_FORBIDDEN':
       return toAuthorizationErrorResponse(error)
+    case 'RESOURCE_NOT_FOUND':
+      return {
+        body: { error_code: 'RESOURCE_NOT_FOUND', error_message: 'resource not found' },
+        status: 404 as const,
+      }
     case 'PEDESTRIAN_NOT_FOUND':
       return {
         body: {

--- a/apps/kaede/src/schemas/organization-local-auth.ts
+++ b/apps/kaede/src/schemas/organization-local-auth.ts
@@ -2,22 +2,25 @@ import { z } from '@hono/zod-openapi'
 import { isoDatetimeSchema, membershipRoleSchema, uuidSchema } from './common.js'
 import { organizationSlugSchema } from './organizations.js'
 
+const safeReturnToSchema = z
+  .string()
+  .min(1)
+  .max(2048)
+  .refine(
+    (value) => value.startsWith('/') && !value.startsWith('//') && !value.includes('\\'),
+    'return_to must be a safe application-relative path'
+  )
+
 export const organizationLocalAuthParamsSchema = z
   .object({ organizationSlug: organizationSlugSchema })
   .openapi('OrganizationLocalAuthParams')
 
 export const localOrganizationLoginRequestSchema = z
   .object({
+    intent: z.enum(['login', 'reauthenticate']).optional(),
     login_email: z.string().email().max(255),
     password: z.string().min(1).max(100),
-    return_to: z
-      .string()
-      .min(1)
-      .max(2048)
-      .refine(
-        (value) => value.startsWith('/') && !value.startsWith('//') && !value.includes('\\'),
-        'return_to must be a safe application-relative path'
-      ),
+    return_to: safeReturnToSchema.optional(),
   })
   .openapi('LocalOrganizationLoginRequest')
 
@@ -35,7 +38,7 @@ export const localOrganizationLoginResponseSchema = z
       authenticated_at: isoDatetimeSchema,
       expires_at: isoDatetimeSchema,
     }),
-    return_to: localOrganizationLoginRequestSchema.shape.return_to,
+    return_to: safeReturnToSchema,
   })
   .openapi('LocalOrganizationLoginResponse')
 

--- a/apps/kaede/src/schemas/organization-oidc-auth.ts
+++ b/apps/kaede/src/schemas/organization-oidc-auth.ts
@@ -26,7 +26,17 @@ export const organizationOidcStartParamsSchema = z.object({
 export const organizationOidcStartRequestSchema = z
   .object({
     intent: oidcIntentSchema,
-    return_to: safeReturnToSchema,
+    return_to: safeReturnToSchema.optional(),
+    mobile: z
+      .object({
+        redirect_uri: z.string().url(),
+        code_challenge: z
+          .string()
+          .length(43)
+          .regex(/^[A-Za-z0-9_-]+$/),
+        code_challenge_method: z.literal('S256'),
+      })
+      .optional(),
     invite_token: z.string().min(1).optional(),
   })
   .superRefine((value, context) => {
@@ -42,6 +52,28 @@ export const organizationOidcStartRequestSchema = z
         code: z.ZodIssueCode.custom,
         message: 'invite_token is only allowed for accept_invite',
         path: ['invite_token'],
+      })
+    }
+    const isMobileIntent = value.intent === 'login' || value.intent === 'reauthenticate'
+    if (isMobileIntent && !value.return_to && !value.mobile) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'return_to or mobile is required',
+        path: ['return_to'],
+      })
+    }
+    if (value.mobile && !isMobileIntent) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'mobile is only allowed for login or reauthenticate',
+        path: ['mobile'],
+      })
+    }
+    if (value.mobile && value.return_to) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'return_to cannot be combined with mobile',
+        path: ['return_to'],
       })
     }
   })

--- a/apps/kaede/src/services/auth/index.ts
+++ b/apps/kaede/src/services/auth/index.ts
@@ -17,9 +17,11 @@ export {
   createSession,
   findSessionByToken,
   findValidSessionByToken,
+  findValidSessionById,
   revokeAllSessionsByUserId,
   revokeSessionByToken,
   updateSessionLastSeen,
+  rotateSessionToken,
 } from './session-repository.js'
 export type { CreateSessionParams, CreateSessionResult, Session } from './session-repository.js'
 export { generateSessionToken, hashSessionToken } from './session-token.js'

--- a/apps/kaede/src/services/auth/session-repository.ts
+++ b/apps/kaede/src/services/auth/session-repository.ts
@@ -117,6 +117,20 @@ export const findValidSessionByToken = async (
   }
 }
 
+export const findValidSessionById = async (
+  sessionId: string,
+  now: Date = new Date(),
+  executor: DbExecutor = db
+): Promise<Session | undefined> => {
+  return executor
+    .selectFrom('sessions')
+    .selectAll()
+    .where('id', '=', sessionId)
+    .where('revoked_at', 'is', null)
+    .where('expires_at', '>', now)
+    .executeTakeFirst()
+}
+
 export const revokeSessionByToken = async (
   token: string,
   revokedAt: Date = new Date(),
@@ -166,4 +180,20 @@ export const updateSessionLastSeen = async (
     .where('id', '=', sessionId)
     .returningAll()
     .executeTakeFirst()
+}
+
+export const rotateSessionToken = async (
+  sessionId: string,
+  executor: DbExecutor = db
+): Promise<{ token: string; session: Session } | undefined> => {
+  const token = generateSessionToken()
+  const session = await executor
+    .updateTable('sessions')
+    .set({ session_hash: hashSessionToken(token) })
+    .where('id', '=', sessionId)
+    .where('revoked_at', 'is', null)
+    .where('expires_at', '>', new Date())
+    .returningAll()
+    .executeTakeFirst()
+  return session ? { token, session } : undefined
 }

--- a/apps/kaede/src/services/db/generated.ts
+++ b/apps/kaede/src/services/db/generated.ts
@@ -149,6 +149,23 @@ export interface OidcLoginTransactions {
   return_to: string
   session_id: string | null
   state_hash: string
+  expected_user_id: string | null
+  mobile_redirect_uri: string | null
+  mobile_code_challenge: string | null
+  mobile_code_challenge_method: string | null
+}
+
+export interface MobileSessionExchangeCodes {
+  id: Generated<string>
+  code_hash: string
+  oidc_transaction_id: string
+  session_id: string
+  user_id: string
+  organization_id: string
+  intent: string
+  expires_at: Timestamp
+  consumed_at: Timestamp | null
+  created_at: Generated<Timestamp>
 }
 
 export interface OrganizationAuthSettings {
@@ -390,6 +407,7 @@ export interface DB {
   floors: Floors
   oidc_identities: OidcIdentities
   oidc_login_transactions: OidcLoginTransactions
+  mobile_session_exchange_codes: MobileSessionExchangeCodes
   organization_auth_settings: OrganizationAuthSettings
   organization_creation_requests: OrganizationCreationRequests
   organization_invite_redemptions: OrganizationInviteRedemptions

--- a/apps/kaede/src/services/floors/floor-repository.ts
+++ b/apps/kaede/src/services/floors/floor-repository.ts
@@ -51,6 +51,7 @@ const floorRowsQuery = () =>
       'floors.created_at',
       'floors.updated_at',
     ])
+    .whereRef('buildings.organization_id', '=', 'floors.organization_id')
 
 export const listFloors = async ({ buildingIds, organizationIds }: ListFloorsOptions = {}) => {
   if (buildingIds?.length === 0 || organizationIds?.length === 0) {

--- a/apps/kaede/src/services/mobile-session-exchange/index.ts
+++ b/apps/kaede/src/services/mobile-session-exchange/index.ts
@@ -1,0 +1,84 @@
+import { createHash, randomBytes } from 'node:crypto'
+import { createPkceCodeChallenge, findValidSessionById } from '../auth/index.js'
+import { db } from '../db/index.js'
+import type { DbExecutor } from '../executor.js'
+
+const CODE_TTL_MS = 60 * 1000
+
+const hashExchangeCode = (code: string) => createHash('sha256').update(code).digest('base64url')
+
+export const issueMobileSessionExchangeCode = async (
+  input: {
+    oidcTransactionId: string
+    sessionId: string
+    userId: string
+    organizationId: string
+    intent: 'login' | 'reauthenticate'
+    now: Date
+  },
+  executor: DbExecutor = db
+) => {
+  const code = randomBytes(32).toString('base64url')
+  await executor
+    .insertInto('mobile_session_exchange_codes')
+    .values({
+      code_hash: hashExchangeCode(code),
+      oidc_transaction_id: input.oidcTransactionId,
+      session_id: input.sessionId,
+      user_id: input.userId,
+      organization_id: input.organizationId,
+      intent: input.intent,
+      expires_at: new Date(input.now.getTime() + CODE_TTL_MS),
+      consumed_at: null,
+    })
+    .executeTakeFirstOrThrow()
+  return code
+}
+
+export const consumeMobileSessionExchangeCode = async (
+  code: string,
+  verifier: string,
+  now: Date = new Date(),
+  executor: DbExecutor = db
+) => {
+  const row = await executor
+    .selectFrom('mobile_session_exchange_codes as exchange')
+    .innerJoin(
+      'oidc_login_transactions as transaction',
+      'transaction.id',
+      'exchange.oidc_transaction_id'
+    )
+    .select([
+      'exchange.id',
+      'exchange.session_id',
+      'exchange.user_id',
+      'exchange.expires_at',
+      'exchange.consumed_at',
+      'transaction.mobile_code_challenge as code_challenge',
+      'transaction.mobile_code_challenge_method as code_challenge_method',
+    ])
+    .where('exchange.code_hash', '=', hashExchangeCode(code))
+    .executeTakeFirst()
+
+  if (!row || row.consumed_at || row.expires_at <= now || row.code_challenge_method !== 'S256') {
+    return undefined
+  }
+  if (createPkceCodeChallenge(verifier) !== row.code_challenge) return undefined
+
+  const session = await findValidSessionById(row.session_id, now, executor)
+  if (!session) return undefined
+
+  const consumed = await executor
+    .updateTable('mobile_session_exchange_codes')
+    .set({ consumed_at: now })
+    .where('id', '=', row.id)
+    .where('consumed_at', 'is', null)
+    .where('expires_at', '>', now)
+    .returning(['id'])
+    .executeTakeFirst()
+  if (!consumed) return undefined
+
+  return { session: session, userId: row.user_id }
+}
+
+export { hashExchangeCode }

--- a/apps/kaede/src/services/pedestrians/index.ts
+++ b/apps/kaede/src/services/pedestrians/index.ts
@@ -1,5 +1,6 @@
 export {
   findPedestrianById,
+  findPedestrianByUserIdAndOrganizationId,
   findPedestrianByUserId,
   insertPedestrian,
   listPedestrians,

--- a/apps/kaede/src/services/pedestrians/pedestrian-repository.ts
+++ b/apps/kaede/src/services/pedestrians/pedestrian-repository.ts
@@ -60,3 +60,24 @@ export const findPedestrianByUserId = async (
     .where('user_id', '=', userId)
     .executeTakeFirst()
 }
+
+export const findPedestrianByUserIdAndOrganizationId = async (
+  userId: string,
+  organizationId: string,
+  executor: DbExecutor = db
+): Promise<Pedestrian | undefined> => {
+  return executor
+    .selectFrom('pedestrians as pedestrian')
+    .innerJoin('organization_memberships as membership', (join) =>
+      join
+        .onRef('membership.id', '=', 'pedestrian.membership_id')
+        .onRef('membership.organization_id', '=', 'pedestrian.organization_id')
+    )
+    .selectAll('pedestrian')
+    .where('pedestrian.user_id', '=', userId)
+    .where('pedestrian.organization_id', '=', organizationId)
+    .where('membership.user_id', '=', userId)
+    .where('membership.organization_id', '=', organizationId)
+    .where('membership.status', '=', 'active')
+    .executeTakeFirst()
+}

--- a/apps/kaede/src/services/recordings/index.ts
+++ b/apps/kaede/src/services/recordings/index.ts
@@ -1,6 +1,8 @@
 export {
   findRecordingAuthorizationById,
+  findRecordingAuthorizationByIdForOrganization,
   findRecordingById,
+  findRecordingByIdForOrganization,
   insertRecording,
   listRecordingsByOrganizationIdPaginated,
   listRecordingsByPedestrianIdPaginated,

--- a/apps/kaede/src/services/recordings/recording-repository.ts
+++ b/apps/kaede/src/services/recordings/recording-repository.ts
@@ -44,6 +44,24 @@ export const findRecordingById = async (
     .executeTakeFirst()
 }
 
+export const findRecordingByIdForOrganization = async (
+  recordingId: string,
+  organizationId: string,
+  executor: DbExecutor = db
+): Promise<Recording | undefined> => {
+  return executor
+    .selectFrom('recordings as recording')
+    .innerJoin('pedestrians as pedestrian', 'pedestrian.id', 'recording.pedestrian_id')
+    .innerJoin('floors as floor', 'floor.id', 'recording.floor_id')
+    .selectAll('recording')
+    .where('recording.id', '=', recordingId)
+    .where('recording.deleted_at', 'is', null)
+    .where('recording.organization_id', '=', organizationId)
+    .where('pedestrian.organization_id', '=', organizationId)
+    .where('floor.organization_id', '=', organizationId)
+    .executeTakeFirst()
+}
+
 export const listRecordingsByOrganizationIdPaginated = async (
   organizationId: string,
   options: PaginationOptions,
@@ -131,6 +149,27 @@ export const findRecordingAuthorizationById = async (
       'pedestrians.user_id as pedestrian_user_id',
     ])
     .where('recordings.id', '=', recordingId)
+    .executeTakeFirst()
+}
+
+export const findRecordingAuthorizationByIdForOrganization = async (
+  recordingId: string,
+  organizationId: string,
+  executor: DbExecutor = db
+): Promise<RecordingAuthorizationRow | undefined> => {
+  return activeRecordingsQuery(executor)
+    .innerJoin('pedestrians', 'pedestrians.id', 'recordings.pedestrian_id')
+    .innerJoin('floors', 'floors.id', 'recordings.floor_id')
+    .select([
+      'recordings.id as id',
+      'recordings.organization_id as organization_id',
+      'recordings.pedestrian_id as pedestrian_id',
+      'pedestrians.user_id as pedestrian_user_id',
+    ])
+    .where('recordings.id', '=', recordingId)
+    .where('recordings.organization_id', '=', organizationId)
+    .where('pedestrians.organization_id', '=', organizationId)
+    .where('floors.organization_id', '=', organizationId)
     .executeTakeFirst()
 }
 

--- a/apps/kaede/src/usecases/organization-local-auth/login.ts
+++ b/apps/kaede/src/usecases/organization-local-auth/login.ts
@@ -24,6 +24,8 @@ export type LocalOrganizationLoginError =
   | { type: 'AUTH_IDENTITY_USER_MISMATCH' }
   | { type: 'AUTH_MEMBERSHIP_NOT_ACTIVE' }
   | { type: 'AUTH_USER_DISABLED' }
+  | { type: 'AUTH_UNAUTHENTICATED' }
+  | { type: 'AUTH_SESSION_ALREADY_EXISTS' }
   | { type: 'AUTH_SESSION_EXPIRED' }
   | { type: 'AUTH_SESSION_REVOKED' }
 
@@ -76,7 +78,7 @@ const sessionError = (
     case 'SESSION_REVOKED':
       return { type: 'AUTH_SESSION_REVOKED' }
     case 'SESSION_NOT_FOUND':
-      return { type: 'AUTH_INVALID_CREDENTIALS' }
+      return { type: 'AUTH_UNAUTHENTICATED' }
   }
 }
 
@@ -89,10 +91,24 @@ export const loginToOrganizationWithLocalCredential = async (
   executor?: DbExecutor
 ): Promise<LocalOrganizationLoginResult> => {
   return runInTransaction(executor, async (trx) => {
+    const intent = payload.intent ?? (sessionToken ? 'reauthenticate' : 'login')
     const policy = await findOrganizationLocalAuthPolicyBySlug(organizationSlug, trx)
 
     if (!policy?.local_auth_enabled || policy.organization_status !== 'active') {
       return { ok: false, error: { type: 'AUTH_METHOD_NOT_ALLOWED' } } as const
+    }
+
+    let existingSession: Awaited<ReturnType<typeof findValidSessionByToken>> | undefined
+    if (sessionToken) {
+      existingSession = await findValidSessionByToken(sessionToken, now, trx)
+      if (intent === 'reauthenticate' && !existingSession.ok) {
+        return { ok: false, error: sessionError(existingSession.error) } as const
+      }
+      if (intent === 'login' && existingSession.ok) {
+        return { ok: false, error: { type: 'AUTH_SESSION_ALREADY_EXISTS' } } as const
+      }
+    } else if (intent === 'reauthenticate') {
+      return { ok: false, error: { type: 'AUTH_UNAUTHENTICATED' } } as const
     }
 
     const normalizedLoginEmail = normalizeLocalLoginEmail(payload.login_email)
@@ -119,7 +135,7 @@ export const loginToOrganizationWithLocalCredential = async (
       return { ok: false, error: { type: 'AUTH_INVALID_CREDENTIALS' } } as const
     }
 
-    const eventType = sessionToken ? 'local_reauthenticate' : 'local_login'
+    const eventType = intent === 'reauthenticate' ? 'local_reauthenticate' : 'local_login'
     const eventContext = {
       event_type: eventType,
       user_id: credential.user_id,
@@ -181,16 +197,15 @@ export const loginToOrganizationWithLocalCredential = async (
     let activeSession
     let createdSessionToken: string | undefined
 
-    if (sessionToken) {
-      const sessionResult = await findValidSessionByToken(sessionToken, now, trx)
-      if (!sessionResult.ok) {
-        return { ok: false, error: sessionError(sessionResult.error) } as const
+    if (intent === 'reauthenticate') {
+      if (!existingSession?.ok) {
+        return { ok: false, error: { type: 'AUTH_UNAUTHENTICATED' } } as const
       }
-      if (sessionResult.session.user_id !== credential.user_id) {
+      if (existingSession.session.user_id !== credential.user_id) {
         await insertAuthenticationEvent(
           {
             ...eventContext,
-            session_id: sessionResult.session.id,
+            session_id: existingSession.session.id,
             outcome: 'failure',
             failure_code: 'AUTH_IDENTITY_USER_MISMATCH',
           },
@@ -198,7 +213,7 @@ export const loginToOrganizationWithLocalCredential = async (
         )
         return { ok: false, error: { type: 'AUTH_IDENTITY_USER_MISMATCH' } } as const
       }
-      activeSession = sessionResult.session
+      activeSession = existingSession.session
     } else {
       const created = await createSession(
         { authMethod: 'password', userId: credential.user_id, now },
@@ -261,7 +276,7 @@ export const loginToOrganizationWithLocalCredential = async (
           authenticated_at: grant.authenticated_at.toISOString(),
           expires_at: grant.expires_at.toISOString(),
         },
-        return_to: payload.return_to,
+        return_to: payload.return_to ?? '/',
       },
     }
   })

--- a/apps/kaede/src/usecases/organization-oidc-auth/callback.ts
+++ b/apps/kaede/src/usecases/organization-oidc-auth/callback.ts
@@ -2,6 +2,7 @@ import type { GoogleIdTokenClaims } from '../../services/auth/index.js'
 import { createSession, findValidSessionByToken } from '../../services/auth/index.js'
 import { db } from '../../services/db/index.js'
 import type { DbExecutor } from '../../services/executor.js'
+import { issueMobileSessionExchangeCode } from '../../services/mobile-session-exchange/index.js'
 import {
   canonicalizeOidcIssuer,
   claimOidcLoginTransaction,
@@ -81,6 +82,8 @@ export type CompleteOrganizationOidcResult =
       value: {
         return_to: string
         sessionToken?: string
+        mobileSessionExchangeCode?: string
+        mobileRedirectUri?: string
       }
     }
   | {
@@ -319,16 +322,15 @@ export const completeOrganizationOidc = async (
     let session
     let createdSessionToken: string | undefined
     if (transaction.intent === 'reauthenticate') {
-      if (!transaction.session_id || !options.sessionToken) {
+      if (!transaction.session_id) {
         return {
           ok: false,
           error: { type: 'AUTH_SESSION_REQUIRED' },
           return_to: transaction.return_to,
         } as const
       }
-      const cookieSession = await findValidSessionByToken(options.sessionToken, now, trx)
       const transactionSession = await findValidSessionById(transaction.session_id, now, trx)
-      if (!cookieSession.ok || cookieSession.session.id !== transactionSession?.id) {
+      if (transaction.expected_user_id !== transactionSession?.user_id) {
         return {
           ok: false,
           error: { type: 'AUTH_SESSION_REQUIRED' },
@@ -395,11 +397,27 @@ export const completeOrganizationOidc = async (
       trx
     )
 
+    const mobileSessionExchangeCode = transaction.mobile_redirect_uri
+      ? await issueMobileSessionExchangeCode(
+          {
+            oidcTransactionId: transaction.id,
+            sessionId: session.id,
+            userId: identity.user_id,
+            organizationId: provider.organization_id,
+            intent: transaction.intent as 'login' | 'reauthenticate',
+            now,
+          },
+          trx
+        )
+      : undefined
+
     return {
       ok: true,
       value: {
         return_to: transaction.return_to,
-        sessionToken: createdSessionToken,
+        sessionToken: transaction.mobile_redirect_uri ? undefined : createdSessionToken,
+        mobileSessionExchangeCode,
+        mobileRedirectUri: transaction.mobile_redirect_uri ?? undefined,
       },
     } as const
   })

--- a/apps/kaede/src/usecases/organization-oidc-auth/start.ts
+++ b/apps/kaede/src/usecases/organization-oidc-auth/start.ts
@@ -36,6 +36,8 @@ export interface StartOrganizationOidcOptions {
 export type StartOrganizationOidcError =
   | { type: 'AUTH_METHOD_NOT_ALLOWED' }
   | { type: 'AUTH_SESSION_REQUIRED' }
+  | { type: 'AUTH_UNAUTHENTICATED' }
+  | { type: 'AUTH_SESSION_ALREADY_EXISTS' }
   | { type: 'AUTH_SESSION_EXPIRED' }
   | { type: 'AUTH_SESSION_REVOKED' }
   | { type: 'AUTH_MEMBERSHIP_NOT_ACTIVE' }
@@ -95,12 +97,15 @@ export const startOrganizationOidc = async (
     if (sessionToken) {
       const session = await findValidSessionByToken(sessionToken, now, trx)
       if (!session.ok) return { ok: false, error: mapSessionError(session.error) } as const
+      if (payload.intent === 'login') {
+        return { ok: false, error: { type: 'AUTH_SESSION_ALREADY_EXISTS' } } as const
+      }
       sessionId = session.session.id
       sessionUserId = session.session.user_id
     }
     if (payload.intent === 'reauthenticate' || payload.intent === 'link_identity') {
       if (!sessionId || !sessionUserId) {
-        return { ok: false, error: { type: 'AUTH_SESSION_REQUIRED' } } as const
+        return { ok: false, error: { type: 'AUTH_UNAUTHENTICATED' } } as const
       }
       const membership = await findActiveMembershipByOrganizationAndUser(
         provider.organization_id,
@@ -168,7 +173,11 @@ export const startOrganizationOidc = async (
           codeVerifier,
           options.transactionSecret
         ),
-        return_to: payload.return_to,
+        return_to: payload.return_to ?? '/',
+        expected_user_id: payload.intent === 'reauthenticate' ? sessionUserId : null,
+        mobile_redirect_uri: payload.mobile?.redirect_uri ?? null,
+        mobile_code_challenge: payload.mobile?.code_challenge ?? null,
+        mobile_code_challenge_method: payload.mobile?.code_challenge_method ?? null,
         expires_at: new Date(now.getTime() + OIDC_TRANSACTION_TTL_MS),
         consumed_at: null,
       },

--- a/apps/kaede/src/usecases/organizations/index.ts
+++ b/apps/kaede/src/usecases/organizations/index.ts
@@ -315,6 +315,68 @@ const requireOrganizationManagerOrAdmin = async (
   }
 }
 
+const requireOrganizationMemberOrAdmin = async (
+  sessionToken: string | undefined,
+  organizationId: string,
+  executor?: DbExecutor
+): Promise<
+  OrganizationResult<{
+    userId: string
+    globalRole: 'none' | 'admin'
+    membershipRole: string | null
+  }>
+> => {
+  const actor = await requireActiveSessionUser(sessionToken, executor)
+
+  if (!actor.ok) {
+    return {
+      ok: false,
+      error: mapAuthError(actor.error),
+    }
+  }
+
+  const organization = await findOrganizationById(organizationId, executor)
+
+  if (!organization) {
+    return {
+      ok: false,
+      error: { type: 'ORGANIZATION_NOT_FOUND' },
+    }
+  }
+
+  if (actor.value.global_role === 'admin') {
+    return {
+      ok: true,
+      value: {
+        userId: actor.value.id,
+        globalRole: 'admin',
+        membershipRole: null,
+      },
+    }
+  }
+
+  const membership = await findOrganizationMembership(organizationId, actor.value.id, executor)
+
+  if (
+    membership?.status !== 'active' ||
+    (membership.role !== 'member' && membership.role !== 'manager' && membership.role !== 'owner')
+  ) {
+    return {
+      ok: false,
+      error: { type: 'AUTH_FORBIDDEN' },
+    }
+  }
+
+  return {
+    ok: true,
+    value: {
+      userId: actor.value.id,
+      globalRole: 'none',
+      membershipRole: membership.role,
+    },
+  }
+}
+
 export const listOrganizationsForSession = async (
   sessionToken: string | undefined,
   executor?: DbExecutor
@@ -516,7 +578,7 @@ export const listOrganizationFloorsForSession = async (
   organizationId: string,
   executor?: DbExecutor
 ): Promise<OrganizationResult<{ floors: FloorResponse[] }>> => {
-  const actor = await requireOrganizationManagerOrAdmin(sessionToken, organizationId, executor)
+  const actor = await requireOrganizationMemberOrAdmin(sessionToken, organizationId, executor)
 
   if (!actor.ok) {
     return actor

--- a/apps/kaede/src/usecases/pedestrians/get-my-pedestrian.ts
+++ b/apps/kaede/src/usecases/pedestrians/get-my-pedestrian.ts
@@ -1,6 +1,9 @@
 import type { RequestActor } from '../../middleware/request-actor-context.js'
 import type { PedestrianResponse } from '../../schemas/pedestrians.js'
-import { findPedestrianByUserId } from '../../services/pedestrians/index.js'
+import {
+  findPedestrianByUserId,
+  findPedestrianByUserIdAndOrganizationId,
+} from '../../services/pedestrians/index.js'
 import type { AuthorizationError } from '../authorization.js'
 import { toPedestrianResponse } from './pedestrian-response.js'
 
@@ -23,6 +26,32 @@ export const getMyPedestrian = async (actor: RequestActor): Promise<GetMyPedestr
   }
 
   const pedestrian = await findPedestrianByUserId(actor.user_id)
+
+  if (!pedestrian) {
+    return {
+      ok: false,
+      error: { type: 'PEDESTRIAN_NOT_FOUND' },
+    }
+  }
+
+  return {
+    ok: true,
+    value: toPedestrianResponse(pedestrian),
+  }
+}
+
+export const getMyPedestrianForOrganization = async (
+  actor: RequestActor,
+  organizationId: string
+): Promise<GetMyPedestrianResult> => {
+  if (actor.type === 'service_client') {
+    return {
+      ok: false,
+      error: { type: 'AUTH_ORGANIZATION_FORBIDDEN' },
+    }
+  }
+
+  const pedestrian = await findPedestrianByUserIdAndOrganizationId(actor.user_id, organizationId)
 
   if (!pedestrian) {
     return {

--- a/apps/kaede/src/usecases/recordings/complete-upload.ts
+++ b/apps/kaede/src/usecases/recordings/complete-upload.ts
@@ -4,7 +4,9 @@ import type { UploadTarget } from '../../schemas/common.js'
 import type { RecordingIdParams } from '../../schemas/recordings.js'
 import {
   findRecordingAuthorizationById,
+  findRecordingAuthorizationByIdForOrganization,
   findRecordingById,
+  findRecordingByIdForOrganization,
   markRecordingUploadReady,
 } from '../../services/recordings/index.js'
 import {
@@ -51,9 +53,12 @@ export type CompleteUploadResult =
 
 export const completeUpload = async (
   actor: RequestActor,
-  params: RecordingIdParams
+  params: RecordingIdParams,
+  organizationId?: string
 ): Promise<CompleteUploadResult> => {
-  const recording = await findRecordingById(params.recordingId)
+  const recording = organizationId
+    ? await findRecordingByIdForOrganization(params.recordingId, organizationId)
+    : await findRecordingById(params.recordingId)
 
   if (!recording) {
     return {
@@ -65,7 +70,9 @@ export const completeUpload = async (
     }
   }
 
-  const recordingAuthorization = await findRecordingAuthorizationById(recording.id)
+  const recordingAuthorization = organizationId
+    ? await findRecordingAuthorizationByIdForOrganization(recording.id, organizationId)
+    : await findRecordingAuthorizationById(recording.id)
 
   if (!recordingAuthorization) {
     return {

--- a/apps/kaede/src/usecases/recordings/init-recording.ts
+++ b/apps/kaede/src/usecases/recordings/init-recording.ts
@@ -13,6 +13,10 @@ import { requireRecordingAccess } from '../authorization.js'
 export type InitRecordingError =
   | AuthorizationError
   | {
+      type: 'RESOURCE_NOT_FOUND'
+      resourceId: string
+    }
+  | {
       type: 'PEDESTRIAN_NOT_FOUND'
       pedestrianId: string
     }
@@ -63,7 +67,11 @@ const throwOrganizationInvariantError = (message: string): never => {
   throw error
 }
 
-export const initRecording = async (actor: RequestActor, payload: InitRecordingRequest) => {
+export const initRecording = async (
+  actor: RequestActor,
+  payload: InitRecordingRequest,
+  organizationId?: string
+): Promise<InitRecordingResult> => {
   const [pedestrian, floor] = await Promise.all([
     findPedestrianById(payload.pedestrian_id),
     findFloorById(payload.floor_id),
@@ -73,8 +81,9 @@ export const initRecording = async (actor: RequestActor, payload: InitRecordingR
     return {
       ok: false,
       error: {
-        type: 'PEDESTRIAN_NOT_FOUND',
-        pedestrianId: payload.pedestrian_id,
+        ...(organizationId
+          ? { type: 'RESOURCE_NOT_FOUND' as const, resourceId: payload.pedestrian_id }
+          : { type: 'PEDESTRIAN_NOT_FOUND' as const, pedestrianId: payload.pedestrian_id }),
       },
     } satisfies InitRecordingResult
   }
@@ -83,8 +92,9 @@ export const initRecording = async (actor: RequestActor, payload: InitRecordingR
     return {
       ok: false,
       error: {
-        type: 'FLOOR_NOT_FOUND',
-        floorId: payload.floor_id,
+        ...(organizationId
+          ? { type: 'RESOURCE_NOT_FOUND' as const, resourceId: payload.floor_id }
+          : { type: 'FLOOR_NOT_FOUND' as const, floorId: payload.floor_id }),
       },
     } satisfies InitRecordingResult
   }
@@ -95,6 +105,20 @@ export const initRecording = async (actor: RequestActor, payload: InitRecordingR
 
   if (!floor.organization_id) {
     throwOrganizationInvariantError(`floor ${floor.id} does not have organization_id`)
+  }
+
+  if (organizationId && pedestrian.organization_id !== organizationId) {
+    return {
+      ok: false,
+      error: { type: 'RESOURCE_NOT_FOUND', resourceId: payload.pedestrian_id },
+    } satisfies InitRecordingResult
+  }
+
+  if (organizationId && floor.organization_id !== organizationId) {
+    return {
+      ok: false,
+      error: { type: 'RESOURCE_NOT_FOUND', resourceId: payload.floor_id },
+    } satisfies InitRecordingResult
   }
 
   if (pedestrian.organization_id !== floor.organization_id) {

--- a/apps/kaede/src/usecases/recordings/refresh-upload-urls.ts
+++ b/apps/kaede/src/usecases/recordings/refresh-upload-urls.ts
@@ -4,7 +4,9 @@ import { recordingUploadStatusSchema } from '../../schemas/common.js'
 import type { RefreshUploadUrlsRequest, RecordingIdParams } from '../../schemas/recordings.js'
 import {
   findRecordingAuthorizationById,
+  findRecordingAuthorizationByIdForOrganization,
   findRecordingById,
+  findRecordingByIdForOrganization,
 } from '../../services/recordings/index.js'
 import { issueRecordingUploadUrls } from '../../services/storage/index.js'
 import type { AuthorizationError } from '../authorization.js'
@@ -50,9 +52,12 @@ export type RefreshUploadUrlsResult =
 export const refreshUploadUrls = async (
   actor: RequestActor,
   params: RecordingIdParams,
-  payload: RefreshUploadUrlsRequest
+  payload: RefreshUploadUrlsRequest,
+  organizationId?: string
 ) => {
-  const recording = await findRecordingById(params.recordingId)
+  const recording = organizationId
+    ? await findRecordingByIdForOrganization(params.recordingId, organizationId)
+    : await findRecordingById(params.recordingId)
 
   if (!recording) {
     return {
@@ -64,7 +69,9 @@ export const refreshUploadUrls = async (
     } satisfies RefreshUploadUrlsResult
   }
 
-  const recordingAuthorization = await findRecordingAuthorizationById(recording.id)
+  const recordingAuthorization = organizationId
+    ? await findRecordingAuthorizationByIdForOrganization(recording.id, organizationId)
+    : await findRecordingAuthorizationById(recording.id)
 
   if (!recordingAuthorization) {
     return {

--- a/apps/kaede/tests/services/auth/organization-oidc-auth.test.ts
+++ b/apps/kaede/tests/services/auth/organization-oidc-auth.test.ts
@@ -110,13 +110,14 @@ const linkIdentity = async (
 
 const startLogin = async (
   fixture: Awaited<ReturnType<typeof createFixture>>,
-  sessionToken?: string
+  sessionToken?: string,
+  intent: 'login' | 'reauthenticate' = 'login'
 ) => {
   const result = await startOrganizationOidc(
     fixture.organization.slug,
     fixture.provider.id,
     sessionToken,
-    { intent: 'login', return_to: '/orgs/oidc-organization' },
+    { intent, return_to: '/orgs/oidc-organization' },
     {
       client: {
         createAuthorizationUrl: ({ state }) =>
@@ -309,8 +310,12 @@ describe('organization OIDC authentication', () => {
     const fixture = await createFixture()
     await linkIdentity(fixture)
     const otherUser = await createUser('other-user@example.test')
+    await db
+      .insertInto('organization_memberships')
+      .values({ organization_id: fixture.organization.id, user_id: otherUser.id, role: 'member' })
+      .execute()
     const session = await createSession({ userId: otherUser.id, now }, db)
-    const state = await startLogin(fixture, session.token)
+    const state = await startLogin(fixture, session.token, 'reauthenticate')
 
     const result = await completeOrganizationOidc('authorization-code', state, {
       client: callbackClient(),

--- a/db/migrations/20260813010000_add_mobile_oidc_session_exchange.sql
+++ b/db/migrations/20260813010000_add_mobile_oidc_session_exchange.sql
@@ -1,0 +1,36 @@
+ALTER TABLE oidc_login_transactions
+  ADD COLUMN expected_user_id uuid,
+  ADD COLUMN mobile_redirect_uri text,
+  ADD COLUMN mobile_code_challenge text,
+  ADD COLUMN mobile_code_challenge_method text;
+
+ALTER TABLE oidc_login_transactions
+  ADD CONSTRAINT oidc_login_transactions_mobile_fields_chk CHECK (
+    (mobile_redirect_uri IS NULL AND mobile_code_challenge IS NULL AND mobile_code_challenge_method IS NULL)
+    OR (
+      mobile_redirect_uri IS NOT NULL
+      AND mobile_code_challenge IS NOT NULL
+      AND mobile_code_challenge_method = 'S256'
+    )
+  );
+
+CREATE TABLE mobile_session_exchange_codes (
+  id uuid DEFAULT gen_random_uuid() NOT NULL,
+  code_hash text NOT NULL,
+  oidc_transaction_id uuid NOT NULL,
+  session_id uuid NOT NULL,
+  user_id uuid NOT NULL,
+  organization_id uuid NOT NULL,
+  intent text NOT NULL,
+  expires_at timestamp with time zone NOT NULL,
+  consumed_at timestamp with time zone,
+  created_at timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT mobile_session_exchange_codes_hash_nonempty_chk CHECK (length(btrim(code_hash)) > 0),
+  CONSTRAINT mobile_session_exchange_codes_intent_chk CHECK (intent IN ('login', 'reauthenticate'))
+);
+
+CREATE UNIQUE INDEX mobile_session_exchange_codes_code_hash_idx
+  ON mobile_session_exchange_codes (code_hash);
+CREATE INDEX mobile_session_exchange_codes_expiry_idx
+  ON mobile_session_exchange_codes (expires_at)
+  WHERE consumed_at IS NULL;

--- a/db/migrations/20260813010000_add_mobile_oidc_session_exchange.sql
+++ b/db/migrations/20260813010000_add_mobile_oidc_session_exchange.sql
@@ -1,3 +1,5 @@
+-- migrate:up
+
 ALTER TABLE oidc_login_transactions
   ADD COLUMN expected_user_id uuid,
   ADD COLUMN mobile_redirect_uri text,
@@ -34,3 +36,16 @@ CREATE UNIQUE INDEX mobile_session_exchange_codes_code_hash_idx
 CREATE INDEX mobile_session_exchange_codes_expiry_idx
   ON mobile_session_exchange_codes (expires_at)
   WHERE consumed_at IS NULL;
+
+-- migrate:down
+
+DROP INDEX IF EXISTS mobile_session_exchange_codes_expiry_idx;
+DROP INDEX IF EXISTS mobile_session_exchange_codes_code_hash_idx;
+DROP TABLE IF EXISTS mobile_session_exchange_codes;
+
+ALTER TABLE oidc_login_transactions
+  DROP CONSTRAINT IF EXISTS oidc_login_transactions_mobile_fields_chk,
+  DROP COLUMN IF EXISTS mobile_code_challenge_method,
+  DROP COLUMN IF EXISTS mobile_code_challenge,
+  DROP COLUMN IF EXISTS mobile_redirect_uri,
+  DROP COLUMN IF EXISTS expected_user_id;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -218,6 +218,10 @@ CREATE TABLE public.oidc_login_transactions (
     nonce text NOT NULL,
     pkce_code_verifier_ciphertext text NOT NULL,
     return_to text NOT NULL,
+    expected_user_id uuid,
+    mobile_redirect_uri text,
+    mobile_code_challenge text,
+    mobile_code_challenge_method text,
     expires_at timestamp with time zone NOT NULL,
     consumed_at timestamp with time zone,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
@@ -225,9 +229,28 @@ CREATE TABLE public.oidc_login_transactions (
     CONSTRAINT oidc_login_transactions_intent_state_chk CHECK ((((intent = 'login'::text) AND (session_id IS NULL) AND (invite_id IS NULL)) OR ((intent = 'reauthenticate'::text) AND (session_id IS NOT NULL) AND (invite_id IS NULL)) OR ((intent = 'accept_invite'::text) AND (invite_id IS NOT NULL)) OR ((intent = 'link_identity'::text) AND (session_id IS NOT NULL) AND (invite_id IS NULL)))),
     CONSTRAINT oidc_login_transactions_nonce_nonempty_chk CHECK ((length(btrim(nonce)) > 0)),
     CONSTRAINT oidc_login_transactions_pkce_nonempty_chk CHECK ((length(btrim(pkce_code_verifier_ciphertext)) > 0)),
+    CONSTRAINT oidc_login_transactions_mobile_fields_chk CHECK (((mobile_redirect_uri IS NULL AND mobile_code_challenge IS NULL AND mobile_code_challenge_method IS NULL) OR (mobile_redirect_uri IS NOT NULL AND mobile_code_challenge IS NOT NULL AND mobile_code_challenge_method = 'S256'::text))),
     CONSTRAINT oidc_login_transactions_return_to_chk CHECK ((("left"(return_to, 1) = '/'::text) AND ("left"(return_to, 2) <> '//'::text) AND (POSITION(('\'::text) IN (return_to)) = 0))),
     CONSTRAINT oidc_login_transactions_state_hash_nonempty_chk CHECK ((length(btrim(state_hash)) > 0))
 );
+
+CREATE TABLE public.mobile_session_exchange_codes (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    code_hash text NOT NULL,
+    oidc_transaction_id uuid NOT NULL,
+    session_id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    organization_id uuid NOT NULL,
+    intent text NOT NULL,
+    expires_at timestamp with time zone NOT NULL,
+    consumed_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT mobile_session_exchange_codes_hash_nonempty_chk CHECK ((length(btrim(code_hash)) > 0)),
+    CONSTRAINT mobile_session_exchange_codes_intent_chk CHECK ((intent = ANY (ARRAY['login'::text, 'reauthenticate'::text])))
+);
+
+CREATE UNIQUE INDEX mobile_session_exchange_codes_code_hash_idx ON public.mobile_session_exchange_codes USING btree (code_hash);
+CREATE INDEX mobile_session_exchange_codes_expiry_idx ON public.mobile_session_exchange_codes USING btree (expires_at) WHERE (consumed_at IS NULL);
 
 
 --


### PR DESCRIPTION
# issue番号

https://github.com/kajiLabTeam/okarin/issues/247

# 変更内容(写真か動画も一緒に)

- Organization-scoped Pedestrian / Floor / Recording APIを追加
- Local / OIDC認証の intent と Mobile OIDC Session Exchange（PKCE、single-use、Set-Cookie）を追加
- Membership Grant、Organization tenant整合性、認証エラー制約を実装
- OIDC Transaction と mobile exchange code 用のDB migration/schemaを追加
- Kaede: tsc、認証・録音系 Vitest、pre-commit format/lint/typecheck を実行済み

# 影響範囲(あれば)

- Kaede API、OIDC設定（MOBILE_OIDC_REDIRECT_URI）、DB migration